### PR TITLE
cmake: Pass -DENABLE_FUZZERS=ON to enable building fuzzers

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -17,12 +17,21 @@ jobs:
             cc: gcc
             cxx: g++
             build-system: cmake
+            cmake-opts: '-DENABLE_FUZZERS=OFF'
 
           - name: ubuntu-latest-clang-cmake
             os: ubuntu-latest
             cc: clang
             cxx: clang++
             build-system: cmake
+            cmake-opts: '-DENABLE_FUZZERS=ON'
+
+          - name: macos-latest-clang-cmake
+            os: macos-latest
+            cc: clang
+            cxx: clang++
+            build-system: cmake
+            cmake-opts: '-DENABLE_FUZZERS=OFF'
 
     runs-on: ${{ matrix.os }}
 
@@ -33,7 +42,7 @@ jobs:
       env:
         CC: ${{ matrix.cc }}
         CXX: ${{ matrix.cxx }}
-      run: cmake -B ${{github.workspace}}/out -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/out -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{ matrix.cmake-opts }}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/out --config ${{env.BUILD_TYPE}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,16 @@ cmake_minimum_required(VERSION 3.5)
 
 project(ULTRAHDR VERSION 1.0.0)
 
+option(ENABLE_FUZZERS "Enables fuzzers" OFF)
+
+# Add -fuzzer-no-link to sanitize argument if fuzzer build is enabled
+if (${ENABLE_FUZZERS})
+if(DEFINED SANITIZE)
+    set(SANITIZE "${SANITIZE},fuzzer-no-link")
+else()
+    set(SANITIZE "fuzzer-no-link")
+endif()
+endif()
 set(CMAKE_CXX_STANDARD 17)
 
 include(ExternalProject)
@@ -114,6 +124,7 @@ target_link_libraries(ultrahdr_unit_test
     ${SRC_DIR}/third_party/build/googletest/src/googletest-build/lib/libgtest_main.a
 )
 
+if (${ENABLE_FUZZERS})
 libultrahdr_add_fuzzer(ultrahdr_enc_fuzzer ultrahdr
     SOURCES
         ${SRC_DIR}/fuzzer/ultrahdr_enc_fuzzer.cpp
@@ -131,3 +142,4 @@ libultrahdr_add_fuzzer(ultrahdr_dec_fuzzer ultrahdr
         ${SRC_DIR}/third_party/libjpeg-turbo/
         ${SRC_DIR}/third_party/build/libjpeg-turbo/src/libjpeg-turbo-build
 )
+endif()

--- a/fuzzer/README.md
+++ b/fuzzer/README.md
@@ -17,11 +17,11 @@ Create a directory inside libultrahdr and change directory
  $ mkdir build
  $ cd build
 ```
-Build fuzzer with required sanitizers (-DSANITIZE=fuzzer-no-link is mandatory
-  to enable fuzzers)
+Build fuzzer with required sanitizers
+Note: Using clang and setting -DENABLE_FUZZERS=ON is mandatory to enable fuzzers.
 ```
  $ cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
-   -DCMAKE_BUILD_TYPE=Debug -DSANITIZE=fuzzer-no-link,address,\
+   -DCMAKE_BUILD_TYPE=Debug -DENABLE_FUZZERS=ON -DSANITIZE=address,\
    signed-integer-overflow,unsigned-integer-overflow
  $ make
  ```


### PR DESCRIPTION
Fuzzer build is now based on an argument passed to cmake. 
With this, macos builds can now be verified for each pull request.