### PR TITLE
Use ALOG methods to print messages from jpeg and image_io

### DIFF
--- a/jpegdecoderhelper.cpp
+++ b/jpegdecoderhelper.cpp
@@ -97,6 +97,14 @@ static void jpegrerror_exit(j_common_ptr cinfo) {
     longjmp(err->setjmp_buffer, 1);
 }
 
+static void output_message(j_common_ptr cinfo) {
+    char buffer[JMSG_LENGTH_MAX];
+
+    /* Create the message */
+    (*cinfo->err->format_message)(cinfo, buffer);
+    ALOGE("%s\n", buffer);
+}
+
 JpegDecoderHelper::JpegDecoderHelper() {}
 
 JpegDecoderHelper::~JpegDecoderHelper() {}
@@ -163,6 +171,7 @@ bool JpegDecoderHelper::extractEXIF(const void* image, int length) {
 
     cinfo.err = jpeg_std_error(&myerr.pub);
     myerr.pub.error_exit = jpegrerror_exit;
+    myerr.pub.output_message = output_message;
 
     if (setjmp(myerr.setjmp_buffer)) {
         jpeg_destroy_decompress(&cinfo);
@@ -209,6 +218,8 @@ bool JpegDecoderHelper::decode(const void* image, int length, bool decodeToRGBA)
     jpegrerror_mgr myerr;
     cinfo.err = jpeg_std_error(&myerr.pub);
     myerr.pub.error_exit = jpegrerror_exit;
+    myerr.pub.output_message = output_message;
+
     if (setjmp(myerr.setjmp_buffer)) {
         jpeg_destroy_decompress(&cinfo);
         return false;
@@ -342,6 +353,8 @@ bool JpegDecoderHelper::getCompressedImageParameters(const void* image, int leng
     jpegrerror_mgr myerr;
     cinfo.err = jpeg_std_error(&myerr.pub);
     myerr.pub.error_exit = jpegrerror_exit;
+    myerr.pub.output_message = output_message;
+
     if (setjmp(myerr.setjmp_buffer)) {
         jpeg_destroy_decompress(&cinfo);
         return false;

--- a/jpegr.cpp
+++ b/jpegr.cpp
@@ -71,6 +71,16 @@ int GetCPUCoreCount() {
 }
 
 /*
+ * MessageWriter implementation for ALOG functions.
+ */
+class AlogMessageWriter : public MessageWriter {
+ public:
+  void WriteMessage(const Message& message) override {
+    ALOGD(GetFormattedMessage(message));
+  }
+};
+
+/*
  * Helper function copies the JPEG image from without EXIF.
  *
  * @param pDest destination of the data to be written.
@@ -1122,6 +1132,7 @@ status_t JpegR::extractPrimaryImageAndGainMap(jr_compressed_ptr jpegr_image_ptr,
   }
 
   MessageHandler msg_handler;
+  msg_handler.SetMessageWriter(make_unique<AlogMessageWriter>(AlogMessageWriter()));
   std::shared_ptr<DataSegment> seg =
           DataSegment::Create(DataRange(0, jpegr_image_ptr->length),
                               static_cast<const uint8_t*>(jpegr_image_ptr->data),


### PR DESCRIPTION
- Override output_message method for jpeg decoder
- Use SetMessageWriter() while calling Jpeg scanner from image_io

This ensures that logs are written using ALOG routines and can be suppressed for fuzzer runs easily.