### PR TITLE
Replace divides with multiplies in get*Pixel functions

### DIFF
--- a/lib/src/gainmapmath.cpp
+++ b/lib/src/gainmapmath.cpp
@@ -575,8 +575,9 @@ Color getYuv420Pixel(jr_uncompressed_ptr image, size_t x, size_t y) {
 
   // 128 bias for UV given we are using jpeglib; see:
   // https://github.com/kornelski/libjpeg/blob/master/structure.doc
-  return {{{static_cast<float>(y_uint) / 255.0f, (static_cast<float>(u_uint) - 128.0f) / 255.0f,
-            (static_cast<float>(v_uint) - 128.0f) / 255.0f}}};
+  return {
+      {{static_cast<float>(y_uint) * (1 / 255.0f), static_cast<float>(u_uint - 128) * (1 / 255.0f),
+        static_cast<float>(v_uint - 128) * (1 / 255.0f)}}};
 }
 
 Color getP010Pixel(jr_uncompressed_ptr image, size_t x, size_t y) {
@@ -594,9 +595,9 @@ Color getP010Pixel(jr_uncompressed_ptr image, size_t x, size_t y) {
   uint16_t v_uint = chroma_data[pixel_v_idx] >> 6;
 
   // Conversions include taking narrow-range into account.
-  return {{{(static_cast<float>(y_uint) - 64.0f) / 876.0f,
-            (static_cast<float>(u_uint) - 64.0f) / 896.0f - 0.5f,
-            (static_cast<float>(v_uint) - 64.0f) / 896.0f - 0.5f}}};
+  return {{{static_cast<float>(y_uint - 64) * (1 / 876.0f),
+            static_cast<float>(u_uint - 64) * (1 / 896.0f) - 0.5f,
+            static_cast<float>(v_uint - 64) * (1 / 896.0f) - 0.5f}}};
 }
 
 typedef Color (*getPixelFn)(jr_uncompressed_ptr, size_t, size_t);

--- a/tests/gainmapmath_test.cpp
+++ b/tests/gainmapmath_test.cpp
@@ -31,14 +31,14 @@ class GainMapMathTest : public testing::Test {
   float YuvConversionEpsilon() { return 1.0f / (255.0f * 2.0f); }
 
   Color Yuv420(uint8_t y, uint8_t u, uint8_t v) {
-    return {{{static_cast<float>(y) / 255.0f, (static_cast<float>(u) - 128.0f) / 255.0f,
-              (static_cast<float>(v) - 128.0f) / 255.0f}}};
+    return {{{static_cast<float>(y) * (1 / 255.0f), static_cast<float>(u - 128) * (1 / 255.0f),
+              static_cast<float>(v - 128) * (1 / 255.0f)}}};
   }
 
   Color P010(uint16_t y, uint16_t u, uint16_t v) {
-    return {
-        {{(static_cast<float>(y) - 64.0f) / 876.0f, (static_cast<float>(u) - 64.0f) / 896.0f - 0.5f,
-          (static_cast<float>(v) - 64.0f) / 896.0f - 0.5f}}};
+    return {{{static_cast<float>(y - 64) * (1 / 876.0f),
+              static_cast<float>(u - 64) * (1 / 896.0f) - 0.5f,
+              static_cast<float>(v - 64) * (1 / 896.0f) - 0.5f}}};
   }
 
   float Map(uint8_t e) { return static_cast<float>(e) / 255.0f; }


### PR DESCRIPTION
Replaces the divides in the aforementioned functions with reciprocal multiplies. This change requires modification of the test functions as well, otherwise the results end up off by one.

This improves performance across the board with the improvement most notable on small in-order Arm cores. This benefit should be amplified by subsequent Neon optimizations.