### PR TITLE
cmake: Fix 32-bit cross compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,15 +35,6 @@ include(ExternalProject)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
-# Check the target architecture and set compiler flags accordingly
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-    # 64-bit architecture
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -m64")
-else()
-    # 32-bit architecture
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -m32")
-endif()
-
 set(SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
 include("${SRC_DIR}/utils.cmake")

--- a/third_party/cmake/image_io/CMakeLists.txt
+++ b/third_party/cmake/image_io/CMakeLists.txt
@@ -20,17 +20,6 @@ project(IMAGE_IO VERSION 1.0.0)
 
 set(CMAKE_CXX_STANDARD 17)
 
-# Check the target architecture and set compiler flags accordingly
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-    # 64-bit architecture
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -m64")
-else()
-    # 32-bit architecture
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -m32")
-endif()
-
 set(IMAGE_IO_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../image_io")
 
 file(GLOB IMAGE_IO_SRC "${IMAGE_IO_DIR}/src/**/*.cc")


### PR DESCRIPTION
Current CMakeLists.txt prevented cross compiling from x86_64 machine for an x86 target.