### PR TITLE
cmake: Add support to pass SANITIZE argument

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ cmake_minimum_required(VERSION 3.4.1)
 
 project(ULTRAHDR VERSION 1.0.0)
 
+set(CMAKE_CXX_STANDARD 17)
+
 include(ExternalProject)
 
 # Check the target architecture and set compiler flags accordingly
@@ -36,6 +38,7 @@ endif()
 set(SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
 include("${SRC_DIR}/utils.cmake")
+libultrahdr_add_compile_options()
 
 ADD_SUBDIRECTORY("${SRC_DIR}/third_party/cmake/image_io")
 
@@ -83,33 +86,28 @@ target_link_libraries(ultrahdr PRIVATE
 )
 
 # Add source files to the test target
-add_executable(ultrahdr_unit_test
-    "${SRC_DIR}/tests/jpegr_test.cpp"
-    "${SRC_DIR}/tests/gainmapmath_test.cpp"
-    "${SRC_DIR}/tests/icchelper_test.cpp"
-    "${SRC_DIR}/tests/jpegencoderhelper_test.cpp"
-    "${SRC_DIR}/tests/jpegdecoderhelper_test.cpp"
-    "${SRC_DIR}/tests/icchelper_test.cpp"
+libultrahdr_add_executable(ultrahdr_unit_test
+    ultrahdr
+    image_io
+    SOURCES
+        "${SRC_DIR}/tests/jpegr_test.cpp"
+        "${SRC_DIR}/tests/gainmapmath_test.cpp"
+        "${SRC_DIR}/tests/icchelper_test.cpp"
+        "${SRC_DIR}/tests/jpegencoderhelper_test.cpp"
+        "${SRC_DIR}/tests/jpegdecoderhelper_test.cpp"
+        "${SRC_DIR}/tests/icchelper_test.cpp"
+    INCLUDES
+        "${SRC_DIR}/include"
+        "${SRC_DIR}/third_party/googletest/googletest/include"
+        "${SRC_DIR}/third_party/googletest/googlemock/include"
+        "${SRC_DIR}/third_party/libjpeg-turbo/"
+        "${SRC_DIR}/third_party/build/libjpeg-turbo/src/libjpeg-turbo-build"
 )
 
-set_target_properties(ultrahdr_unit_test PROPERTIES
-    COMPILE_FLAGS -std=c++17
-    LINK_FLAGS "-L ./third_party/build/libjpeg-turbo/src/libjpeg-turbo-build/ -pthread")
-
-target_include_directories(ultrahdr_unit_test PRIVATE
-    "${SRC_DIR}/include"
-    "${SRC_DIR}/third_party/googletest/googletest/include"
-    "${SRC_DIR}/third_party/googletest/googlemock/include"
-    "${SRC_DIR}/third_party/libjpeg-turbo/"
-    "${SRC_DIR}/third_party/build/libjpeg-turbo/src/libjpeg-turbo-build"
-)
-
-target_link_libraries(ultrahdr_unit_test PRIVATE
-        ultrahdr
-        image_io
-        ${SRC_DIR}/third_party/build/googletest/src/googletest-build/lib/libgmock.a
-        ${SRC_DIR}/third_party/build/googletest/src/googletest-build/lib/libgtest.a
-        ${SRC_DIR}/third_party/build/googletest/src/googletest-build/lib/libgtest_main.a
+target_link_libraries(ultrahdr_unit_test
+    ${SRC_DIR}/third_party/build/googletest/src/googletest-build/lib/libgmock.a
+    ${SRC_DIR}/third_party/build/googletest/src/googletest-build/lib/libgtest.a
+    ${SRC_DIR}/third_party/build/googletest/src/googletest-build/lib/libgtest_main.a
 )
 
 libultrahdr_add_fuzzer(ultrahdr_enc_fuzzer ultrahdr

--- a/fuzzer/README.md
+++ b/fuzzer/README.md
@@ -1,0 +1,73 @@
+# Fuzzer for ultrahdr decoder and encoder
+
+This describes steps to build ultrahdr_dec_fuzzer and ultrahdr_enc_fuzzer.
+
+## Linux x86/x64
+
+###  Requirements
+- cmake (3.4.1 or above)
+- make
+- clang (12.0 or above)
+  needs to support -fsanitize=fuzzer, -fsanitize=fuzzer-no-link
+
+### Steps to build
+Create a directory inside libultrahdr and change directory
+```
+ $ cd libultrahdr
+ $ mkdir build
+ $ cd build
+```
+Build fuzzer with required sanitizers (-DSANITIZE=fuzzer-no-link is mandatory
+  to enable fuzzers)
+```
+ $ cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+   -DCMAKE_BUILD_TYPE=Debug -DSANITIZE=fuzzer-no-link,address,\
+   signed-integer-overflow,unsigned-integer-overflow
+ $ make
+ ```
+
+### Steps to run
+Create a directory CORPUS_DIR and copy some elementary ultrahdr files
+(for ultrahdr_dec_fuzzer) or yuv files (for ultrahdr_enc_fuzzer) to that directory
+
+To run the fuzzers
+```
+$ ./ultrahdr_dec_fuzzer CORPUS_DIR
+$ ./ultrahdr_enc_fuzzer CORPUS_DIR
+```
+
+## Android
+
+### Steps to build
+Build the fuzzers
+```
+  $ mm -j$(nproc) ultrahdr_dec_fuzzer
+  $ mm -j$(nproc) ultrahdr_enc_fuzzer
+```
+
+### Steps to run
+Create a directory CORPUS_DIR and copy some elementary ultrahdr files
+(for ultrahdr_dec_fuzzer) or yuv files (for ultrahdr_enc_fuzzer) to that folder
+Push this directory to device
+
+To run ultrahdr_dec_fuzzer on device
+```
+  $ adb sync data
+  $ adb shell /data/fuzz/arm64/ultrahdr_dec_fuzzer/ultrahdr_dec_fuzzer CORPUS_DIR
+```
+
+To run ultrahdr_enc_fuzzer on device
+```
+  $ adb sync data
+  $ adb shell /data/fuzz/arm64/ultrahdr_enc_fuzzer/ultrahdr_enc_fuzzer CORPUS_DIR
+```
+
+To run ultrahdr_dec_fuzzer on host
+```
+  $ $ANDROID_HOST_OUT/fuzz/x86_64/ultrahdr_dec_fuzzer/ultrahdr_dec_fuzzer CORPUS_DIR
+```
+
+To run ultrahdr_enc_fuzzer on host
+```
+  $ $ANDROID_HOST_OUT/fuzz/x86_64/ultrahdr_enc_fuzzer/ultrahdr_enc_fuzzer CORPUS_DIR
+```

--- a/utils.cmake
+++ b/utils.cmake
@@ -12,6 +12,24 @@ include(CheckCXXCompilerFlag)
 # LIBS: Additional libraries
 # FUZZER: flag to specify if the target is a fuzzer binary
 # cmake-format: on
+
+# Adds compiler options for all targets
+function(libultrahdr_add_compile_options)
+  if(DEFINED SANITIZE)
+    set(CMAKE_REQUIRED_FLAGS -fsanitize=${SANITIZE})
+    check_cxx_compiler_flag(-fsanitize=${SANITIZE} COMPILER_HAS_SANITIZER)
+    unset(CMAKE_REQUIRED_FLAGS)
+
+    if(NOT COMPILER_HAS_SANITIZER)
+      message(
+        FATAL_ERROR "ERROR: Compiler doesn't support -fsanitize=${SANITIZE}")
+      return()
+    endif()
+    add_compile_options(-fno-omit-frame-pointer -fsanitize=${SANITIZE})
+  endif()
+
+endfunction()
+
 function(libultrahdr_add_executable NAME LIB)
   set(multi_value_args SOURCES INCLUDES LIBS)
   set(optional_args FUZZER)


### PR DESCRIPTION
cmake builds now support passing -DSANITIZE argument to enable various sanitizers.

Also, add README.md with instructions on how to build fuzzers