### PR TITLE
cmake: Re-enable building all the tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,7 +382,7 @@ set_property(DIRECTORY PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
 # File Lists
 ###########################################################
 file(GLOB UHDR_CORE_SRCS_LIST "${SOURCE_DIR}/src/*.cpp")
-file(GLOB UHDR_TEST_SRCS_LIST "${TESTS_DIR}/editorhelper_test.cpp")
+file(GLOB UHDR_TEST_SRCS_LIST "${TESTS_DIR}/*.cpp")
 file(GLOB UHDR_BM_SRCS_LIST "${BENCHMARK_DIR}/*.cpp")
 file(GLOB IMAGE_IO_SRCS_LIST "${THIRD_PARTY_DIR}/image_io/src/**/*.cc")
 


### PR DESCRIPTION
In 4a46a1cb4a5f7105674402fd50fb53e3ab01cffb, CMakeLists.txt was unintentionally modified to select only editor helper tests. This is now fixed by re-enabling all the tests in tests directory.