### PR TITLE
Update jpeg_xmp_info.h

### DIFF
--- a/third_party/image_io/includes/image_io/jpeg/jpeg_xmp_info.h
+++ b/third_party/image_io/includes/image_io/jpeg/jpeg_xmp_info.h
@@ -1,6 +1,7 @@
 #ifndef IMAGE_IO_JPEG_JPEG_XMP_INFO_H_  // NOLINT
 #define IMAGE_IO_JPEG_JPEG_XMP_INFO_H_  // NOLINT
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Adding a new include, which fixed a build failure on gLinux