### PR TITLE
Add support for rgb formats during encode

### DIFF
--- a/examples/ultrahdr_app.cpp
+++ b/examples/ultrahdr_app.cpp
@@ -169,6 +169,11 @@ static bool loadFile(const char* filename, uhdr_raw_image_t* handle) {
       ifd.read(static_cast<char*>(handle->planes[UHDR_PLANE_UV]),
                (handle->w / 2) * (handle->h / 2) * bpp * 2);
       return true;
+    } else if (handle->fmt == UHDR_IMG_FMT_32bppRGBA1010102 ||
+               handle->fmt == UHDR_IMG_FMT_32bppRGBA8888) {
+      const int bpp = 4;
+      ifd.read(static_cast<char*>(handle->planes[UHDR_PLANE_PACKED]), handle->w * handle->h * bpp);
+      return true;
     } else if (handle->fmt == UHDR_IMG_FMT_12bppYCbCr420) {
       ifd.read(static_cast<char*>(handle->planes[UHDR_PLANE_Y]), handle->w * handle->h);
       ifd.read(static_cast<char*>(handle->planes[UHDR_PLANE_U]), (handle->w / 2) * (handle->h / 2));
@@ -233,39 +238,46 @@ static bool writeFile(const char* filename, uhdr_raw_image_t* img) {
 
 class UltraHdrAppInput {
  public:
-  UltraHdrAppInput(const char* p010File, const char* yuv420File, const char* yuv420JpegFile,
-                   const char* gainmapJpegFile, const char* gainmapMetadataCfgFile, size_t width,
-                   size_t height, uhdr_color_gamut_t p010Cg = UHDR_CG_BT_709,
-                   uhdr_color_gamut_t yuv420Cg = UHDR_CG_BT_709,
-                   uhdr_color_transfer_t p010Tf = UHDR_CT_HLG, int quality = 100,
+  UltraHdrAppInput(const char* hdrIntentRawFile, const char* sdrIntentRawFile,
+                   const char* sdrIntentCompressedFile, const char* gainmapCompressedFile,
+                   const char* gainmapMetadataCfgFile, size_t width, size_t height,
+                   uhdr_img_fmt_t hdrCf = UHDR_IMG_FMT_UNSPECIFIED,
+                   uhdr_img_fmt_t sdrCf = UHDR_IMG_FMT_UNSPECIFIED,
+                   uhdr_color_gamut_t hdrCg = UHDR_CG_BT_709,
+                   uhdr_color_gamut_t sdrCg = UHDR_CG_BT_709,
+                   uhdr_color_transfer_t hdrTf = UHDR_CT_HLG, int quality = 100,
                    uhdr_color_transfer_t oTf = UHDR_CT_HLG,
                    uhdr_img_fmt_t oFmt = UHDR_IMG_FMT_32bppRGBA1010102)
-      : mP010File(p010File),
-        mYuv420File(yuv420File),
-        mYuv420JpegFile(yuv420JpegFile),
-        mGainMapJpegFile(gainmapJpegFile),
+      : mHdrIntentRawFile(hdrIntentRawFile),
+        mSdrIntentRawFile(sdrIntentRawFile),
+        mSdrIntentCompressedFile(sdrIntentCompressedFile),
+        mGainMapCompressedFile(gainmapCompressedFile),
         mGainMapMetadataCfgFile(gainmapMetadataCfgFile),
-        mJpegRFile(nullptr),
+        mUhdrFile(nullptr),
         mWidth(width),
         mHeight(height),
-        mP010Cg(p010Cg),
-        mYuv420Cg(yuv420Cg),
-        mP010Tf(p010Tf),
+        mHdrCf(hdrCf),
+        mSdrCf(sdrCf),
+        mHdrCg(hdrCg),
+        mSdrCg(sdrCg),
+        mHdrTf(hdrTf),
         mQuality(quality),
         mOTf(oTf),
         mOfmt(oFmt),
         mMode(0){};
 
-  UltraHdrAppInput(const char* jpegRFile, uhdr_color_transfer_t oTf = UHDR_CT_HLG,
+  UltraHdrAppInput(const char* uhdrFile, uhdr_color_transfer_t oTf = UHDR_CT_HLG,
                    uhdr_img_fmt_t oFmt = UHDR_IMG_FMT_32bppRGBA1010102)
-      : mP010File(nullptr),
-        mYuv420File(nullptr),
-        mJpegRFile(jpegRFile),
+      : mHdrIntentRawFile(nullptr),
+        mSdrIntentRawFile(nullptr),
+        mUhdrFile(uhdrFile),
         mWidth(0),
         mHeight(0),
-        mP010Cg(UHDR_CG_UNSPECIFIED),
-        mYuv420Cg(UHDR_CG_UNSPECIFIED),
-        mP010Tf(UHDR_CT_UNSPECIFIED),
+        mHdrCf(UHDR_IMG_FMT_UNSPECIFIED),
+        mSdrCf(UHDR_IMG_FMT_UNSPECIFIED),
+        mHdrCg(UHDR_CG_UNSPECIFIED),
+        mSdrCg(UHDR_CG_UNSPECIFIED),
+        mHdrTf(UHDR_CT_UNSPECIFIED),
         mQuality(100),
         mOTf(oTf),
         mOfmt(oFmt),
@@ -290,26 +302,28 @@ class UltraHdrAppInput {
         free(mRawRgba8888Image.planes[i]);
         mRawRgba8888Image.planes[i] = nullptr;
       }
-      if (mDestImage.planes[i]) {
-        free(mDestImage.planes[i]);
-        mDestImage.planes[i] = nullptr;
+      if (mDecodedUhdrRgbImage.planes[i]) {
+        free(mDecodedUhdrRgbImage.planes[i]);
+        mDecodedUhdrRgbImage.planes[i] = nullptr;
       }
-      if (mDestYUV444Image.planes[i]) {
-        free(mDestYUV444Image.planes[i]);
-        mDestYUV444Image.planes[i] = nullptr;
+      if (mDecodedUhdrYuv444Image.planes[i]) {
+        free(mDecodedUhdrYuv444Image.planes[i]);
+        mDecodedUhdrYuv444Image.planes[i] = nullptr;
       }
     }
-    if (mJpegImgR.data) free(mJpegImgR.data);
+    if (mUhdrImage.data) free(mUhdrImage.data);
   }
 
-  bool fillJpegRImageHandle();
+  bool fillUhdrImageHandle();
   bool fillP010ImageHandle();
+  bool fillRGB1010102ImageHandle();
   bool convertP010ToRGBImage();
   bool fillYuv420ImageHandle();
-  bool fillYuv420JpegImageHandle();
-  bool fillGainMapJpegImageHandle();
-  bool fillGainMapMetadataDescriptor();
+  bool fillRGBA8888ImageHandle();
   bool convertYuv420ToRGBImage();
+  bool fillSdrCompressedImageHandle();
+  bool fillGainMapCompressedImageHandle();
+  bool fillGainMapMetadataDescriptor();
   bool convertRgba8888ToYUV444Image();
   bool convertRgba1010102ToYUV444Image();
   bool encode();
@@ -319,32 +333,34 @@ class UltraHdrAppInput {
   void computeYUVHdrPSNR();
   void computeYUVSdrPSNR();
 
-  const char* mP010File;
-  const char* mYuv420File;
-  const char* mYuv420JpegFile;
-  const char *mGainMapJpegFile;
-  const char *mGainMapMetadataCfgFile;
-  const char* mJpegRFile;
+  const char* mHdrIntentRawFile;
+  const char* mSdrIntentRawFile;
+  const char* mSdrIntentCompressedFile;
+  const char* mGainMapCompressedFile;
+  const char* mGainMapMetadataCfgFile;
+  const char* mUhdrFile;
   const int mWidth;
   const int mHeight;
-  const uhdr_color_gamut_t mP010Cg;
-  const uhdr_color_gamut_t mYuv420Cg;
-  const uhdr_color_transfer_t mP010Tf;
+  const uhdr_img_fmt_t mHdrCf;
+  const uhdr_img_fmt_t mSdrCf;
+  const uhdr_color_gamut_t mHdrCg;
+  const uhdr_color_gamut_t mSdrCg;
+  const uhdr_color_transfer_t mHdrTf;
   const int mQuality;
   const uhdr_color_transfer_t mOTf;
-  const uhdr_img_fmt mOfmt;
+  const uhdr_img_fmt_t mOfmt;
   const int mMode;
 
   uhdr_raw_image_t mRawP010Image{};
   uhdr_raw_image_t mRawRgba1010102Image{};
   uhdr_raw_image_t mRawYuv420Image{};
-  uhdr_compressed_image_t mYuv420JpegImage{};
-  uhdr_compressed_image_t mGainMapJpegImage{};
-  uhdr_gainmap_metadata mMetadata{};
   uhdr_raw_image_t mRawRgba8888Image{};
-  uhdr_compressed_image_t mJpegImgR{};
-  uhdr_raw_image_t mDestImage{};
-  uhdr_raw_image_t mDestYUV444Image{};
+  uhdr_compressed_image_t mSdrIntentCompressedImage{};
+  uhdr_compressed_image_t mGainMapCompressedImage{};
+  uhdr_gainmap_metadata mGainMapMetadata{};
+  uhdr_compressed_image_t mUhdrImage{};
+  uhdr_raw_image_t mDecodedUhdrRgbImage{};
+  uhdr_raw_image_t mDecodedUhdrYuv444Image{};
   double mPsnr[3]{};
 };
 
@@ -352,8 +368,8 @@ bool UltraHdrAppInput::fillP010ImageHandle() {
   const int bpp = 2;
   int p010Size = mWidth * mHeight * bpp * 1.5;
   mRawP010Image.fmt = UHDR_IMG_FMT_24bppYCbCrP010;
-  mRawP010Image.cg = mP010Cg;
-  mRawP010Image.ct = mP010Tf;
+  mRawP010Image.cg = mHdrCg;
+  mRawP010Image.ct = mHdrTf;
   mRawP010Image.range = UHDR_CR_LIMITED_RANGE;
   mRawP010Image.w = mWidth;
   mRawP010Image.h = mHeight;
@@ -363,13 +379,13 @@ bool UltraHdrAppInput::fillP010ImageHandle() {
   mRawP010Image.stride[UHDR_PLANE_Y] = mWidth;
   mRawP010Image.stride[UHDR_PLANE_UV] = mWidth;
   mRawP010Image.stride[UHDR_PLANE_V] = 0;
-  return loadFile(mP010File, &mRawP010Image);
+  return loadFile(mHdrIntentRawFile, &mRawP010Image);
 }
 
 bool UltraHdrAppInput::fillYuv420ImageHandle() {
   int yuv420Size = mWidth * mHeight * 1.5;
   mRawYuv420Image.fmt = UHDR_IMG_FMT_12bppYCbCr420;
-  mRawYuv420Image.cg = mYuv420Cg;
+  mRawYuv420Image.cg = mSdrCg;
   mRawYuv420Image.ct = UHDR_CT_SRGB;
   mRawYuv420Image.range = UHDR_CR_FULL_RANGE;
   mRawYuv420Image.w = mWidth;
@@ -380,37 +396,71 @@ bool UltraHdrAppInput::fillYuv420ImageHandle() {
   mRawYuv420Image.stride[UHDR_PLANE_Y] = mWidth;
   mRawYuv420Image.stride[UHDR_PLANE_U] = mWidth / 2;
   mRawYuv420Image.stride[UHDR_PLANE_V] = mWidth / 2;
-  return loadFile(mYuv420File, &mRawYuv420Image);
+  return loadFile(mSdrIntentRawFile, &mRawYuv420Image);
 }
 
-bool UltraHdrAppInput::fillYuv420JpegImageHandle() {
-  std::ifstream ifd(mYuv420JpegFile, std::ios::binary | std::ios::ate);
+bool UltraHdrAppInput::fillRGB1010102ImageHandle() {
+  const int bpp = 4;
+  mRawRgba1010102Image.fmt = UHDR_IMG_FMT_32bppRGBA1010102;
+  mRawRgba1010102Image.cg = mHdrCg;
+  mRawRgba1010102Image.ct = mHdrTf;
+  mRawRgba1010102Image.range = UHDR_CR_FULL_RANGE;
+  mRawRgba1010102Image.w = mWidth;
+  mRawRgba1010102Image.h = mHeight;
+  mRawRgba1010102Image.planes[UHDR_PLANE_PACKED] = malloc(mWidth * mHeight * bpp);
+  mRawRgba1010102Image.planes[UHDR_PLANE_UV] = nullptr;
+  mRawRgba1010102Image.planes[UHDR_PLANE_V] = nullptr;
+  mRawRgba1010102Image.stride[UHDR_PLANE_PACKED] = mWidth;
+  mRawRgba1010102Image.stride[UHDR_PLANE_UV] = 0;
+  mRawRgba1010102Image.stride[UHDR_PLANE_V] = 0;
+  return loadFile(mHdrIntentRawFile, &mRawRgba1010102Image);
+}
+
+bool UltraHdrAppInput::fillRGBA8888ImageHandle() {
+  const int bpp = 4;
+  mRawRgba8888Image.fmt = UHDR_IMG_FMT_32bppRGBA8888;
+  mRawRgba8888Image.cg = mSdrCg;
+  mRawRgba8888Image.ct = UHDR_CT_SRGB;
+  mRawRgba8888Image.range = UHDR_CR_FULL_RANGE;
+  mRawRgba8888Image.w = mWidth;
+  mRawRgba8888Image.h = mHeight;
+  mRawRgba8888Image.planes[UHDR_PLANE_PACKED] = malloc(mWidth * mHeight * bpp);
+  mRawRgba8888Image.planes[UHDR_PLANE_U] = nullptr;
+  mRawRgba8888Image.planes[UHDR_PLANE_V] = nullptr;
+  mRawRgba8888Image.stride[UHDR_PLANE_Y] = mWidth;
+  mRawRgba8888Image.stride[UHDR_PLANE_U] = 0;
+  mRawRgba8888Image.stride[UHDR_PLANE_V] = 0;
+  return loadFile(mSdrIntentRawFile, &mRawRgba8888Image);
+}
+
+bool UltraHdrAppInput::fillSdrCompressedImageHandle() {
+  std::ifstream ifd(mSdrIntentCompressedFile, std::ios::binary | std::ios::ate);
   if (ifd.good()) {
     int size = ifd.tellg();
-    mYuv420JpegImage.capacity = size;
-    mYuv420JpegImage.data_sz = size;
-    mYuv420JpegImage.data = nullptr;
-    mYuv420JpegImage.cg = mYuv420Cg;
-    mYuv420JpegImage.ct = UHDR_CT_UNSPECIFIED;
-    mYuv420JpegImage.range = UHDR_CR_UNSPECIFIED;
+    mSdrIntentCompressedImage.capacity = size;
+    mSdrIntentCompressedImage.data_sz = size;
+    mSdrIntentCompressedImage.data = nullptr;
+    mSdrIntentCompressedImage.cg = mSdrCg;
+    mSdrIntentCompressedImage.ct = UHDR_CT_UNSPECIFIED;
+    mSdrIntentCompressedImage.range = UHDR_CR_UNSPECIFIED;
     ifd.close();
-    return loadFile(mYuv420JpegFile, mYuv420JpegImage.data, size);
+    return loadFile(mSdrIntentCompressedFile, mSdrIntentCompressedImage.data, size);
   }
   return false;
 }
 
-bool UltraHdrAppInput::fillGainMapJpegImageHandle() {
-  std::ifstream ifd(mGainMapJpegFile, std::ios::binary | std::ios::ate);
+bool UltraHdrAppInput::fillGainMapCompressedImageHandle() {
+  std::ifstream ifd(mGainMapCompressedFile, std::ios::binary | std::ios::ate);
   if (ifd.good()) {
     int size = ifd.tellg();
-    mGainMapJpegImage.capacity = size;
-    mGainMapJpegImage.data_sz = size;
-    mGainMapJpegImage.data = nullptr;
-    mGainMapJpegImage.cg = UHDR_CG_UNSPECIFIED;
-    mGainMapJpegImage.ct = UHDR_CT_UNSPECIFIED;
-    mGainMapJpegImage.range = UHDR_CR_UNSPECIFIED;
+    mGainMapCompressedImage.capacity = size;
+    mGainMapCompressedImage.data_sz = size;
+    mGainMapCompressedImage.data = nullptr;
+    mGainMapCompressedImage.cg = UHDR_CG_UNSPECIFIED;
+    mGainMapCompressedImage.ct = UHDR_CT_UNSPECIFIED;
+    mGainMapCompressedImage.range = UHDR_CR_UNSPECIFIED;
     ifd.close();
-    return loadFile(mGainMapJpegFile, mGainMapJpegImage.data, size);
+    return loadFile(mGainMapCompressedFile, mGainMapCompressedImage.data, size);
   }
   return false;
 }
@@ -444,25 +494,25 @@ bool UltraHdrAppInput::fillGainMapMetadataDescriptor() {
   float value;
   while (std::getline(file, line)) {
     if (sscanf(line.c_str(), "--%s %f", argument, &value) == 2) {
-      parse_argument(&mMetadata, argument, &value);
+      parse_argument(&mGainMapMetadata, argument, &value);
     }
   }
   file.close();
   return true;
 }
 
-bool UltraHdrAppInput::fillJpegRImageHandle() {
-  std::ifstream ifd(mJpegRFile, std::ios::binary | std::ios::ate);
+bool UltraHdrAppInput::fillUhdrImageHandle() {
+  std::ifstream ifd(mUhdrFile, std::ios::binary | std::ios::ate);
   if (ifd.good()) {
     int size = ifd.tellg();
-    mJpegImgR.capacity = size;
-    mJpegImgR.data_sz = size;
-    mJpegImgR.data = nullptr;
-    mYuv420JpegImage.cg = UHDR_CG_UNSPECIFIED;
-    mYuv420JpegImage.ct = UHDR_CT_UNSPECIFIED;
-    mYuv420JpegImage.range = UHDR_CR_UNSPECIFIED;
+    mUhdrImage.capacity = size;
+    mUhdrImage.data_sz = size;
+    mUhdrImage.data = nullptr;
+    mUhdrImage.cg = UHDR_CG_UNSPECIFIED;
+    mUhdrImage.ct = UHDR_CT_UNSPECIFIED;
+    mUhdrImage.range = UHDR_CR_UNSPECIFIED;
     ifd.close();
-    return loadFile(mJpegRFile, mJpegImgR.data, size);
+    return loadFile(mUhdrFile, mUhdrImage.data, size);
   }
   return false;
 }
@@ -481,40 +531,62 @@ bool UltraHdrAppInput::encode() {
   }
 
   uhdr_codec_private_t* handle = uhdr_create_encoder();
-  if (mP010File != nullptr) {
-    if (!fillP010ImageHandle()) {
-      std::cerr << " failed to load file " << mP010File << std::endl;
+  if (mHdrIntentRawFile != nullptr) {
+    if (mHdrCf == UHDR_IMG_FMT_24bppYCbCrP010) {
+      if (!fillP010ImageHandle()) {
+        std::cerr << " failed to load file " << mHdrIntentRawFile << std::endl;
+        return false;
+      }
+      RET_IF_ERR(uhdr_enc_set_raw_image(handle, &mRawP010Image, UHDR_HDR_IMG))
+    } else if (mHdrCf == UHDR_IMG_FMT_32bppRGBA1010102) {
+      if (!fillRGB1010102ImageHandle()) {
+        std::cerr << " failed to load file " << mHdrIntentRawFile << std::endl;
+        return false;
+      }
+      RET_IF_ERR(uhdr_enc_set_raw_image(handle, &mRawRgba1010102Image, UHDR_HDR_IMG))
+    } else {
+      std::cerr << " invalid hdr intent color format " << mHdrCf << std::endl;
       return false;
     }
-    RET_IF_ERR(uhdr_enc_set_raw_image(handle, &mRawP010Image, UHDR_HDR_IMG))
   }
-  if (mYuv420File != nullptr) {
-    if (!fillYuv420ImageHandle()) {
-      std::cerr << " failed to load file " << mYuv420File << std::endl;
+  if (mSdrIntentRawFile != nullptr) {
+    if (mSdrCf == UHDR_IMG_FMT_12bppYCbCr420) {
+      if (!fillYuv420ImageHandle()) {
+        std::cerr << " failed to load file " << mSdrIntentRawFile << std::endl;
+        return false;
+      }
+      RET_IF_ERR(uhdr_enc_set_raw_image(handle, &mRawYuv420Image, UHDR_SDR_IMG))
+    } else if (mSdrCf == UHDR_IMG_FMT_32bppRGBA8888) {
+      if (!fillRGBA8888ImageHandle()) {
+        std::cerr << " failed to load file " << mSdrIntentRawFile << std::endl;
+        return false;
+      }
+      RET_IF_ERR(uhdr_enc_set_raw_image(handle, &mRawRgba8888Image, UHDR_SDR_IMG))
+    } else {
+      std::cerr << " invalid sdr intent color format " << mSdrCf << std::endl;
       return false;
     }
-    RET_IF_ERR(uhdr_enc_set_raw_image(handle, &mRawYuv420Image, UHDR_SDR_IMG))
   }
-  if (mYuv420JpegFile != nullptr) {
-    if (!fillYuv420JpegImageHandle()) {
-      std::cerr << " failed to load file " << mYuv420JpegFile << std::endl;
+  if (mSdrIntentCompressedFile != nullptr) {
+    if (!fillSdrCompressedImageHandle()) {
+      std::cerr << " failed to load file " << mSdrIntentCompressedFile << std::endl;
       return false;
     }
     RET_IF_ERR(uhdr_enc_set_compressed_image(
-        handle, &mYuv420JpegImage,
-        (mGainMapJpegFile != nullptr && mGainMapMetadataCfgFile != nullptr) ? UHDR_BASE_IMG
-                                                                            : UHDR_SDR_IMG))
+        handle, &mSdrIntentCompressedImage,
+        (mGainMapCompressedFile != nullptr && mGainMapMetadataCfgFile != nullptr) ? UHDR_BASE_IMG
+                                                                                  : UHDR_SDR_IMG))
   }
-  if (mGainMapJpegFile != nullptr && mGainMapMetadataCfgFile != nullptr) {
-    if (!fillGainMapJpegImageHandle()) {
-      std::cerr << " failed to load file " << mGainMapJpegFile << std::endl;
+  if (mGainMapCompressedFile != nullptr && mGainMapMetadataCfgFile != nullptr) {
+    if (!fillGainMapCompressedImageHandle()) {
+      std::cerr << " failed to load file " << mGainMapCompressedFile << std::endl;
       return false;
     }
     if (!fillGainMapMetadataDescriptor()) {
       std::cerr << " failed to read config file " << mGainMapMetadataCfgFile << std::endl;
       return false;
     }
-    RET_IF_ERR(uhdr_enc_set_gainmap_image(handle, &mGainMapJpegImage, &mMetadata))
+    RET_IF_ERR(uhdr_enc_set_gainmap_image(handle, &mGainMapCompressedImage, &mGainMapMetadata))
   }
   RET_IF_ERR(uhdr_enc_set_quality(handle, mQuality, UHDR_BASE_IMG))
 #ifdef PROFILE_ENABLE
@@ -536,12 +608,12 @@ bool UltraHdrAppInput::encode() {
   auto output = uhdr_get_encoded_stream(handle);
 
   // for decoding
-  mJpegImgR.data = malloc(output->data_sz);
-  memcpy(mJpegImgR.data, output->data, output->data_sz);
-  mJpegImgR.capacity = mJpegImgR.data_sz = output->data_sz;
-  mJpegImgR.cg = output->cg;
-  mJpegImgR.ct = output->ct;
-  mJpegImgR.range = output->range;
+  mUhdrImage.data = malloc(output->data_sz);
+  memcpy(mUhdrImage.data, output->data, output->data_sz);
+  mUhdrImage.capacity = mUhdrImage.data_sz = output->data_sz;
+  mUhdrImage.cg = output->cg;
+  mUhdrImage.ct = output->ct;
+  mUhdrImage.range = output->range;
   writeFile("out.jpeg", output->data, output->data_sz);
   uhdr_release_encoder(handle);
 
@@ -549,8 +621,8 @@ bool UltraHdrAppInput::encode() {
 }
 
 bool UltraHdrAppInput::decode() {
-  if (mMode == 1 && !fillJpegRImageHandle()) {
-    std::cerr << " failed to load file " << mJpegRFile << std::endl;
+  if (mMode == 1 && !fillUhdrImageHandle()) {
+    std::cerr << " failed to load file " << mUhdrFile << std::endl;
     return false;
   }
 
@@ -567,7 +639,7 @@ bool UltraHdrAppInput::decode() {
   }
 
   uhdr_codec_private_t* handle = uhdr_create_decoder();
-  RET_IF_ERR(uhdr_dec_set_image(handle, &mJpegImgR))
+  RET_IF_ERR(uhdr_dec_set_image(handle, &mUhdrImage))
   RET_IF_ERR(uhdr_dec_set_out_color_transfer(handle, mOTf))
   RET_IF_ERR(uhdr_dec_set_out_img_format(handle, mOfmt))
 
@@ -589,19 +661,19 @@ bool UltraHdrAppInput::decode() {
 
   uhdr_raw_image_t* output = uhdr_get_decoded_image(handle);
 
-  mDestImage.fmt = output->fmt;
-  mDestImage.cg = output->cg;
-  mDestImage.ct = output->ct;
-  mDestImage.range = output->range;
-  mDestImage.w = output->w;
-  mDestImage.h = output->h;
+  mDecodedUhdrRgbImage.fmt = output->fmt;
+  mDecodedUhdrRgbImage.cg = output->cg;
+  mDecodedUhdrRgbImage.ct = output->ct;
+  mDecodedUhdrRgbImage.range = output->range;
+  mDecodedUhdrRgbImage.w = output->w;
+  mDecodedUhdrRgbImage.h = output->h;
   int bpp = (output->fmt == UHDR_IMG_FMT_64bppRGBAHalfFloat) ? 8 : 4;
-  mDestImage.planes[UHDR_PLANE_PACKED] = malloc(output->w * output->h * bpp);
+  mDecodedUhdrRgbImage.planes[UHDR_PLANE_PACKED] = malloc(output->w * output->h * bpp);
   char* inData = static_cast<char*>(output->planes[UHDR_PLANE_PACKED]);
-  char* outData = static_cast<char*>(mDestImage.planes[UHDR_PLANE_PACKED]);
+  char* outData = static_cast<char*>(mDecodedUhdrRgbImage.planes[UHDR_PLANE_PACKED]);
   const size_t inStride = output->stride[UHDR_PLANE_PACKED] * bpp;
   const size_t outStride = output->w * bpp;
-  mDestImage.stride[UHDR_PLANE_PACKED] = output->w;
+  mDecodedUhdrRgbImage.stride[UHDR_PLANE_PACKED] = output->w;
   const size_t length = output->w * bpp;
   for (unsigned i = 0; i < output->h; i++, inData += inStride, outData += outStride) {
     memcpy(outData, inData, length);
@@ -615,14 +687,14 @@ bool UltraHdrAppInput::decode() {
 #define CLIP3(x, min, max) ((x) < (min)) ? (min) : ((x) > (max)) ? (max) : (x)
 bool UltraHdrAppInput::convertP010ToRGBImage() {
   const float* coeffs = BT2020YUVtoRGBMatrix;
-  if (mP010Cg == UHDR_CG_BT_709) {
+  if (mHdrCg == UHDR_CG_BT_709) {
     coeffs = BT709YUVtoRGBMatrix;
-  } else if (mP010Cg == UHDR_CG_BT_2100) {
+  } else if (mHdrCg == UHDR_CG_BT_2100) {
     coeffs = BT2020YUVtoRGBMatrix;
-  } else if (mP010Cg == UHDR_CG_DISPLAY_P3) {
+  } else if (mHdrCg == UHDR_CG_DISPLAY_P3) {
     coeffs = BT601YUVtoRGBMatrix;
   } else {
-    std::cerr << "color matrix not present for gamut " << mP010Cg << " using BT2020Matrix"
+    std::cerr << "color matrix not present for gamut " << mHdrCg << " using BT2020Matrix"
               << std::endl;
   }
 
@@ -655,8 +727,8 @@ bool UltraHdrAppInput::convertP010ToRGBImage() {
       v0 = CLIP3(v0, 64.0f, 960.0f);
 
       y0 = (y0 - 64.0f) / 876.0f;
-      u0 = (u0 - 64.0f) / 896.0f - 0.5f;
-      v0 = (v0 - 64.0f) / 896.0f - 0.5f;
+      u0 = (u0 - 512.0f) / 896.0f;
+      v0 = (v0 - 512.0f) / 896.0f;
 
       float r = coeffs[0] * y0 + coeffs[1] * u0 + coeffs[2] * v0;
       float g = coeffs[3] * y0 + coeffs[4] * u0 + coeffs[5] * v0;
@@ -675,7 +747,9 @@ bool UltraHdrAppInput::convertP010ToRGBImage() {
       rgbData++;
     }
   }
+#ifdef DUMP_DEBUG_DATA
   writeFile("inRgba1010102.raw", &mRawRgba1010102Image);
+#endif
   return true;
 }
 
@@ -699,6 +773,16 @@ bool UltraHdrAppInput::convertYuv420ToRGBImage() {
   uint8_t* v = static_cast<uint8_t*>(mRawYuv420Image.planes[UHDR_PLANE_V]);
 
   const float* coeffs = BT601YUVtoRGBMatrix;
+  if (mSdrCg == UHDR_CG_BT_709) {
+    coeffs = BT709YUVtoRGBMatrix;
+  } else if (mSdrCg == UHDR_CG_BT_2100) {
+    coeffs = BT2020YUVtoRGBMatrix;
+  } else if (mSdrCg == UHDR_CG_DISPLAY_P3) {
+    coeffs = BT601YUVtoRGBMatrix;
+  } else {
+    std::cerr << "color matrix not present for gamut " << mSdrCg << " using BT601Matrix"
+              << std::endl;
+  }
   for (size_t i = 0; i < mRawYuv420Image.h; i++) {
     for (size_t j = 0; j < mRawYuv420Image.w; j++) {
       float y0 = float(y[mRawYuv420Image.stride[UHDR_PLANE_Y] * i + j]);
@@ -729,36 +813,54 @@ bool UltraHdrAppInput::convertYuv420ToRGBImage() {
       rgbData++;
     }
   }
+#ifdef DUMP_DEBUG_DATA
   writeFile("inRgba8888.raw", &mRawRgba8888Image);
+#endif
   return true;
 }
 
 bool UltraHdrAppInput::convertRgba8888ToYUV444Image() {
-  mDestYUV444Image.fmt = static_cast<uhdr_img_fmt_t>(UHDR_IMG_FMT_24bppYCbCr444);
-  mDestYUV444Image.cg = mDestImage.cg;
-  mDestYUV444Image.ct = mDestImage.ct;
-  mDestYUV444Image.range = UHDR_CR_FULL_RANGE;
-  mDestYUV444Image.w = mDestImage.w;
-  mDestYUV444Image.h = mDestImage.h;
-  mDestYUV444Image.planes[UHDR_PLANE_Y] = malloc(mDestImage.w * mDestImage.h);
-  mDestYUV444Image.planes[UHDR_PLANE_U] = malloc(mDestImage.w * mDestImage.h);
-  mDestYUV444Image.planes[UHDR_PLANE_V] = malloc(mDestImage.w * mDestImage.h);
-  mDestYUV444Image.stride[UHDR_PLANE_Y] = mWidth;
-  mDestYUV444Image.stride[UHDR_PLANE_U] = mWidth;
-  mDestYUV444Image.stride[UHDR_PLANE_V] = mWidth;
+  mDecodedUhdrYuv444Image.fmt = static_cast<uhdr_img_fmt_t>(UHDR_IMG_FMT_24bppYCbCr444);
+  mDecodedUhdrYuv444Image.cg = mDecodedUhdrRgbImage.cg;
+  mDecodedUhdrYuv444Image.ct = mDecodedUhdrRgbImage.ct;
+  mDecodedUhdrYuv444Image.range = UHDR_CR_FULL_RANGE;
+  mDecodedUhdrYuv444Image.w = mDecodedUhdrRgbImage.w;
+  mDecodedUhdrYuv444Image.h = mDecodedUhdrRgbImage.h;
+  mDecodedUhdrYuv444Image.planes[UHDR_PLANE_Y] =
+      malloc(mDecodedUhdrRgbImage.w * mDecodedUhdrRgbImage.h);
+  mDecodedUhdrYuv444Image.planes[UHDR_PLANE_U] =
+      malloc(mDecodedUhdrRgbImage.w * mDecodedUhdrRgbImage.h);
+  mDecodedUhdrYuv444Image.planes[UHDR_PLANE_V] =
+      malloc(mDecodedUhdrRgbImage.w * mDecodedUhdrRgbImage.h);
+  mDecodedUhdrYuv444Image.stride[UHDR_PLANE_Y] = mWidth;
+  mDecodedUhdrYuv444Image.stride[UHDR_PLANE_U] = mWidth;
+  mDecodedUhdrYuv444Image.stride[UHDR_PLANE_V] = mWidth;
 
-  uint32_t* rgbData = static_cast<uint32_t*>(mDestImage.planes[UHDR_PLANE_PACKED]);
+  uint32_t* rgbData = static_cast<uint32_t*>(mDecodedUhdrRgbImage.planes[UHDR_PLANE_PACKED]);
 
-  uint8_t* yData = static_cast<uint8_t*>(mDestYUV444Image.planes[UHDR_PLANE_Y]);
-  uint8_t* uData = static_cast<uint8_t*>(mDestYUV444Image.planes[UHDR_PLANE_U]);
-  uint8_t* vData = static_cast<uint8_t*>(mDestYUV444Image.planes[UHDR_PLANE_V]);
+  uint8_t* yData = static_cast<uint8_t*>(mDecodedUhdrYuv444Image.planes[UHDR_PLANE_Y]);
+  uint8_t* uData = static_cast<uint8_t*>(mDecodedUhdrYuv444Image.planes[UHDR_PLANE_U]);
+  uint8_t* vData = static_cast<uint8_t*>(mDecodedUhdrYuv444Image.planes[UHDR_PLANE_V]);
 
   const float* coeffs = BT601RGBtoYUVMatrix;
-  for (size_t i = 0; i < mDestImage.h; i++) {
-    for (size_t j = 0; j < mDestImage.w; j++) {
-      float r0 = float(rgbData[mDestImage.stride[UHDR_PLANE_PACKED] * i + j] & 0xff);
-      float g0 = float((rgbData[mDestImage.stride[UHDR_PLANE_PACKED] * i + j] >> 8) & 0xff);
-      float b0 = float((rgbData[mDestImage.stride[UHDR_PLANE_PACKED] * i + j] >> 16) & 0xff);
+  if (mDecodedUhdrRgbImage.cg == UHDR_CG_BT_709) {
+    coeffs = BT709RGBtoYUVMatrix;
+  } else if (mDecodedUhdrRgbImage.cg == UHDR_CG_BT_2100) {
+    coeffs = BT2020RGBtoYUVMatrix;
+  } else if (mDecodedUhdrRgbImage.cg == UHDR_CG_DISPLAY_P3) {
+    coeffs = BT601RGBtoYUVMatrix;
+  } else {
+    std::cerr << "color matrix not present for gamut " << mDecodedUhdrRgbImage.cg
+              << " using BT601Matrix" << std::endl;
+  }
+
+  for (size_t i = 0; i < mDecodedUhdrRgbImage.h; i++) {
+    for (size_t j = 0; j < mDecodedUhdrRgbImage.w; j++) {
+      float r0 = float(rgbData[mDecodedUhdrRgbImage.stride[UHDR_PLANE_PACKED] * i + j] & 0xff);
+      float g0 =
+          float((rgbData[mDecodedUhdrRgbImage.stride[UHDR_PLANE_PACKED] * i + j] >> 8) & 0xff);
+      float b0 =
+          float((rgbData[mDecodedUhdrRgbImage.stride[UHDR_PLANE_PACKED] * i + j] >> 16) & 0xff);
 
       r0 /= 255.0f;
       g0 /= 255.0f;
@@ -776,52 +878,59 @@ bool UltraHdrAppInput::convertRgba8888ToYUV444Image() {
       u = CLIP3(u, 0.0f, 255.0f);
       v = CLIP3(v, 0.0f, 255.0f);
 
-      yData[mDestYUV444Image.stride[UHDR_PLANE_Y] * i + j] = uint8_t(y);
-      uData[mDestYUV444Image.stride[UHDR_PLANE_U] * i + j] = uint8_t(u);
-      vData[mDestYUV444Image.stride[UHDR_PLANE_V] * i + j] = uint8_t(v);
+      yData[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_Y] * i + j] = uint8_t(y);
+      uData[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_U] * i + j] = uint8_t(u);
+      vData[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_V] * i + j] = uint8_t(v);
     }
   }
-  writeFile("outyuv444.yuv", &mDestYUV444Image);
+#ifdef DUMP_DEBUG_DATA
+  writeFile("outyuv444.yuv", &mDecodedUhdrYuv444Image);
+#endif
   return true;
 }
 
 bool UltraHdrAppInput::convertRgba1010102ToYUV444Image() {
   const float* coeffs = BT2020RGBtoYUVMatrix;
-  if (mP010Cg == UHDR_CG_BT_709) {
+  if (mDecodedUhdrRgbImage.cg == UHDR_CG_BT_709) {
     coeffs = BT709RGBtoYUVMatrix;
-  } else if (mP010Cg == UHDR_CG_BT_2100) {
+  } else if (mDecodedUhdrRgbImage.cg == UHDR_CG_BT_2100) {
     coeffs = BT2020RGBtoYUVMatrix;
-  } else if (mP010Cg == UHDR_CG_DISPLAY_P3) {
+  } else if (mDecodedUhdrRgbImage.cg == UHDR_CG_DISPLAY_P3) {
     coeffs = BT601RGBtoYUVMatrix;
   } else {
-    std::cerr << "color matrix not present for gamut " << mP010Cg << " using BT2020Matrix"
-              << std::endl;
+    std::cerr << "color matrix not present for gamut " << mDecodedUhdrRgbImage.cg
+              << " using BT2020Matrix" << std::endl;
   }
 
-  mDestYUV444Image.fmt = static_cast<uhdr_img_fmt_t>(UHDR_IMG_FMT_48bppYCbCr444);
-  mDestYUV444Image.cg = mDestImage.cg;
-  mDestYUV444Image.ct = mDestImage.ct;
-  mDestYUV444Image.range = UHDR_CR_FULL_RANGE;
-  mDestYUV444Image.w = mDestImage.w;
-  mDestYUV444Image.h = mDestImage.h;
-  mDestYUV444Image.planes[UHDR_PLANE_Y] = malloc(mDestImage.w * mDestImage.h * 2);
-  mDestYUV444Image.planes[UHDR_PLANE_U] = malloc(mDestImage.w * mDestImage.h * 2);
-  mDestYUV444Image.planes[UHDR_PLANE_V] = malloc(mDestImage.w * mDestImage.h * 2);
-  mDestYUV444Image.stride[UHDR_PLANE_Y] = mWidth;
-  mDestYUV444Image.stride[UHDR_PLANE_U] = mWidth;
-  mDestYUV444Image.stride[UHDR_PLANE_V] = mWidth;
+  mDecodedUhdrYuv444Image.fmt = static_cast<uhdr_img_fmt_t>(UHDR_IMG_FMT_48bppYCbCr444);
+  mDecodedUhdrYuv444Image.cg = mDecodedUhdrRgbImage.cg;
+  mDecodedUhdrYuv444Image.ct = mDecodedUhdrRgbImage.ct;
+  mDecodedUhdrYuv444Image.range = UHDR_CR_LIMITED_RANGE;
+  mDecodedUhdrYuv444Image.w = mDecodedUhdrRgbImage.w;
+  mDecodedUhdrYuv444Image.h = mDecodedUhdrRgbImage.h;
+  mDecodedUhdrYuv444Image.planes[UHDR_PLANE_Y] =
+      malloc(mDecodedUhdrRgbImage.w * mDecodedUhdrRgbImage.h * 2);
+  mDecodedUhdrYuv444Image.planes[UHDR_PLANE_U] =
+      malloc(mDecodedUhdrRgbImage.w * mDecodedUhdrRgbImage.h * 2);
+  mDecodedUhdrYuv444Image.planes[UHDR_PLANE_V] =
+      malloc(mDecodedUhdrRgbImage.w * mDecodedUhdrRgbImage.h * 2);
+  mDecodedUhdrYuv444Image.stride[UHDR_PLANE_Y] = mWidth;
+  mDecodedUhdrYuv444Image.stride[UHDR_PLANE_U] = mWidth;
+  mDecodedUhdrYuv444Image.stride[UHDR_PLANE_V] = mWidth;
 
-  uint32_t* rgbData = static_cast<uint32_t*>(mDestImage.planes[UHDR_PLANE_PACKED]);
+  uint32_t* rgbData = static_cast<uint32_t*>(mDecodedUhdrRgbImage.planes[UHDR_PLANE_PACKED]);
 
-  uint16_t* yData = static_cast<uint16_t*>(mDestYUV444Image.planes[UHDR_PLANE_Y]);
-  uint16_t* uData = static_cast<uint16_t*>(mDestYUV444Image.planes[UHDR_PLANE_U]);
-  uint16_t* vData = static_cast<uint16_t*>(mDestYUV444Image.planes[UHDR_PLANE_V]);
+  uint16_t* yData = static_cast<uint16_t*>(mDecodedUhdrYuv444Image.planes[UHDR_PLANE_Y]);
+  uint16_t* uData = static_cast<uint16_t*>(mDecodedUhdrYuv444Image.planes[UHDR_PLANE_U]);
+  uint16_t* vData = static_cast<uint16_t*>(mDecodedUhdrYuv444Image.planes[UHDR_PLANE_V]);
 
-  for (size_t i = 0; i < mDestImage.h; i++) {
-    for (size_t j = 0; j < mDestImage.w; j++) {
-      float r0 = float(rgbData[mDestImage.stride[UHDR_PLANE_PACKED] * i + j] & 0x3ff);
-      float g0 = float((rgbData[mDestImage.stride[UHDR_PLANE_PACKED] * i + j] >> 10) & 0x3ff);
-      float b0 = float((rgbData[mDestImage.stride[UHDR_PLANE_PACKED] * i + j] >> 20) & 0x3ff);
+  for (size_t i = 0; i < mDecodedUhdrRgbImage.h; i++) {
+    for (size_t j = 0; j < mDecodedUhdrRgbImage.w; j++) {
+      float r0 = float(rgbData[mDecodedUhdrRgbImage.stride[UHDR_PLANE_PACKED] * i + j] & 0x3ff);
+      float g0 =
+          float((rgbData[mDecodedUhdrRgbImage.stride[UHDR_PLANE_PACKED] * i + j] >> 10) & 0x3ff);
+      float b0 =
+          float((rgbData[mDecodedUhdrRgbImage.stride[UHDR_PLANE_PACKED] * i + j] >> 20) & 0x3ff);
 
       r0 /= 1023.0f;
       g0 /= 1023.0f;
@@ -839,12 +948,14 @@ bool UltraHdrAppInput::convertRgba1010102ToYUV444Image() {
       u = CLIP3(u, 64.0f, 960.0f);
       v = CLIP3(v, 64.0f, 960.0f);
 
-      yData[mDestYUV444Image.stride[UHDR_PLANE_Y] * i + j] = uint16_t(y);
-      uData[mDestYUV444Image.stride[UHDR_PLANE_U] * i + j] = uint16_t(u);
-      vData[mDestYUV444Image.stride[UHDR_PLANE_V] * i + j] = uint16_t(v);
+      yData[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_Y] * i + j] = uint16_t(y);
+      uData[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_U] * i + j] = uint16_t(u);
+      vData[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_V] * i + j] = uint16_t(v);
     }
   }
-  writeFile("outyuv444.yuv", &mDestYUV444Image);
+#ifdef DUMP_DEBUG_DATA
+  writeFile("outyuv444.yuv", &mDecodedUhdrYuv444Image);
+#endif
   return true;
 }
 
@@ -854,18 +965,18 @@ void UltraHdrAppInput::computeRGBHdrPSNR() {
     return;
   }
   uint32_t* rgbDataSrc = static_cast<uint32_t*>(mRawRgba1010102Image.planes[UHDR_PLANE_PACKED]);
-  uint32_t* rgbDataDst = static_cast<uint32_t*>(mDestImage.planes[UHDR_PLANE_PACKED]);
+  uint32_t* rgbDataDst = static_cast<uint32_t*>(mDecodedUhdrRgbImage.planes[UHDR_PLANE_PACKED]);
   if (rgbDataSrc == nullptr || rgbDataDst == nullptr) {
     std::cerr << "invalid src or dst pointer for psnr computation " << std::endl;
     return;
   }
-  if (mOTf != mP010Tf) {
+  if (mOTf != mHdrTf) {
     std::cout << "input transfer function and output format are not compatible, psnr results "
                  "may be unreliable"
               << std::endl;
   }
   uint64_t rSqError = 0, gSqError = 0, bSqError = 0;
-  for (size_t i = 0; i < mRawP010Image.w * mRawP010Image.h; i++) {
+  for (size_t i = 0; i < mDecodedUhdrRgbImage.w * mDecodedUhdrRgbImage.h; i++) {
     int rSrc = *rgbDataSrc & 0x3ff;
     int rDst = *rgbDataDst & 0x3ff;
     rSqError += (rSrc - rDst) * (rSrc - rDst);
@@ -881,13 +992,13 @@ void UltraHdrAppInput::computeRGBHdrPSNR() {
     rgbDataSrc++;
     rgbDataDst++;
   }
-  double meanSquareError = (double)rSqError / (mRawP010Image.w * mRawP010Image.h);
+  double meanSquareError = (double)rSqError / (mDecodedUhdrRgbImage.w * mDecodedUhdrRgbImage.h);
   mPsnr[0] = meanSquareError ? 10 * log10((double)1023 * 1023 / meanSquareError) : 100;
 
-  meanSquareError = (double)gSqError / (mRawP010Image.w * mRawP010Image.h);
+  meanSquareError = (double)gSqError / (mDecodedUhdrRgbImage.w * mDecodedUhdrRgbImage.h);
   mPsnr[1] = meanSquareError ? 10 * log10((double)1023 * 1023 / meanSquareError) : 100;
 
-  meanSquareError = (double)bSqError / (mRawP010Image.w * mRawP010Image.h);
+  meanSquareError = (double)bSqError / (mDecodedUhdrRgbImage.w * mDecodedUhdrRgbImage.h);
   mPsnr[2] = meanSquareError ? 10 * log10((double)1023 * 1023 / meanSquareError) : 100;
 
   std::cout << "psnr r :: " << mPsnr[0] << " psnr g :: " << mPsnr[1] << " psnr b :: " << mPsnr[2]
@@ -900,14 +1011,14 @@ void UltraHdrAppInput::computeRGBSdrPSNR() {
     return;
   }
   uint32_t* rgbDataSrc = static_cast<uint32_t*>(mRawRgba8888Image.planes[UHDR_PLANE_PACKED]);
-  uint32_t* rgbDataDst = static_cast<uint32_t*>(mDestImage.planes[UHDR_PLANE_PACKED]);
+  uint32_t* rgbDataDst = static_cast<uint32_t*>(mDecodedUhdrRgbImage.planes[UHDR_PLANE_PACKED]);
   if (rgbDataSrc == nullptr || rgbDataDst == nullptr) {
     std::cerr << "invalid src or dst pointer for psnr computation " << std::endl;
     return;
   }
 
   uint64_t rSqError = 0, gSqError = 0, bSqError = 0;
-  for (size_t i = 0; i < mRawYuv420Image.w * mRawYuv420Image.h; i++) {
+  for (size_t i = 0; i < mDecodedUhdrRgbImage.w * mDecodedUhdrRgbImage.h; i++) {
     int rSrc = *rgbDataSrc & 0xff;
     int rDst = *rgbDataDst & 0xff;
     rSqError += (rSrc - rDst) * (rSrc - rDst);
@@ -923,13 +1034,13 @@ void UltraHdrAppInput::computeRGBSdrPSNR() {
     rgbDataSrc++;
     rgbDataDst++;
   }
-  double meanSquareError = (double)rSqError / (mRawYuv420Image.w * mRawYuv420Image.h);
+  double meanSquareError = (double)rSqError / (mDecodedUhdrRgbImage.w * mDecodedUhdrRgbImage.h);
   mPsnr[0] = meanSquareError ? 10 * log10((double)255 * 255 / meanSquareError) : 100;
 
-  meanSquareError = (double)gSqError / (mRawYuv420Image.w * mRawYuv420Image.h);
+  meanSquareError = (double)gSqError / (mDecodedUhdrRgbImage.w * mDecodedUhdrRgbImage.h);
   mPsnr[1] = meanSquareError ? 10 * log10((double)255 * 255 / meanSquareError) : 100;
 
-  meanSquareError = (double)bSqError / (mRawYuv420Image.w * mRawYuv420Image.h);
+  meanSquareError = (double)bSqError / (mDecodedUhdrRgbImage.w * mDecodedUhdrRgbImage.h);
   mPsnr[2] = meanSquareError ? 10 * log10((double)255 * 255 / meanSquareError) : 100;
 
   std::cout << "psnr r :: " << mPsnr[0] << " psnr g :: " << mPsnr[1] << " psnr b :: " << mPsnr[2]
@@ -945,59 +1056,60 @@ void UltraHdrAppInput::computeYUVHdrPSNR() {
   uint16_t* uDataSrc = static_cast<uint16_t*>(mRawP010Image.planes[UHDR_PLANE_UV]);
   uint16_t* vDataSrc = uDataSrc + 1;
 
-  uint16_t* yDataDst = static_cast<uint16_t*>(mDestYUV444Image.planes[UHDR_PLANE_Y]);
-  uint16_t* uDataDst = static_cast<uint16_t*>(mDestYUV444Image.planes[UHDR_PLANE_U]);
-  uint16_t* vDataDst = static_cast<uint16_t*>(mDestYUV444Image.planes[UHDR_PLANE_V]);
+  uint16_t* yDataDst = static_cast<uint16_t*>(mDecodedUhdrYuv444Image.planes[UHDR_PLANE_Y]);
+  uint16_t* uDataDst = static_cast<uint16_t*>(mDecodedUhdrYuv444Image.planes[UHDR_PLANE_U]);
+  uint16_t* vDataDst = static_cast<uint16_t*>(mDecodedUhdrYuv444Image.planes[UHDR_PLANE_V]);
   if (yDataSrc == nullptr || uDataSrc == nullptr || yDataDst == nullptr || uDataDst == nullptr ||
       vDataDst == nullptr) {
     std::cerr << "invalid src or dst pointer for psnr computation " << std::endl;
     return;
   }
-  if (mOTf != mP010Tf) {
+  if (mOTf != mHdrTf) {
     std::cout << "input transfer function and output format are not compatible, psnr results "
                  "may be unreliable"
               << std::endl;
   }
 
   uint64_t ySqError = 0, uSqError = 0, vSqError = 0;
-  for (size_t i = 0; i < mDestYUV444Image.h; i++) {
-    for (size_t j = 0; j < mDestYUV444Image.w; j++) {
+  for (size_t i = 0; i < mDecodedUhdrYuv444Image.h; i++) {
+    for (size_t j = 0; j < mDecodedUhdrYuv444Image.w; j++) {
       int ySrc = (yDataSrc[mRawP010Image.stride[UHDR_PLANE_Y] * i + j] >> 6) & 0x3ff;
       ySrc = CLIP3(ySrc, 64, 940);
-      int yDst = yDataDst[mDestYUV444Image.stride[UHDR_PLANE_Y] * i + j] & 0x3ff;
+      int yDst = yDataDst[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_Y] * i + j] & 0x3ff;
       ySqError += (ySrc - yDst) * (ySrc - yDst);
 
       if (i % 2 == 0 && j % 2 == 0) {
         int uSrc =
             (uDataSrc[mRawP010Image.stride[UHDR_PLANE_UV] * (i / 2) + (j / 2) * 2] >> 6) & 0x3ff;
         uSrc = CLIP3(uSrc, 64, 960);
-        int uDst = uDataDst[mDestYUV444Image.stride[UHDR_PLANE_U] * i + j] & 0x3ff;
-        uDst += uDataDst[mDestYUV444Image.stride[UHDR_PLANE_U] * i + j + 1] & 0x3ff;
-        uDst += uDataDst[mDestYUV444Image.stride[UHDR_PLANE_U] * (i + 1) + j + 1] & 0x3ff;
-        uDst += uDataDst[mDestYUV444Image.stride[UHDR_PLANE_U] * (i + 1) + j + 1] & 0x3ff;
+        int uDst = uDataDst[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_U] * i + j] & 0x3ff;
+        uDst += uDataDst[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_U] * i + j + 1] & 0x3ff;
+        uDst += uDataDst[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_U] * (i + 1) + j + 1] & 0x3ff;
+        uDst += uDataDst[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_U] * (i + 1) + j + 1] & 0x3ff;
         uDst = (uDst + 2) >> 2;
         uSqError += (uSrc - uDst) * (uSrc - uDst);
 
         int vSrc =
             (vDataSrc[mRawP010Image.stride[UHDR_PLANE_UV] * (i / 2) + (j / 2) * 2] >> 6) & 0x3ff;
         vSrc = CLIP3(vSrc, 64, 960);
-        int vDst = vDataDst[mDestYUV444Image.stride[UHDR_PLANE_V] * i + j] & 0x3ff;
-        vDst += vDataDst[mDestYUV444Image.stride[UHDR_PLANE_V] * i + j + 1] & 0x3ff;
-        vDst += vDataDst[mDestYUV444Image.stride[UHDR_PLANE_V] * (i + 1) + j + 1] & 0x3ff;
-        vDst += vDataDst[mDestYUV444Image.stride[UHDR_PLANE_V] * (i + 1) + j + 1] & 0x3ff;
+        int vDst = vDataDst[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_V] * i + j] & 0x3ff;
+        vDst += vDataDst[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_V] * i + j + 1] & 0x3ff;
+        vDst += vDataDst[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_V] * (i + 1) + j + 1] & 0x3ff;
+        vDst += vDataDst[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_V] * (i + 1) + j + 1] & 0x3ff;
         vDst = (vDst + 2) >> 2;
         vSqError += (vSrc - vDst) * (vSrc - vDst);
       }
     }
   }
 
-  double meanSquareError = (double)ySqError / (mDestYUV444Image.w * mDestYUV444Image.h);
+  double meanSquareError =
+      (double)ySqError / (mDecodedUhdrYuv444Image.w * mDecodedUhdrYuv444Image.h);
   mPsnr[0] = meanSquareError ? 10 * log10((double)1023 * 1023 / meanSquareError) : 100;
 
-  meanSquareError = (double)uSqError / (mDestYUV444Image.w * mDestYUV444Image.h / 4);
+  meanSquareError = (double)uSqError / (mDecodedUhdrYuv444Image.w * mDecodedUhdrYuv444Image.h / 4);
   mPsnr[1] = meanSquareError ? 10 * log10((double)1023 * 1023 / meanSquareError) : 100;
 
-  meanSquareError = (double)vSqError / (mDestYUV444Image.w * mDestYUV444Image.h / 4);
+  meanSquareError = (double)vSqError / (mDecodedUhdrYuv444Image.w * mDecodedUhdrYuv444Image.h / 4);
   mPsnr[2] = meanSquareError ? 10 * log10((double)1023 * 1023 / meanSquareError) : 100;
 
   std::cout << "psnr y :: " << mPsnr[0] << " psnr u :: " << mPsnr[1] << " psnr v :: " << mPsnr[2]
@@ -1014,46 +1126,47 @@ void UltraHdrAppInput::computeYUVSdrPSNR() {
   uint8_t* uDataSrc = static_cast<uint8_t*>(mRawYuv420Image.planes[UHDR_PLANE_U]);
   uint8_t* vDataSrc = static_cast<uint8_t*>(mRawYuv420Image.planes[UHDR_PLANE_V]);
 
-  uint8_t* yDataDst = static_cast<uint8_t*>(mDestYUV444Image.planes[UHDR_PLANE_Y]);
-  uint8_t* uDataDst = static_cast<uint8_t*>(mDestYUV444Image.planes[UHDR_PLANE_U]);
-  uint8_t* vDataDst = static_cast<uint8_t*>(mDestYUV444Image.planes[UHDR_PLANE_V]);
+  uint8_t* yDataDst = static_cast<uint8_t*>(mDecodedUhdrYuv444Image.planes[UHDR_PLANE_Y]);
+  uint8_t* uDataDst = static_cast<uint8_t*>(mDecodedUhdrYuv444Image.planes[UHDR_PLANE_U]);
+  uint8_t* vDataDst = static_cast<uint8_t*>(mDecodedUhdrYuv444Image.planes[UHDR_PLANE_V]);
 
   uint64_t ySqError = 0, uSqError = 0, vSqError = 0;
-  for (size_t i = 0; i < mDestYUV444Image.h; i++) {
-    for (size_t j = 0; j < mDestYUV444Image.w; j++) {
+  for (size_t i = 0; i < mDecodedUhdrYuv444Image.h; i++) {
+    for (size_t j = 0; j < mDecodedUhdrYuv444Image.w; j++) {
       int ySrc = yDataSrc[mRawYuv420Image.stride[UHDR_PLANE_Y] * i + j];
-      int yDst = yDataDst[mDestYUV444Image.stride[UHDR_PLANE_Y] * i + j];
+      int yDst = yDataDst[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_Y] * i + j];
       ySqError += (ySrc - yDst) * (ySrc - yDst);
 
       if (i % 2 == 0 && j % 2 == 0) {
         int uSrc = uDataSrc[mRawYuv420Image.stride[UHDR_PLANE_U] * (i / 2) + j / 2];
-        int uDst = uDataDst[mDestYUV444Image.stride[UHDR_PLANE_U] * i + j];
-        uDst += uDataDst[mDestYUV444Image.stride[UHDR_PLANE_U] * i + j + 1];
-        uDst += uDataDst[mDestYUV444Image.stride[UHDR_PLANE_U] * (i + 1) + j];
-        uDst += uDataDst[mDestYUV444Image.stride[UHDR_PLANE_U] * (i + 1) + j + 1];
+        int uDst = uDataDst[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_U] * i + j];
+        uDst += uDataDst[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_U] * i + j + 1];
+        uDst += uDataDst[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_U] * (i + 1) + j];
+        uDst += uDataDst[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_U] * (i + 1) + j + 1];
         uDst = (uDst + 2) >> 2;
         uSqError += (uSrc - uDst) * (uSrc - uDst);
 
         int vSrc = vDataSrc[mRawYuv420Image.stride[UHDR_PLANE_V] * (i / 2) + j / 2];
-        int vDst = vDataDst[mDestYUV444Image.stride[UHDR_PLANE_V] * i + j];
-        vDst += vDataDst[mDestYUV444Image.stride[UHDR_PLANE_V] * i + j + 1];
-        vDst += vDataDst[mDestYUV444Image.stride[UHDR_PLANE_V] * (i + 1) + j];
-        vDst += vDataDst[mDestYUV444Image.stride[UHDR_PLANE_V] * (i + 1) + j + 1];
+        int vDst = vDataDst[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_V] * i + j];
+        vDst += vDataDst[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_V] * i + j + 1];
+        vDst += vDataDst[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_V] * (i + 1) + j];
+        vDst += vDataDst[mDecodedUhdrYuv444Image.stride[UHDR_PLANE_V] * (i + 1) + j + 1];
         vDst = (vDst + 2) >> 2;
         vSqError += (vSrc - vDst) * (vSrc - vDst);
       }
     }
   }
-  double meanSquareError = (double)ySqError / (mDestYUV444Image.w * mDestYUV444Image.h);
+  double meanSquareError =
+      (double)ySqError / (mDecodedUhdrYuv444Image.w * mDecodedUhdrYuv444Image.h);
   mPsnr[0] = meanSquareError ? 10 * log10((double)255 * 255 / meanSquareError) : 100;
 
-  meanSquareError = (double)uSqError / (mDestYUV444Image.w * mDestYUV444Image.h / 4);
+  meanSquareError = (double)uSqError / (mDecodedUhdrYuv444Image.w * mDecodedUhdrYuv444Image.h / 4);
   mPsnr[1] = meanSquareError ? 10 * log10((double)255 * 255 / meanSquareError) : 100;
 
-  meanSquareError = (double)vSqError / (mDestYUV444Image.w * mDestYUV444Image.h / 4);
+  meanSquareError = (double)vSqError / (mDecodedUhdrYuv444Image.w * mDecodedUhdrYuv444Image.h / 4);
   mPsnr[2] = meanSquareError ? 10 * log10((double)255 * 255 / meanSquareError) : 100;
 
-  std::cout << "psnr y :: " << mPsnr[0] << " psnr  u:: " << mPsnr[1] << " psnr v :: " << mPsnr[2]
+  std::cout << "psnr y :: " << mPsnr[0] << " psnr u :: " << mPsnr[1] << " psnr v :: " << mPsnr[2]
             << std::endl;
 }
 
@@ -1061,10 +1174,16 @@ static void usage(const char* name) {
   fprintf(stderr, "\n## ultra hdr demo application.\nUsage : %s \n", name);
   fprintf(stderr, "    -m    mode of operation. [0:encode, 1:decode] \n");
   fprintf(stderr, "\n## encoder options : \n");
-  fprintf(stderr, "    -p    raw 10 bit input resource in p010 color format. \n");
+  fprintf(stderr, "    -p    raw 10 bit input resource \n");
   fprintf(stderr,
-          "    -y    raw 8 bit input resource in yuv420, optional. \n"
+          "    -y    raw 8 bit input resource, optional. \n"
           "          if not provided tonemapping happens internally. \n");
+  fprintf(stderr,
+          "    -a    raw 10 bit input resource color format. Required if raw hdr intent is "
+          "provided. [0:p010, 5:rgb1010102] \n");
+  fprintf(stderr,
+          "    -b    raw 8 bit input resource color format. Required if raw sdr intent is "
+          "provided. [1:yuv420, 3:rgba8888] \n");
   fprintf(stderr, "    -i    compressed 8 bit jpeg file path. \n");
   fprintf(stderr, "    -g    compressed 8 bit gainmap file path. \n");
   fprintf(stderr, "    -f    gainmap metadata config file. \n");
@@ -1089,27 +1208,29 @@ static void usage(const char* name) {
           "hlg, pq shall be paired with rgba1010102. linear shall be paired with rgbahalffloat");
   fprintf(stderr, "\n## examples of usage :\n");
   fprintf(stderr, "\n## encode api-0 :\n");
-  fprintf(stderr, "    ultrahdr_app -m 0 -p cosmat_1920x1080_p010.yuv -w 1920 -h 1080 -q 97\n");
   fprintf(stderr,
-          "    ultrahdr_app -m 0 -p cosmat_1920x1080_p010.yuv -w 1920 -h 1080 -q 97 -C 1 -t 2\n");
+          "    ultrahdr_app -m 0 -p cosmat_1920x1080_p010.yuv -w 1920 -h 1080 -q 97 -a 0\n");
+  fprintf(
+      stderr,
+      "    ultrahdr_app -m 0 -p cosmat_1920x1080_p010.yuv -w 1920 -h 1080 -q 97 -C 1 -t 2 -a 0\n");
   fprintf(stderr, "\n## encode api-1 :\n");
   fprintf(stderr,
           "    ultrahdr_app -m 0 -p cosmat_1920x1080_p010.yuv -y cosmat_1920x1080_420.yuv -w 1920 "
-          "-h 1080 -q 97\n");
+          "-h 1080 -q 97 -a 0 -b 1\n");
   fprintf(stderr,
           "    ultrahdr_app -m 0 -p cosmat_1920x1080_p010.yuv -y cosmat_1920x1080_420.yuv -w 1920 "
-          "-h 1080 -q 97 -C 2 -c 1 -t 1\n");
+          "-h 1080 -q 97 -C 2 -c 1 -t 1 -a 0 -b 1\n");
   fprintf(stderr,
           "    ultrahdr_app -m 0 -p cosmat_1920x1080_p010.yuv -y cosmat_1920x1080_420.yuv -w 1920 "
-          "-h 1080 -q 97 -C 2 -c 1 -t 1 -e 1\n");
+          "-h 1080 -q 97 -C 2 -c 1 -t 1 -e 1 -a 0 -b 1\n");
   fprintf(stderr, "\n## encode api-2 :\n");
   fprintf(stderr,
           "    ultrahdr_app -m 0 -p cosmat_1920x1080_p010.yuv -y cosmat_1920x1080_420.yuv -i "
-          "cosmat_1920x1080_420_8bit.jpg -w 1920 -h 1080 -t 1 -o 3 -O 3 -e 1\n");
+          "cosmat_1920x1080_420_8bit.jpg -w 1920 -h 1080 -t 1 -o 3 -O 3 -e 1 -a 0 -b 1\n");
   fprintf(stderr, "\n## encode api-3 :\n");
   fprintf(stderr,
           "    ultrahdr_app -m 0 -p cosmat_1920x1080_p010.yuv -i cosmat_1920x1080_420_8bit.jpg -w "
-          "1920 -h 1080 -t 1 -o 1 -O 5 -e 1\n");
+          "1920 -h 1080 -t 1 -o 1 -O 5 -e 1 -a 0\n");
   fprintf(stderr, "\n## encode api-4 :\n");
   fprintf(stderr,
           "    ultrahdr_app -m 0 -i cosmat_1920x1080_420_8bit.jpg -g cosmat_1920x1080_420_8bit.jpg "
@@ -1122,33 +1243,41 @@ static void usage(const char* name) {
 }
 
 int main(int argc, char* argv[]) {
-  char opt_string[] = "p:y:i:g:f:w:h:C:c:t:q:o:O:m:j:e:";
-  char *p010_file = nullptr, *yuv420_file = nullptr, *jpegr_file = nullptr,
-       *yuv420_jpeg_file = nullptr, *gainmap_jpeg_file = nullptr,
+  char opt_string[] = "p:y:i:g:f:w:h:C:c:t:q:o:O:m:j:e:a:b:";
+  char *hdr_intent_raw_file = nullptr, *sdr_intent_raw_file = nullptr, *uhdr_file = nullptr,
+       *sdr_intent_compressed_file = nullptr, *gainmap_compressed_file = nullptr,
        *gainmap_metadata_cfg_file = nullptr;
   int width = 0, height = 0;
-  uhdr_color_gamut_t p010Cg = UHDR_CG_BT_709;
-  uhdr_color_gamut_t yuv420Cg = UHDR_CG_BT_709;
-  uhdr_color_transfer_t p010Tf = UHDR_CT_HLG;
+  uhdr_color_gamut_t hdr_cg = UHDR_CG_BT_709;
+  uhdr_color_gamut_t sdr_cg = UHDR_CG_BT_709;
+  uhdr_img_fmt_t hdr_cf = UHDR_IMG_FMT_UNSPECIFIED;
+  uhdr_img_fmt_t sdr_cf = UHDR_IMG_FMT_UNSPECIFIED;
+  uhdr_color_transfer_t hdr_tf = UHDR_CT_HLG;
   int quality = 100;
-  uhdr_color_transfer_t outTf = UHDR_CT_HLG;
-  uhdr_img_fmt_t outFmt = UHDR_IMG_FMT_32bppRGBA1010102;
+  uhdr_color_transfer_t out_tf = UHDR_CT_HLG;
+  uhdr_img_fmt_t out_cf = UHDR_IMG_FMT_32bppRGBA1010102;
   int mode = 0;
   int compute_psnr = 0;
   int ch;
   while ((ch = getopt_s(argc, argv, opt_string)) != -1) {
     switch (ch) {
+      case 'a':
+        hdr_cf = static_cast<uhdr_img_fmt_t>(atoi(optarg_s));
+        break;
+      case 'b':
+        sdr_cf = static_cast<uhdr_img_fmt_t>(atoi(optarg_s));
+        break;
       case 'p':
-        p010_file = optarg_s;
+        hdr_intent_raw_file = optarg_s;
         break;
       case 'y':
-        yuv420_file = optarg_s;
+        sdr_intent_raw_file = optarg_s;
         break;
       case 'i':
-        yuv420_jpeg_file = optarg_s;
+        sdr_intent_compressed_file = optarg_s;
         break;
       case 'g':
-        gainmap_jpeg_file = optarg_s;
+        gainmap_compressed_file = optarg_s;
         break;
       case 'f':
         gainmap_metadata_cfg_file = optarg_s;
@@ -1160,28 +1289,28 @@ int main(int argc, char* argv[]) {
         height = atoi(optarg_s);
         break;
       case 'C':
-        p010Cg = static_cast<uhdr_color_gamut_t>(atoi(optarg_s));
+        hdr_cg = static_cast<uhdr_color_gamut_t>(atoi(optarg_s));
         break;
       case 'c':
-        yuv420Cg = static_cast<uhdr_color_gamut_t>(atoi(optarg_s));
+        sdr_cg = static_cast<uhdr_color_gamut_t>(atoi(optarg_s));
         break;
       case 't':
-        p010Tf = static_cast<uhdr_color_transfer_t>(atoi(optarg_s));
+        hdr_tf = static_cast<uhdr_color_transfer_t>(atoi(optarg_s));
         break;
       case 'q':
         quality = atoi(optarg_s);
         break;
       case 'O':
-        outFmt = static_cast<uhdr_img_fmt_t>(atoi(optarg_s));
+        out_cf = static_cast<uhdr_img_fmt_t>(atoi(optarg_s));
         break;
       case 'o':
-        outTf = static_cast<uhdr_color_transfer_t>(atoi(optarg_s));
+        out_tf = static_cast<uhdr_color_transfer_t>(atoi(optarg_s));
         break;
       case 'm':
         mode = atoi(optarg_s);
         break;
       case 'j':
-        jpegr_file = optarg_s;
+        uhdr_file = optarg_s;
         break;
       case 'e':
         compute_psnr = atoi(optarg_s);
@@ -1192,38 +1321,46 @@ int main(int argc, char* argv[]) {
     }
   }
   if (mode == 0) {
-    if ((width <= 0 || height <= 0 || p010_file == nullptr) &&
-        (yuv420_jpeg_file == nullptr || gainmap_jpeg_file == nullptr ||
+    if ((width <= 0 || height <= 0 || hdr_intent_raw_file == nullptr) &&
+        (sdr_intent_compressed_file == nullptr || gainmap_compressed_file == nullptr ||
          gainmap_metadata_cfg_file == nullptr)) {
       usage(argv[0]);
       return -1;
     }
-    UltraHdrAppInput appInput(p010_file, yuv420_file, yuv420_jpeg_file, gainmap_jpeg_file,
-                              gainmap_metadata_cfg_file, width, height, p010Cg, yuv420Cg, p010Tf,
-                              quality, outTf, outFmt);
+    UltraHdrAppInput appInput(hdr_intent_raw_file, sdr_intent_raw_file, sdr_intent_compressed_file,
+                              gainmap_compressed_file, gainmap_metadata_cfg_file, width, height,
+                              hdr_cf, sdr_cf, hdr_cg, sdr_cg, hdr_tf, quality, out_tf, out_cf);
     if (!appInput.encode()) return -1;
     if (compute_psnr == 1) {
       if (!appInput.decode()) return -1;
-      if (outFmt == UHDR_IMG_FMT_32bppRGBA8888 && yuv420_file != nullptr) {
-        appInput.convertYuv420ToRGBImage();
+      if (out_cf == UHDR_IMG_FMT_32bppRGBA8888 && sdr_intent_raw_file != nullptr) {
+        if (sdr_cf == UHDR_IMG_FMT_12bppYCbCr420) {
+          appInput.convertYuv420ToRGBImage();
+        }
         appInput.computeRGBSdrPSNR();
-        appInput.convertRgba8888ToYUV444Image();
-        appInput.computeYUVSdrPSNR();
-      } else if (outFmt == UHDR_IMG_FMT_32bppRGBA1010102 && p010_file != nullptr) {
-        appInput.convertP010ToRGBImage();
+        if (sdr_cf == UHDR_IMG_FMT_12bppYCbCr420) {
+          appInput.convertRgba8888ToYUV444Image();
+          appInput.computeYUVSdrPSNR();
+        }
+      } else if (out_cf == UHDR_IMG_FMT_32bppRGBA1010102 && hdr_intent_raw_file != nullptr) {
+        if (hdr_cf == UHDR_IMG_FMT_24bppYCbCrP010) {
+          appInput.convertP010ToRGBImage();
+        }
         appInput.computeRGBHdrPSNR();
-        appInput.convertRgba1010102ToYUV444Image();
-        appInput.computeYUVHdrPSNR();
+        if (hdr_cf == UHDR_IMG_FMT_24bppYCbCrP010) {
+          appInput.convertRgba1010102ToYUV444Image();
+          appInput.computeYUVHdrPSNR();
+        }
       } else {
         std::cerr << "failed to compute psnr " << std::endl;
       }
     }
   } else if (mode == 1) {
-    if (jpegr_file == nullptr) {
+    if (uhdr_file == nullptr) {
       usage(argv[0]);
       return -1;
     }
-    UltraHdrAppInput appInput(jpegr_file, outTf, outFmt);
+    UltraHdrAppInput appInput(uhdr_file, out_tf, out_cf);
     if (!appInput.decode()) return -1;
   } else {
     std::cerr << "unrecognized input mode " << mode << std::endl;

--- a/lib/include/ultrahdr/gainmapmath.h
+++ b/lib/include/ultrahdr/gainmapmath.h
@@ -19,7 +19,10 @@
 
 #include <array>
 #include <cmath>
+#include <cstring>
 
+#include "ultrahdr_api.h"
+#include "ultrahdr/ultrahdrcommon.h"
 #include "ultrahdr/ultrahdr.h"
 #include "ultrahdr/jpegr.h"
 
@@ -516,6 +519,11 @@ uint32_t colorToRgba1010102(Color e_gamma);
  * Alpha always set to 1.0.
  */
 uint64_t colorToRgbaF16(Color e_gamma);
+
+/*
+ * Helper for preparing encoder raw inputs for encoding
+ */
+std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr(uhdr_raw_image_t* src);
 
 }  // namespace ultrahdr
 

--- a/lib/src/editorhelper.cpp
+++ b/lib/src/editorhelper.cpp
@@ -331,4 +331,5 @@ std::unique_ptr<uhdr_raw_image_ext_t> apply_resize(ultrahdr::uhdr_resize_effect_
   }
   return std::move(dst);
 }
+
 }  // namespace ultrahdr


### PR DESCRIPTION
Fixed issues in color space conversion modules of
sample app. Also rename variables in sample app
accurately

Test: ultrahdr_app -m 0 -p cosmat_1920x1080_p010.yuv \
  -w 1920 -h 1080 -q 97 -a 0

Change-Id: I86eeef02f5bc0e6b8c28de0da46b0f6d7eec6358