### PR TITLE
Updates to jpeg encoder helper class

### DIFF
--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -225,7 +225,7 @@ status_t JpegR::encodeJPEGR(jr_uncompressed_ptr p010_image_ptr, ultrahdr_transfe
     p010_image.chroma_stride = p010_image.luma_stride;
   }
 
-  const size_t yu420_luma_stride = ALIGNM(p010_image.width, JpegEncoderHelper::kCompressBatchSize);
+  const size_t yu420_luma_stride = ALIGNM(p010_image.width, 16);
   unique_ptr<uint8_t[]> yuv420_image_data =
       make_unique<uint8_t[]>(yu420_luma_stride * p010_image.height * 3 / 2);
   jpegr_uncompressed_struct yuv420_image;
@@ -269,11 +269,15 @@ status_t JpegR::encodeJPEGR(jr_uncompressed_ptr p010_image_ptr, ultrahdr_transfe
 
   // compress 420 image
   JpegEncoderHelper jpeg_enc_obj_yuv420;
-  if (!jpeg_enc_obj_yuv420.compressImage(reinterpret_cast<uint8_t*>(yuv420_image.data),
-                                         reinterpret_cast<uint8_t*>(yuv420_image.chroma_data),
-                                         yuv420_image.width, yuv420_image.height,
-                                         yuv420_image.luma_stride, yuv420_image.chroma_stride,
-                                         quality, icc->getData(), icc->getLength())) {
+  const uint8_t* planes[3]{reinterpret_cast<uint8_t*>(yuv420_image.data),
+                           reinterpret_cast<uint8_t*>(yuv420_image.chroma_data),
+                           reinterpret_cast<uint8_t*>(yuv420_image.chroma_data) +
+                               yuv420_image.chroma_stride * yuv420_image.height / 2};
+  const size_t strides[3]{yuv420_image.luma_stride, yuv420_image.chroma_stride,
+                          yuv420_image.chroma_stride};
+  if (!jpeg_enc_obj_yuv420.compressImage(planes, strides, yuv420_image.width, yuv420_image.height,
+                                         JpegEncoderHelper::YUV420, quality, icc->getData(),
+                                         icc->getLength())) {
     return ERROR_JPEGR_ENCODE_ERROR;
   }
   jpegr_compressed_struct jpeg;
@@ -344,8 +348,7 @@ status_t JpegR::encodeJPEGR(jr_uncompressed_ptr p010_image_ptr,
   unique_ptr<uint8_t[]> yuv_420_bt601_data;
   // Convert to bt601 YUV encoding for JPEG encode
   if (yuv420_image.colorGamut != ULTRAHDR_COLORGAMUT_P3) {
-    const size_t yuv_420_bt601_luma_stride =
-        ALIGNM(yuv420_image.width, JpegEncoderHelper::kCompressBatchSize);
+    const size_t yuv_420_bt601_luma_stride = ALIGNM(yuv420_image.width, 16);
     yuv_420_bt601_data =
         make_unique<uint8_t[]>(yuv_420_bt601_luma_stride * yuv420_image.height * 3 / 2);
     yuv420_bt601_image.data = yuv_420_bt601_data.get();
@@ -405,11 +408,15 @@ status_t JpegR::encodeJPEGR(jr_uncompressed_ptr p010_image_ptr,
 
   // compress 420 image
   JpegEncoderHelper jpeg_enc_obj_yuv420;
-  if (!jpeg_enc_obj_yuv420.compressImage(
-          reinterpret_cast<uint8_t*>(yuv420_bt601_image.data),
-          reinterpret_cast<uint8_t*>(yuv420_bt601_image.chroma_data), yuv420_bt601_image.width,
-          yuv420_bt601_image.height, yuv420_bt601_image.luma_stride,
-          yuv420_bt601_image.chroma_stride, quality, icc->getData(), icc->getLength())) {
+  const uint8_t* planes[3]{reinterpret_cast<uint8_t*>(yuv420_bt601_image.data),
+                           reinterpret_cast<uint8_t*>(yuv420_bt601_image.chroma_data),
+                           reinterpret_cast<uint8_t*>(yuv420_bt601_image.chroma_data) +
+                               yuv420_bt601_image.chroma_stride * yuv420_bt601_image.height / 2};
+  const size_t strides[3]{yuv420_bt601_image.luma_stride, yuv420_bt601_image.chroma_stride,
+                          yuv420_bt601_image.chroma_stride};
+  if (!jpeg_enc_obj_yuv420.compressImage(planes, strides, yuv420_bt601_image.width,
+                                         yuv420_bt601_image.height, JpegEncoderHelper::YUV420,
+                                         quality, icc->getData(), icc->getLength())) {
     return ERROR_JPEGR_ENCODE_ERROR;
   }
 
@@ -805,18 +812,20 @@ status_t JpegR::compressGainMap(jr_uncompressed_ptr gainmap_image_ptr,
     return ERROR_JPEGR_BAD_PTR;
   }
 
+  const uint8_t* planes[]{reinterpret_cast<uint8_t*>(gainmap_image_ptr->data)};
   if (kUseMultiChannelGainMap) {
-    if (!jpeg_enc_obj_ptr->compressImage(reinterpret_cast<uint8_t*>(gainmap_image_ptr->data),
-                                         gainmap_image_ptr->width, gainmap_image_ptr->height,
+    const size_t strides[]{gainmap_image_ptr->width * 3};
+    if (!jpeg_enc_obj_ptr->compressImage(planes, strides, gainmap_image_ptr->width,
+                                         gainmap_image_ptr->height, JpegEncoderHelper::RGB,
                                          kMapCompressQuality, nullptr, 0)) {
       return ERROR_JPEGR_ENCODE_ERROR;
     }
   } else {
+    const size_t strides[]{gainmap_image_ptr->width};
     // Don't need to convert YUV to Bt601 since single channel
-    if (!jpeg_enc_obj_ptr->compressImage(reinterpret_cast<uint8_t*>(gainmap_image_ptr->data),
-                                         nullptr, gainmap_image_ptr->width,
-                                         gainmap_image_ptr->height, gainmap_image_ptr->luma_stride,
-                                         0, kMapCompressQuality, nullptr, 0)) {
+    if (!jpeg_enc_obj_ptr->compressImage(planes, strides, gainmap_image_ptr->width,
+                                         gainmap_image_ptr->height, JpegEncoderHelper::GRAYSCALE,
+                                         kMapCompressQuality, nullptr, 0)) {
       return ERROR_JPEGR_ENCODE_ERROR;
     }
   }

--- a/tests/jpegencoderhelper_test.cpp
+++ b/tests/jpegencoderhelper_test.cpp
@@ -105,35 +105,47 @@ void JpegEncoderHelperTest::TearDown() {}
 
 TEST_F(JpegEncoderHelperTest, encodeAlignedImage) {
   JpegEncoderHelper encoder;
-  EXPECT_TRUE(encoder.compressImage(
-      mAlignedImage.buffer.get(),
-      mAlignedImage.buffer.get() + mAlignedImage.width * mAlignedImage.height, mAlignedImage.width,
-      mAlignedImage.height, mAlignedImage.width, mAlignedImage.width / 2, JPEG_QUALITY, NULL, 0));
+  const uint8_t* yPlane = mAlignedImage.buffer.get();
+  const uint8_t* uPlane = yPlane + mAlignedImage.width * mAlignedImage.height;
+  const uint8_t* vPlane = uPlane + mAlignedImage.width * mAlignedImage.height / 4;
+  const uint8_t* planes[3]{yPlane, uPlane, vPlane};
+  const size_t strides[3]{mAlignedImage.width, mAlignedImage.width / 2, mAlignedImage.width / 2};
+  EXPECT_TRUE(encoder.compressImage(planes, strides, mAlignedImage.width, mAlignedImage.height,
+                                    JpegEncoderHelper::YUV420, JPEG_QUALITY, NULL, 0));
   ASSERT_GT(encoder.getCompressedImageSize(), static_cast<uint32_t>(0));
 }
 
 TEST_F(JpegEncoderHelperTest, encodeUnalignedImage) {
   JpegEncoderHelper encoder;
-  EXPECT_TRUE(encoder.compressImage(
-      mUnalignedImage.buffer.get(),
-      mUnalignedImage.buffer.get() + mUnalignedImage.width * mUnalignedImage.height,
-      mUnalignedImage.width, mUnalignedImage.height, mUnalignedImage.width,
-      mUnalignedImage.width / 2, JPEG_QUALITY, NULL, 0));
+  const uint8_t* yPlane = mUnalignedImage.buffer.get();
+  const uint8_t* uPlane = yPlane + mUnalignedImage.width * mUnalignedImage.height;
+  const uint8_t* vPlane = uPlane + mUnalignedImage.width * mUnalignedImage.height / 4;
+  const uint8_t* planes[3]{yPlane, uPlane, vPlane};
+  const size_t strides[3]{mUnalignedImage.width, mUnalignedImage.width / 2,
+                          mUnalignedImage.width / 2};
+  EXPECT_TRUE(encoder.compressImage(planes, strides, mUnalignedImage.width, mUnalignedImage.height,
+                                    JpegEncoderHelper::YUV420, JPEG_QUALITY, NULL, 0));
   ASSERT_GT(encoder.getCompressedImageSize(), static_cast<uint32_t>(0));
 }
 
 TEST_F(JpegEncoderHelperTest, encodeSingleChannelImage) {
   JpegEncoderHelper encoder;
-  EXPECT_TRUE(encoder.compressImage(mSingleChannelImage.buffer.get(), nullptr,
-                                    mSingleChannelImage.width, mSingleChannelImage.height,
-                                    mSingleChannelImage.width, 0, JPEG_QUALITY, NULL, 0));
+  const uint8_t* yPlane = mSingleChannelImage.buffer.get();
+  const uint8_t* planes[1]{yPlane};
+  const size_t strides[1]{mSingleChannelImage.width};
+  EXPECT_TRUE(encoder.compressImage(planes, strides, mSingleChannelImage.width,
+                                    mSingleChannelImage.height, JpegEncoderHelper::GRAYSCALE,
+                                    JPEG_QUALITY, NULL, 0));
   ASSERT_GT(encoder.getCompressedImageSize(), static_cast<uint32_t>(0));
 }
 
 TEST_F(JpegEncoderHelperTest, encodeRGBImage) {
   JpegEncoderHelper encoder;
-  EXPECT_TRUE(encoder.compressImage(mRgbImage.buffer.get(), mRgbImage.width, mRgbImage.height,
-                                    JPEG_QUALITY, NULL, 0));
+  const uint8_t* rgbPlane = mRgbImage.buffer.get();
+  const uint8_t* planes[1]{rgbPlane};
+  const size_t strides[1]{mRgbImage.width * 3};
+  EXPECT_TRUE(encoder.compressImage(planes, strides, mRgbImage.width, mRgbImage.height,
+                                    JpegEncoderHelper::RGB, JPEG_QUALITY, NULL, 0));
   ASSERT_GT(encoder.getCompressedImageSize(), static_cast<uint32_t>(0));
 }
 


### PR DESCRIPTION
- Add support for more sampling formats
- RGB jpeg encode now defaults to 444 sampling format instead of 420
- For unaligned blocks memset chroma planes to 128 to create black borders
- Add more fail safe checks, diagnostics
- Ensure memory is released during encoding failures

Test: ./ultrahdr_unit_test
Test: ./ultrahdr_enc_fuzzer