### PR TITLE
Add support for decoding different jpg subsampling factors

### DIFF
--- a/examples/ultrahdr_app.cpp
+++ b/examples/ultrahdr_app.cpp
@@ -260,8 +260,8 @@ class UltraHdrAppInput {
         mSdrIntentCompressedFile(sdrIntentCompressedFile),
         mGainMapCompressedFile(gainmapCompressedFile),
         mGainMapMetadataCfgFile(gainmapMetadataCfgFile),
-        mOutputFile(outputFile),
         mUhdrFile(nullptr),
+        mOutputFile(outputFile),
         mWidth(width),
         mHeight(height),
         mHdrCf(hdrCf),
@@ -1384,13 +1384,10 @@ int main(int argc, char* argv[]) {
       std::cerr << "did not receive raw resources for encoding." << std::endl;
       return -1;
     }
-    if (output_file == nullptr) {
-      output_file = "out.jpeg";
-    }
     UltraHdrAppInput appInput(hdr_intent_raw_file, sdr_intent_raw_file, sdr_intent_compressed_file,
-                              gainmap_compressed_file, gainmap_metadata_cfg_file, output_file,
-                              width, height, hdr_cf, sdr_cf, hdr_cg, sdr_cg, hdr_tf, quality,
-                              out_tf, out_cf);
+                              gainmap_compressed_file, gainmap_metadata_cfg_file,
+                              output_file ? output_file : "out.jpeg", width, height, hdr_cf, sdr_cf,
+                              hdr_cg, sdr_cg, hdr_tf, quality, out_tf, out_cf);
     if (!appInput.encode()) return -1;
     if (compute_psnr == 1) {
       if (!appInput.decode()) return -1;
@@ -1421,10 +1418,7 @@ int main(int argc, char* argv[]) {
       std::cerr << "did not receive resources for decoding " << std::endl;
       return -1;
     }
-    if (output_file == nullptr) {
-      output_file = "outrgb.raw";
-    }
-    UltraHdrAppInput appInput(uhdr_file, output_file, out_tf, out_cf);
+    UltraHdrAppInput appInput(uhdr_file, output_file ? output_file : "outrgb.raw", out_tf, out_cf);
     if (!appInput.decode()) return -1;
   } else {
     std::cerr << "unrecognized input mode " << mode << std::endl;

--- a/lib/include/ultrahdr/jpegdecoderhelper.h
+++ b/lib/include/ultrahdr/jpegdecoderhelper.h
@@ -38,139 +38,145 @@ extern "C" {
 namespace ultrahdr {
 
 // constraint on max width and max height is only due to device alloc constraints
-// Can tune these values basing on the target device
+// can tune these values basing on the target device
 static const int kMaxWidth = 8192;
 static const int kMaxHeight = 8192;
 
+/*!\brief List of supported operations */
 typedef enum {
-  PARSE_ONLY = 0,          // Dont decode. Parse for dimensions, EXIF, ICC, XMP
-  DECODE_TO_RGBA = 1,      // Parse and decode to rgba
-  DECODE_TO_YCBCR = 2,     // Parse and decode to YCBCR or Grayscale
-                           // if input has 1 channel, decode to Grayscale
-                           // if input has 3 channels, decode to YCBCR
-  DECODE_TO_GAIN_MAP = 3,  // parse and decode gain map.
-                           // if input has 1 channel, decode to Grayscale
-                           // if input has 3 channels, decode to RGBA
+  PARSE_STREAM = (1 << 0),   /**< Parse jpeg header, APPn markers (Exif, Icc, Xmp, Iso) */
+  DECODE_STREAM = (1 << 16), /**< Single channel images are decoded to Grayscale format and multi
+                                channel images are decoded to RGB format */
+  DECODE_TO_YCBCR_CS = (1 << 17), /**< Decode image to YCbCr Color Space  */
+  DECODE_TO_RGB_CS = (1 << 18),   /**< Decode image to RGB Color Space  */
 } decode_mode_t;
 
-/*
- * Encapsulates a converter from JPEG to raw image (YUV420planer or grey-scale) format.
- * This class is not thread-safe.
- */
+/*!\brief Encapsulates a converter from JPEG to raw image format. This class is not thread-safe */
 class JpegDecoderHelper {
  public:
-  JpegDecoderHelper();
-  ~JpegDecoderHelper();
-  /*
-   * Decompresses JPEG image to raw image (YUV420planer, grey-scale or RGBA) format. After
-   * calling this method, call getDecompressedImage() to get the image.
-   * Returns false if decompressing the image fails.
+  // ===============================================================================================
+  // Enum Definitions
+  // ===============================================================================================
+
+  /*!\brief list of jpg decoder output formats */
+  typedef enum {
+    UNKNOWN,
+    GRAYSCALE,
+    YUV444,
+    YUV440,
+    YUV422,
+    YUV420,
+    YUV411,
+    YUV410,
+    RGB,
+    RGBA,
+  } jpg_out_fmt_t;
+
+  JpegDecoderHelper() = default;
+  ~JpegDecoderHelper() = default;
+
+  /*!\brief This function decodes the bitstream that is passed to it to the desired format and
+   * stores the results internally. The result is accessible via getter functions.
+   *
+   * \param[in]  image    pointer to compressed image
+   * \param[in]  length   length of compressed image
+   * \param[in]  mode     output decode format
+   *
+   * \returns true if operation succeeds, false otherwise.
    */
-  bool decompressImage(const void* image, int length, decode_mode_t decodeTo = DECODE_TO_YCBCR);
-  /*
-   * Returns the decompressed raw image buffer pointer. This method must be called only after
-   * calling decompressImage().
+  bool decompressImage(const void* image, int length, decode_mode_t mode = DECODE_TO_YCBCR_CS);
+
+  /*!\brief This function parses the bitstream that is passed to it and makes image information
+   * available to the client via getter() functions. It does not decompress the image. That is done
+   * by decompressImage().
+   *
+   * \param[in]  image    pointer to compressed image
+   * \param[in]  length   length of compressed image
+   *
+   * \returns true if operation succeeds, false otherwise.
    */
-  void* getDecompressedImagePtr();
-  /*
-   * Returns the decompressed raw image buffer size. This method must be called only after
-   * calling decompressImage().
-   */
-  size_t getDecompressedImageSize();
-  /*
-   * Returns the image width in pixels. This method must be called only after calling
-   * decompressImage().
-   */
-  size_t getDecompressedImageWidth();
-  /*
-   * Returns the image width in pixels. This method must be called only after calling
-   * decompressImage().
-   */
-  size_t getDecompressedImageHeight();
-  /*
-   * Returns the XMP data from the image.
-   */
-  void* getXMPPtr();
-  /*
-   * Returns the decompressed XMP buffer size. This method must be called only after
-   * calling decompressImage() or getCompressedImageParameters().
-   */
-  size_t getXMPSize();
-  /*
-   * Extracts EXIF package and updates the EXIF position / length without decoding the image.
-   */
-  bool extractEXIF(const void* image, int length);
-  /*
-   * Returns the EXIF data from the image.
-   * This method must be called after extractEXIF() or decompressImage().
-   */
-  void* getEXIFPtr();
-  /*
-   * Returns the decompressed EXIF buffer size. This method must be called only after
-   * calling decompressImage(), extractEXIF() or getCompressedImageParameters().
-   */
-  size_t getEXIFSize();
-  /*
-   * Returns the position offset of EXIF package
-   * (4 bypes offset to FF sign, the byte after FF E1 XX XX <this byte>),
-   * or -1  if no EXIF exists.
-   * This method must be called after extractEXIF() or decompressImage().
-   */
-  int getEXIFPos() { return mExifPos; }
-  /*
-   * Returns the ICC data from the image.
-   */
-  void* getICCPtr();
-  /*
-   * Returns the decompressed ICC buffer size. This method must be called only after
-   * calling decompressImage() or getCompressedImageParameters().
-   */
-  size_t getICCSize();
-  /*
-   * Returns the iso metadata from the image.
-   */
-  void* getIsoMetadataPtr();
-  /*
-   * Returns the decompressed iso metadata buffer size. This method must be called only after
-   * calling decompressImage() or getCompressedImageParameters().
-   */
-  size_t getIsoMetadataSize();
-  /*
-   * Decompresses metadata of the image. All vectors are owned by the caller.
-   */
-  bool getCompressedImageParameters(const void* image, int length);
+  bool parseImage(const void* image, int length) {
+    return decompressImage(image, length, PARSE_STREAM);
+  }
+
+  /*! Below public methods are only effective if a call to decompressImage() is made and it returned
+   * true. */
+
+  /*!\brief returns pointer to decompressed image */
+  void* getDecompressedImagePtr() { return mResultBuffer.data(); }
+
+  /*!\brief returns size of decompressed image */
+  size_t getDecompressedImageSize() { return mResultBuffer.size(); }
+
+  /*!\brief returns format of decompressed image */
+  jpg_out_fmt_t getDecompressedImageFormat() { return mOutFormat; }
+
+  /*! Below public methods are only effective if a call to parseImage() or decompressImage() is made
+   * and it returned true. */
+
+  /*!\brief returns image width */
+  size_t getDecompressedImageWidth() { return mPlaneWidth[0]; }
+
+  /*!\brief returns image height */
+  size_t getDecompressedImageHeight() { return mPlaneHeight[0]; }
+
+  /*!\brief returns pointer to xmp block present in input image */
+  void* getXMPPtr() { return mXMPBuffer.data(); }
+
+  /*!\brief returns size of xmp block */
+  size_t getXMPSize() { return mXMPBuffer.size(); }
+
+  /*!\brief returns pointer to exif block present in input image */
+  void* getEXIFPtr() { return mEXIFBuffer.data(); }
+
+  /*!\brief returns size of exif block */
+  size_t getEXIFSize() { return mEXIFBuffer.size(); }
+
+  /*!\brief returns pointer to icc block present in input image */
+  void* getICCPtr() { return mICCBuffer.data(); }
+
+  /*!\brief returns size of icc block */
+  size_t getICCSize() { return mICCBuffer.size(); }
+
+  /*!\brief returns pointer to iso block present in input image */
+  void* getIsoMetadataPtr() { return mIsoMetadataBuffer.data(); }
+
+  /*!\brief returns size of iso block */
+  size_t getIsoMetadataSize() { return mIsoMetadataBuffer.size(); }
+
+  /*!\brief returns the offset of exif data payload with reference to 'image' address that is passed
+   * via parseImage()/decompressImage() call. Note this does not include jpeg marker (0xffe1) and
+   * the next 2 bytes indicating the size of the payload. If exif block is not present in the image
+   * passed, then it returns -1. */
+  int getEXIFPos() { return mExifPayLoadOffset; }
 
  private:
-  bool decode(const void* image, int length, decode_mode_t decodeTo);
-  // Returns false if errors occur.
-  bool decompress(jpeg_decompress_struct* cinfo, const uint8_t* dest, bool isSingleChannel);
-  bool decompressYUV(jpeg_decompress_struct* cinfo, const uint8_t* dest);
-  bool decompressRGBA(jpeg_decompress_struct* cinfo, const uint8_t* dest);
-  bool decompressSingleChannel(jpeg_decompress_struct* cinfo, const uint8_t* dest);
-  // Process 16 lines of Y and 16 lines of U/V each time.
-  // We must pass at least 16 scanlines according to libjpeg documentation.
-  static const int kCompressBatchSize = 16;
-  // The buffer that holds the decompressed result.
-  std::vector<JOCTET> mResultBuffer;
-  // The buffer that holds XMP Data.
-  std::vector<JOCTET> mXMPBuffer;
-  // The buffer that holds EXIF Data.
-  std::vector<JOCTET> mEXIFBuffer;
-  // The buffer that holds ICC Data.
-  std::vector<JOCTET> mICCBuffer;
-  // The buffer that holds iso metadata.
-  std::vector<JOCTET> mIsoMetadataBuffer;
+  // max number of components supported
+  static constexpr int kMaxNumComponents = 3;
 
-  // Resolution of the decompressed image.
-  size_t mWidth;
-  size_t mHeight;
+  bool decode(const void* image, int length, decode_mode_t mode);
+  bool decode(jpeg_decompress_struct* cinfo, uint8_t* dest);
+  bool decodeToCSYCbCr(jpeg_decompress_struct* cinfo, uint8_t* dest);
+  bool decodeToCSRGB(jpeg_decompress_struct* cinfo, uint8_t* dest);
 
-  // Position of EXIF package, default value is -1 which means no EXIF package appears.
-  int mExifPos = -1;
+  // temporary storage
+  std::unique_ptr<uint8_t[]> mPlanesMCURow[kMaxNumComponents];
 
-  std::unique_ptr<uint8_t[]> mEmpty = nullptr;
-  std::unique_ptr<uint8_t[]> mBufferIntermediate = nullptr;
+  std::vector<JOCTET> mResultBuffer;       // buffer to store decoded data
+  std::vector<JOCTET> mXMPBuffer;          // buffer to store xmp data
+  std::vector<JOCTET> mEXIFBuffer;         // buffer to store exif data
+  std::vector<JOCTET> mICCBuffer;          // buffer to store icc data
+  std::vector<JOCTET> mIsoMetadataBuffer;  // buffer to store iso data
+
+  // image attributes
+  jpg_out_fmt_t mOutFormat;
+  size_t mPlaneWidth[kMaxNumComponents];
+  size_t mPlaneHeight[kMaxNumComponents];
+
+  int mExifPayLoadOffset;  // Position of EXIF package, default value is -1 which means no EXIF
+                           // package appears.
 };
+
 } /* namespace ultrahdr  */
 
 #endif  // ULTRAHDR_JPEGDECODERHELPER_H

--- a/lib/include/ultrahdr/jpegrutils.h
+++ b/lib/include/ultrahdr/jpegrutils.h
@@ -76,7 +76,7 @@ status_t Write(jr_compressed_ptr destination, const void* source, int length, in
  * @param metadata place to store HDR metadata values
  * @return true if metadata is successfully retrieved, false otherwise
  */
-bool getMetadataFromXMP(uint8_t* xmp_data, size_t xmp_size, ultrahdr_metadata_struct* metadata);
+bool getMetadataFromXMP(uint8_t* xmp_data, int xmp_size, ultrahdr_metadata_struct* metadata);
 
 /*
  * This method generates XMP metadata for the primary image.

--- a/lib/src/jpegrutils.cpp
+++ b/lib/src/jpegrutils.cpp
@@ -433,10 +433,10 @@ const string XMPXmlHandler::hdrCapacityMinAttrName = kMapHDRCapacityMin;
 const string XMPXmlHandler::hdrCapacityMaxAttrName = kMapHDRCapacityMax;
 const string XMPXmlHandler::baseRenditionIsHdrAttrName = kMapBaseRenditionIsHDR;
 
-bool getMetadataFromXMP(uint8_t* xmp_data, size_t xmp_size, ultrahdr_metadata_struct* metadata) {
+bool getMetadataFromXMP(uint8_t* xmp_data, int xmp_size, ultrahdr_metadata_struct* metadata) {
   string nameSpace = "http://ns.adobe.com/xap/1.0/\0";
 
-  if (xmp_size < nameSpace.size() + 2) {
+  if (xmp_size < (int)nameSpace.size() + 2) {
     // Data too short
     return false;
   }
@@ -455,7 +455,7 @@ bool getMetadataFromXMP(uint8_t* xmp_data, size_t xmp_size, ultrahdr_metadata_st
   // parser. if there is no packet header, do nothing otherwise go to the position of '<' without
   // '?' after it.
   int offset = 0;
-  for (unsigned i = 0; i < xmp_size; ++i) {
+  for (int i = 0; i < xmp_size - 1; ++i) {
     if (xmp_data[i] == '<') {
       if (xmp_data[i + 1] != '?') {
         offset = i;

--- a/tests/jpegdecoderhelper_test.cpp
+++ b/tests/jpegdecoderhelper_test.cpp
@@ -109,7 +109,7 @@ TEST_F(JpegDecoderHelperTest, decodeYuvImage) {
 
 TEST_F(JpegDecoderHelperTest, decodeYuvImageToRgba) {
   JpegDecoderHelper decoder;
-  EXPECT_TRUE(decoder.decompressImage(mYuvImage.buffer.get(), mYuvImage.size, DECODE_TO_RGBA));
+  EXPECT_TRUE(decoder.decompressImage(mYuvImage.buffer.get(), mYuvImage.size, DECODE_TO_RGB_CS));
   ASSERT_GT(decoder.getDecompressedImageSize(), static_cast<uint32_t>(0));
   EXPECT_EQ(IccHelper::readIccColorGamut(decoder.getICCPtr(), decoder.getICCSize()),
             ULTRAHDR_COLORGAMUT_UNSPECIFIED);
@@ -127,14 +127,13 @@ TEST_F(JpegDecoderHelperTest, decodeGreyImage) {
   JpegDecoderHelper decoder;
   EXPECT_TRUE(decoder.decompressImage(mGreyImage.buffer.get(), mGreyImage.size));
   ASSERT_GT(decoder.getDecompressedImageSize(), static_cast<uint32_t>(0));
-  EXPECT_TRUE(
-      decoder.decompressImage(mGreyImage.buffer.get(), mGreyImage.size, DECODE_TO_GAIN_MAP));
+  EXPECT_TRUE(decoder.decompressImage(mGreyImage.buffer.get(), mGreyImage.size, DECODE_STREAM));
   ASSERT_GT(decoder.getDecompressedImageSize(), static_cast<uint32_t>(0));
 }
 
 TEST_F(JpegDecoderHelperTest, decodeRgbImageToRgba) {
   JpegDecoderHelper decoder;
-  EXPECT_TRUE(decoder.decompressImage(mRgbImage.buffer.get(), mRgbImage.size, DECODE_TO_GAIN_MAP));
+  EXPECT_TRUE(decoder.decompressImage(mRgbImage.buffer.get(), mRgbImage.size, DECODE_STREAM));
   ASSERT_GT(decoder.getDecompressedImageSize(), static_cast<uint32_t>(0));
   EXPECT_EQ(IccHelper::readIccColorGamut(decoder.getICCPtr(), decoder.getICCSize()),
             ULTRAHDR_COLORGAMUT_UNSPECIFIED);
@@ -142,7 +141,7 @@ TEST_F(JpegDecoderHelperTest, decodeRgbImageToRgba) {
 
 TEST_F(JpegDecoderHelperTest, getCompressedImageParameters) {
   JpegDecoderHelper decoder;
-  EXPECT_TRUE(decoder.getCompressedImageParameters(mYuvImage.buffer.get(), mYuvImage.size));
+  EXPECT_TRUE(decoder.parseImage(mYuvImage.buffer.get(), mYuvImage.size));
   EXPECT_EQ(IMAGE_WIDTH, decoder.getDecompressedImageWidth());
   EXPECT_EQ(IMAGE_HEIGHT, decoder.getDecompressedImageHeight());
   EXPECT_EQ(decoder.getICCSize(), 0);
@@ -151,7 +150,7 @@ TEST_F(JpegDecoderHelperTest, getCompressedImageParameters) {
 
 TEST_F(JpegDecoderHelperTest, getCompressedImageParametersIcc) {
   JpegDecoderHelper decoder;
-  EXPECT_TRUE(decoder.getCompressedImageParameters(mYuvIccImage.buffer.get(), mYuvIccImage.size));
+  EXPECT_TRUE(decoder.parseImage(mYuvIccImage.buffer.get(), mYuvIccImage.size));
   EXPECT_EQ(IMAGE_WIDTH, decoder.getDecompressedImageWidth());
   EXPECT_EQ(IMAGE_HEIGHT, decoder.getDecompressedImageHeight());
   EXPECT_GT(decoder.getICCSize(), 0);


### PR DESCRIPTION
Initial versions supports decoding images with subsampling factor 4:2:0. This changes broadens the support.

Test: ./ultrahdr_unit_test
Test: ./ultrahdr_dec_fuzzer