### PR TITLE
Limit max resolution to 5312 in either direction.

### DIFF
--- a/include/ultrahdr/jpegdecoderhelper.h
+++ b/include/ultrahdr/jpegdecoderhelper.h
@@ -37,8 +37,8 @@ extern "C" {
 
 // constraint on max width and max height is only due to device alloc constraints
 // Can tune these values basing on the target device
-static const int kMaxWidth = 8192;
-static const int kMaxHeight = 8192;
+static const int kMaxWidth = 5312;
+static const int kMaxHeight = 5312;
 
 namespace ultrahdr {
 /*


### PR DESCRIPTION
Fuzzer runs are getting timed out due to extremely large test resolutions. Limit max weight and max height to a value that supports 16mp in portrait and landscape

Bug: oss-fuzz-63322
Test: ./ultrahdr_enc_fuzzer