### PR TITLE
Update fuzzer according to the updates made to decodeJPEGR

### DIFF
--- a/fuzzer/ultrahdr_dec_fuzzer.cpp
+++ b/fuzzer/ultrahdr_dec_fuzzer.cpp
@@ -56,11 +56,9 @@ void UltraHdrDecFuzzer::process() {
   auto decodedRaw = std::make_unique<uint8_t[]>(outSize);
   decodedJpegR.data = decodedRaw.get();
   ultrahdr_metadata_struct metadata;
-  jpegr_uncompressed_struct decodedGainMap{};
   (void)jpegHdr.decodeJPEGR(&jpegImgR, &decodedJpegR,
                             mFdp.ConsumeFloatingPointInRange<float>(1.0, FLT_MAX), nullptr, of,
-                            &decodedGainMap, &metadata);
-  if (decodedGainMap.data) free(decodedGainMap.data);
+                            nullptr, &metadata);
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {

--- a/fuzzer/ultrahdr_enc_fuzzer.cpp
+++ b/fuzzer/ultrahdr_enc_fuzzer.cpp
@@ -297,14 +297,12 @@ void UltraHdrEncFuzzer::process() {
         auto decodedRaw = std::make_unique<uint8_t[]>(outSize);
         decodedJpegR.data = decodedRaw.get();
         ultrahdr_metadata_struct metadata;
-        jpegr_uncompressed_struct decodedGainMap{};
         status = jpegHdr.decodeJPEGR(&jpegImgR, &decodedJpegR,
                                      mFdp.ConsumeFloatingPointInRange<float>(1.0, FLT_MAX), nullptr,
-                                     of, &decodedGainMap, &metadata);
+                                     of, nullptr, &metadata);
         if (status != JPEGR_NO_ERROR) {
           ALOGE("encountered error during decoding %d", status);
         }
-        if (decodedGainMap.data) free(decodedGainMap.data);
       } else {
         ALOGE("encountered error during get jpeg info %d", status);
       }


### PR DESCRIPTION
Earlier the gainmap data is allocated by the library and shared externally. Now the decodeJPEGR function expects to receive the location to which the gainmap data needs to be written