### PR TITLE
improve ce9d00b

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ if(UHDR_BUILD_BENCHMARK AND WIN32)
 endif()
 
 # side effects
-if(UHDR_BUILD_FUZZERS)
+if(UHDR_BUILD_FUZZERS OR UHDR_BUILD_DEPS)
   set(UHDR_ENABLE_INSTALL FALSE) # during fuzz testing dont install targets
   set(UHDR_BUILD_DEPS TRUE) # for fuzz testing its best to build all dependencies from source.
                             # This is to instrument dependencies libs as well
@@ -495,20 +495,21 @@ if(UHDR_ENABLE_INSTALL)
   set(UHDR_TARGET_NAME uhdr)
   add_library(${UHDR_TARGET_NAME} SHARED)
   add_dependencies(${UHDR_TARGET_NAME} ${UHDR_CORE_LIB_NAME})
+  target_link_libraries(${UHDR_TARGET_NAME} PRIVATE ${JPEG_LIBRARIES})
   set_target_properties(${UHDR_TARGET_NAME} PROPERTIES PUBLIC_HEADER ultrahdr_api.h)
   combine_static_libs(${UHDR_CORE_LIB_NAME} ${UHDR_TARGET_NAME})
 
-  if(NOT MSVC)
+  if(NOT(WIN32 OR XCODE))
     include(GNUInstallDirs)
 
     # pkg-config: libuhdr.pc
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/libuhdr.pc.template"
                    "${CMAKE_CURRENT_BINARY_DIR}/libuhdr.pc" @ONLY NEWLINE_STYLE UNIX)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libuhdr.pc"
-            DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_LIBRARY_ARCHITECTURE}/pkgconfig")
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
     install(TARGETS ${UHDR_TARGET_NAME}
-            DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_LIBRARY_ARCHITECTURE}/"
-            PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_PREFIX}/include")
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+            PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
     add_custom_target(uninstall)
     add_custom_command(TARGET uninstall

--- a/README.md
+++ b/README.md
@@ -18,15 +18,22 @@ More information about libultrahdr can be found at
 Building libultrahdr
 ======================
 
-libultrahdr compresses base image and gain map image in to jpeg format.
-For this libjpeg-turbo is used. This is cloned from
-<https://github.com/libjpeg-turbo/libjpeg-turbo.git> and included in the
-build process.
+libultrahdr compresses an hdr and sdr rendition of an image in to jpeg format
+using gain map technology and vice versa. For this libjpeg is used. If libjpeg
+library is not present then cmake configuration will fail. This can be resolved
+by installing libjpeg using package manager and then configuring or passing
+UHDR_BUILD_DEPS=1 at the time of configure. cmake -DUHDR_BUILD_DEPS=1 will
+clone jpeg from <https://github.com/libjpeg-turbo/libjpeg-turbo.git> and
+include it in the build process.
 
 Requirements
 --------------
 
 - [CMake](http://www.cmake.org) v3.13 or later
+
+- Compiler with support for C++17
+
+- libjpeg package or
 
 - [NASM](http://www.nasm.us) or [Yasm](http://yasm.tortall.net)
   (If libjpeg-turbo needs to be built with SIMD extensions)
@@ -34,8 +41,6 @@ Requirements
   * If using Yasm, 1.2.0 or later is required.
   * If building on macOS, NASM or Yasm can be obtained from
     [MacPorts](http://www.macports.org/) or [Homebrew](http://brew.sh/).
-
-- Compilers with support for C++17
 
 Should work with GCC v7 (or later) and Clang 5 (or later) on Linux and Mac Platforms.
 
@@ -53,46 +58,22 @@ To build libultrahdr, examples, unit tests:
     cmake -G "Unix Makefiles"  -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DUHDR_BUILD_TESTS=1 ../
     make
     ctest
+    make install
 
 This will generate the following files under *{build_directory}*:
 
-**libultrahdr.a**<br> Static link library for the ultrahdr API
+**libuhdr.so or libuhdr.dylib**<br> ultrahdr shared library
 
-**ultrahdr_app**<br> Sample application demonstrating ultrahdr API
+**libuhdr.pc**<br> ultrahdr pkg-config file
+
+**ultrahdr_app**<br> Statically linked sample application demonstrating ultrahdr API
 
 **ultrahdr_unit_test**<br> Unit tests
 
-### Visual C++ (IDE)
+make install will install libuhdr.so, ultrahdr_api.h, libuhdr.pc for system-wide usage.
+make uninstall will remove the same.
 
-    mkdir {build_directory}
-    cd {build_directory}
-    cmake -G "Visual Studio 16 2019" -DUHDR_BUILD_TESTS=1 ../
-    cmake --build ./ --config=Release
-    ctest -C Release
-
-This will generate the following files under *{build_directory/Release}*:
-
-**ultrahdr.lib**<br> Static link library for the ultrahdr API
-
-**ultrahdr_app.exe**<br> Sample application demonstrating ultrahdr API
-
-**ultrahdr_unit_test.exe**<br> Unit tests
-
-### Visual C++ (Command line)
-
-    mkdir {build_directory}
-    cd {build_directory}
-    cmake -G "NMake Makefiles" -DUHDR_BUILD_TESTS=1 ../
-    cmake --build ./
-    ctest
-
-This will generate the following files under *{build_directory}*:
-
-**ultrahdr.lib**<br> Static link library for the ultrahdr API
-
-**ultrahdr_app.exe**<br> Sample application demonstrating ultrahdr API
-
-**ultrahdr_unit_test.exe**<br> Unit tests
+Note: you may need to run ldconfig after install/uninstall
 
 ### MinGW
 
@@ -113,7 +94,35 @@ environment.
 
 This will generate the following files under *{build_directory}*:
 
-**libultrahdr.a**<br> Static link library for the ultrahdr API
+**libuhdr.dll**<br> ultrahdr shared library
+
+**ultrahdr_app.exe**<br> Sample application demonstrating ultrahdr API
+
+**ultrahdr_unit_test.exe**<br> Unit tests
+
+### Visual C++ (IDE)
+
+    mkdir {build_directory}
+    cd {build_directory}
+    cmake -G "Visual Studio 16 2019" -DUHDR_BUILD_DEPS=1 -DUHDR_BUILD_TESTS=1 ../
+    cmake --build ./ --config=Release
+    ctest -C Release
+
+This will generate the following files under *{build_directory/Release}*:
+
+**ultrahdr_app.exe**<br> Sample application demonstrating ultrahdr API
+
+**ultrahdr_unit_test.exe**<br> Unit tests
+
+### Visual C++ (Command line)
+
+    mkdir {build_directory}
+    cd {build_directory}
+    cmake -G "NMake Makefiles" -DUHDR_BUILD_DEPS=1 -DUHDR_BUILD_TESTS=1 ../
+    cmake --build ./
+    ctest
+
+This will generate the following files under *{build_directory}*:
 
 **ultrahdr_app.exe**<br> Sample application demonstrating ultrahdr API
 
@@ -138,29 +147,5 @@ Refer to [README.md](fuzzer/README.md) for complete instructions.
 Using libultrahdr
 ===================
 
-libultrahdr includes two classes of APIs, one to compress and the other to
-decompress HDR images:
-
-List of encode APIs:
-| Input  | HDR YUV | SDR YUV | JPEG | Encoded gainmap | Quality (0 ~ 100) | EXIF | Use case |
-| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-| API-0  | P010  | No | No | No | Required | Optional | Experimental only. |
-| API-1  | P010  | YUV_420 | No | No | Required | Optional | Raw SDR input. Primary image will be encoded from the raw SDR input in the library. |
-| API-2  | P010  | YUV_420 | Yes | No | No | No | Both JPEG and raw SDR inputs. Gainmap will be calculated from raw HDR and raw SDR inputs, the JPEG input will be preserved (including metadata) as the primary image. |
-| API-3  | P010  | No | Yes | No | No | No | SDR JPEG input. Gainmap will be calculated from raw HDR and the decoding result of the JPEG input, the JPEG input will be preserved (including metadata) as the primary image.  |
-| API-4  | No  | No | Yes | Yes | No | No | SDR JPEG and gainmap inputs. The library will only generate the Ultra HDR related metadata and write everything into the Ultra HDR format, all other metadata from the JPEG input will be preserved. |
-
-List of decode API:
-| Input  | Usage |
-| ------------- | ------------- |
-| compressed_jpegr_image  | The input data. Pointer to JPEG/R stream. |
-| dest  | The output data. Destination that decoded data to be written. |
-| max_display_boost  | (optional, >= 1.0) the maximum available boost supported by a display. |
-| exif  | (optional, default to NULL) Destination that exif data to be written. |
-| gain_map  | (optional, default to NULL) Destination that decoded gain map data to be written. |
-| output_format  | <table><thead><tr><th>Value</th><th>Color format to be written</th></tr></thead><tbody><tr><td>SDR</td><td>RGBA_8888</td></tr><tr><td>HDR_LINEAR</td><td>(default) RGBA_F16 linear</td></tr><tr><td>HDR_PQ</td><td>RGBA_1010102 PQ</td></tr><tr><td>HDR_HLG</td><td>RGBA_1010102 HLG</td></tr></tbody></table> |
-| metadata  | (optional, default to NULL) Destination of metadata (gain map version, min/max content boost). |
-
-For more info:
-- Refer to [ultrahdr_api.h](ultrahdr_api.h) for detailed description of various encode and decode api.
-- Refer to [ultrahdr_app.cpp](examples/ultrahdr_app.cpp) for examples of its usage.
+A detailed description of libultrahdr encode and decode api is included in [ultrahdr_api.h](ultrahdr_api.h)
+and for sample usage refer [ultrahdr_app.cpp](examples/ultrahdr_app.cpp)

--- a/libuhdr.pc.template
+++ b/libuhdr.pc.template
@@ -1,11 +1,11 @@
-prefix="@CMAKE_INSTALL_PREFIX@"
-libdir="${prefix}/lib/@CMAKE_LIBRARY_ARCHITECTURE@"
-includedir="${prefix}/include"
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
 Description: @CMAKE_PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
-Requires: libjpeg
+Requires.private: libjpeg
 Cflags: -I${includedir}
 Libs: -L${libdir} -l@UHDR_TARGET_NAME@
 Libs.private: @CMAKE_THREAD_LIBS_INIT@


### PR DESCRIPTION
- use cmake_library_architecture if defined
- restrict install and uninstall targets to Un*x
- Fixes #95

Test: make install