### PR TITLE
unify pixel format enumerations across utils

### DIFF
--- a/examples/ultrahdr_app.cpp
+++ b/examples/ultrahdr_app.cpp
@@ -61,7 +61,6 @@ const float BT2020RGBtoYUVMatrix[9] = {0.2627,
                                        (-0.0593 / 1.4746)};
 
 // remove these once introduced in ultrahdr_api.h
-const int UHDR_IMG_FMT_24bppYCbCr444 = 100;
 const int UHDR_IMG_FMT_48bppYCbCr444 = 101;
 
 int optind_s = 1;

--- a/fuzzer/ultrahdr_enc_fuzzer.cpp
+++ b/fuzzer/ultrahdr_enc_fuzzer.cpp
@@ -249,7 +249,7 @@ void UltraHdrEncFuzzer::process() {
       const size_t strides[3]{yuv420ImgCopy.luma_stride, yuv420ImgCopy.chroma_stride,
                               yuv420ImgCopy.chroma_stride};
       if (encoder.compressImage(planes, strides, yuv420ImgCopy.width, yuv420ImgCopy.height,
-                                JpegEncoderHelper::YUV420, quality, nullptr, 0)) {
+                                UHDR_IMG_FMT_12bppYCbCr420, quality, nullptr, 0)) {
         jpegImg.length = encoder.getCompressedImageSize();
         jpegImg.maxLength = jpegImg.length;
         jpegImg.data = encoder.getCompressedImagePtr();
@@ -267,7 +267,7 @@ void UltraHdrEncFuzzer::process() {
           const uint8_t* planeGm[1]{reinterpret_cast<uint8_t*>(grayImg.data)};
           const size_t strideGm[1]{grayImg.width};
           if (gainMapEncoder.compressImage(planeGm, strideGm, grayImg.width, grayImg.height,
-                                           JpegEncoderHelper::GRAYSCALE, quality, nullptr, 0)) {
+                                           UHDR_IMG_FMT_8bppYCbCr400, quality, nullptr, 0)) {
             jpegGainMap.length = gainMapEncoder.getCompressedImageSize();
             jpegGainMap.maxLength = jpegImg.length;
             jpegGainMap.data = gainMapEncoder.getCompressedImagePtr();

--- a/lib/include/ultrahdr/jpegdecoderhelper.h
+++ b/lib/include/ultrahdr/jpegdecoderhelper.h
@@ -35,6 +35,8 @@ extern "C" {
 #include <memory>
 #include <vector>
 
+#include "ultrahdr_api.h"
+
 namespace ultrahdr {
 
 // constraint on max width and max height is only due to device alloc constraints
@@ -54,23 +56,6 @@ typedef enum {
 /*!\brief Encapsulates a converter from JPEG to raw image format. This class is not thread-safe */
 class JpegDecoderHelper {
  public:
-  // ===============================================================================================
-  // Enum Definitions
-  // ===============================================================================================
-
-  /*!\brief list of jpg decoder output formats */
-  typedef enum {
-    UNKNOWN,
-    GRAYSCALE,
-    YUV444,
-    YUV440,
-    YUV422,
-    YUV420,
-    YUV411,
-    YUV410,
-    RGB,
-    RGBA,
-  } jpg_out_fmt_t;
 
   JpegDecoderHelper() = default;
   ~JpegDecoderHelper() = default;
@@ -109,7 +94,7 @@ class JpegDecoderHelper {
   size_t getDecompressedImageSize() { return mResultBuffer.size(); }
 
   /*!\brief returns format of decompressed image */
-  jpg_out_fmt_t getDecompressedImageFormat() { return mOutFormat; }
+  uhdr_img_fmt_t getDecompressedImageFormat() { return mOutFormat; }
 
   /*! Below public methods are only effective if a call to parseImage() or decompressImage() is made
    * and it returned true. */
@@ -169,7 +154,7 @@ class JpegDecoderHelper {
   std::vector<JOCTET> mIsoMetadataBuffer;  // buffer to store iso data
 
   // image attributes
-  jpg_out_fmt_t mOutFormat;
+  uhdr_img_fmt_t mOutFormat;
   size_t mPlaneWidth[kMaxNumComponents];
   size_t mPlaneHeight[kMaxNumComponents];
 

--- a/lib/include/ultrahdr/jpegencoderhelper.h
+++ b/lib/include/ultrahdr/jpegencoderhelper.h
@@ -34,6 +34,8 @@ extern "C" {
 #include <cstdint>
 #include <vector>
 
+#include "ultrahdr_api.h"
+
 namespace ultrahdr {
 
 /*!\brief module for managing output */
@@ -45,21 +47,6 @@ struct destination_mgr_impl : jpeg_destination_mgr {
 /*!\brief Encapsulates a converter from raw to jpg image format. This class is not thread-safe */
 class JpegEncoderHelper {
  public:
-  // ===============================================================================================
-  // Enum Definitions
-  // ===============================================================================================
-
-  /*!\brief list of jpg encoder input formats */
-  typedef enum {
-    GRAYSCALE,
-    YUV444,
-    YUV440,
-    YUV422,
-    YUV420,
-    YUV411,
-    YUV410,
-    RGB,
-  } jpg_inp_fmt_t;
 
   JpegEncoderHelper() = default;
   ~JpegEncoderHelper() = default;
@@ -79,7 +66,7 @@ class JpegEncoderHelper {
    * \returns true if operation succeeds, false otherwise.
    */
   bool compressImage(const uint8_t* planes[3], const size_t strides[3], const int width,
-                     const int height, const jpg_inp_fmt_t format, const int qfactor,
+                     const int height, const uhdr_img_fmt_t format, const int qfactor,
                      const void* iccBuffer, const unsigned int iccSize);
 
   /*! Below public methods are only effective if a call to compressImage() is made and it returned
@@ -96,7 +83,7 @@ class JpegEncoderHelper {
   static constexpr int kMaxNumComponents = 3;
 
   bool encode(const uint8_t* planes[3], const size_t strides[3], const int width, const int height,
-              const jpg_inp_fmt_t format, const int qfactor, const void* iccBuffer,
+              const uhdr_img_fmt_t format, const int qfactor, const void* iccBuffer,
               const unsigned int iccSize);
 
   bool compressYCbCr(jpeg_compress_struct* cinfo, const uint8_t* planes[3],

--- a/lib/include/ultrahdr/jpegr.h
+++ b/lib/include/ultrahdr/jpegr.h
@@ -90,7 +90,7 @@ struct jpegr_uncompressed_struct {
   // chroma_data is derived from luma ptr, chroma stride is derived from luma stride.
   size_t chroma_stride = 0;
   // Pixel format.
-  ultrahdr_pixel_format pixelFormat = ULTRAHDR_PIX_FMT_UNSPECIFIED;
+  uhdr_img_fmt_t pixelFormat = UHDR_IMG_FMT_UNSPECIFIED;
 };
 
 /*

--- a/lib/include/ultrahdr/ultrahdr.h
+++ b/lib/include/ultrahdr/ultrahdr.h
@@ -86,18 +86,6 @@ typedef enum {
   ULTRAHDR_OUTPUT_MAX = ULTRAHDR_OUTPUT_HDR_HLG,
 } ultrahdr_output_format;
 
-// Supported pixel format
-typedef enum {
-  ULTRAHDR_PIX_FMT_UNSPECIFIED = -1,
-  ULTRAHDR_PIX_FMT_P010,
-  ULTRAHDR_PIX_FMT_YUV420,
-  ULTRAHDR_PIX_FMT_MONOCHROME,
-  ULTRAHDR_PIX_FMT_RGBA8888,
-  ULTRAHDR_PIX_FMT_RGB888,
-  ULTRAHDR_PIX_FMT_RGBAF16,
-  ULTRAHDR_PIX_FMT_RGBA1010102,
-} ultrahdr_pixel_format;
-
 /*
  * Holds information for gain map related metadata.
  *

--- a/lib/src/jpegdecoderhelper.cpp
+++ b/lib/src/jpegdecoderhelper.cpp
@@ -131,26 +131,26 @@ static void jpeg_extract_marker_payload(const j_decompress_ptr cinfo, const uint
   }
 }
 
-static JpegDecoderHelper::jpg_out_fmt_t getOutputSamplingFormat(const j_decompress_ptr cinfo) {
+static uhdr_img_fmt_t getOutputSamplingFormat(const j_decompress_ptr cinfo) {
   if (cinfo->num_components == 1)
-    return JpegDecoderHelper::GRAYSCALE;
+    return UHDR_IMG_FMT_8bppYCbCr400;
   else {
     int a = cinfo->max_h_samp_factor / cinfo->comp_info[1].h_samp_factor;
     int b = cinfo->max_v_samp_factor / cinfo->comp_info[1].v_samp_factor;
     if (a == 1 && b == 1)
-      return JpegDecoderHelper::YUV444;
+      return UHDR_IMG_FMT_24bppYCbCr444;
     else if (a == 1 && b == 2)
-      return JpegDecoderHelper::YUV440;
+      return UHDR_IMG_FMT_16bppYCbCr440;
     else if (a == 2 && b == 1)
-      return JpegDecoderHelper::YUV422;
+      return UHDR_IMG_FMT_16bppYCbCr422;
     else if (a == 2 && b == 2)
-      return JpegDecoderHelper::YUV420;
+      return UHDR_IMG_FMT_12bppYCbCr420;
     else if (a == 4 && b == 1)
-      return JpegDecoderHelper::YUV411;
+      return UHDR_IMG_FMT_12bppYCbCr411;
     else if (a == 4 && b == 2)
-      return JpegDecoderHelper::YUV410;
+      return UHDR_IMG_FMT_10bppYCbCr410;
   }
-  return JpegDecoderHelper::UNKNOWN;
+  return UHDR_IMG_FMT_UNSPECIFIED;
 }
 
 bool JpegDecoderHelper::decompressImage(const void* image, int length, decode_mode_t mode) {
@@ -169,7 +169,7 @@ bool JpegDecoderHelper::decompressImage(const void* image, int length, decode_mo
   mEXIFBuffer.clear();
   mICCBuffer.clear();
   mIsoMetadataBuffer.clear();
-  mOutFormat = UNKNOWN;
+  mOutFormat = UHDR_IMG_FMT_UNSPECIFIED;
   for (int i = 0; i < kMaxNumComponents; i++) {
     mPlanesMCURow[i].reset();
     mPlaneWidth[i] = 0;
@@ -353,11 +353,11 @@ bool JpegDecoderHelper::decode(jpeg_decompress_struct* cinfo, uint8_t* dest) {
       return decodeToCSYCbCr(cinfo, dest);
 #ifdef JCS_ALPHA_EXTENSIONS
     case JCS_EXT_RGBA:
-      mOutFormat = RGBA;
+      mOutFormat = UHDR_IMG_FMT_32bppRGBA8888;
       return decodeToCSRGB(cinfo, dest);
 #endif
     case JCS_RGB:
-      mOutFormat = RGB;
+      mOutFormat = UHDR_IMG_FMT_24bppRGB888;
       return decodeToCSRGB(cinfo, dest);
     default:
       ALOGE("unrecognized output color space %d", cinfo->out_color_space);

--- a/lib/src/ultrahdr_api.cpp
+++ b/lib/src/ultrahdr_api.cpp
@@ -335,25 +335,6 @@ uhdr_codec_private::~uhdr_codec_private() {
   m_effects.clear();
 }
 
-ultrahdr::ultrahdr_pixel_format map_pix_fmt_to_internal_pix_fmt(uhdr_img_fmt_t fmt) {
-  switch (fmt) {
-    case UHDR_IMG_FMT_12bppYCbCr420:
-      return ultrahdr::ULTRAHDR_PIX_FMT_YUV420;
-    case UHDR_IMG_FMT_24bppYCbCrP010:
-      return ultrahdr::ULTRAHDR_PIX_FMT_P010;
-    case UHDR_IMG_FMT_32bppRGBA1010102:
-      return ultrahdr::ULTRAHDR_PIX_FMT_RGBA1010102;
-    case UHDR_IMG_FMT_32bppRGBA8888:
-      return ultrahdr::ULTRAHDR_PIX_FMT_RGBA8888;
-    case UHDR_IMG_FMT_64bppRGBAHalfFloat:
-      return ultrahdr::ULTRAHDR_PIX_FMT_RGBAF16;
-    case UHDR_IMG_FMT_8bppYCbCr400:
-      return ultrahdr::ULTRAHDR_PIX_FMT_MONOCHROME;
-    default:
-      return ultrahdr::ULTRAHDR_PIX_FMT_UNSPECIFIED;
-  }
-}
-
 ultrahdr::ultrahdr_color_gamut map_cg_to_internal_cg(uhdr_color_gamut_t cg) {
   switch (cg) {
     case UHDR_CG_BT_2100:
@@ -994,7 +975,7 @@ uhdr_error_info_t uhdr_encode(uhdr_codec_private_t* enc) {
       p010_image.luma_stride = hdr_raw_entry->stride[UHDR_PLANE_Y];
       p010_image.chroma_data = hdr_raw_entry->planes[UHDR_PLANE_UV];
       p010_image.chroma_stride = hdr_raw_entry->stride[UHDR_PLANE_UV];
-      p010_image.pixelFormat = map_pix_fmt_to_internal_pix_fmt(hdr_raw_entry->fmt);
+      p010_image.pixelFormat = hdr_raw_entry->fmt;
 
       if (handle->m_compressed_images.find(UHDR_SDR_IMG) == handle->m_compressed_images.end() &&
           handle->m_raw_images.find(UHDR_SDR_IMG) == handle->m_raw_images.end()) {
@@ -1025,7 +1006,7 @@ uhdr_error_info_t uhdr_encode(uhdr_codec_private_t* enc) {
         yuv420_image.luma_stride = sdr_raw_entry->stride[UHDR_PLANE_Y];
         yuv420_image.chroma_data = nullptr;
         yuv420_image.chroma_stride = 0;
-        yuv420_image.pixelFormat = map_pix_fmt_to_internal_pix_fmt(sdr_raw_entry->fmt);
+        yuv420_image.pixelFormat = sdr_raw_entry->fmt;
 
         if (handle->m_compressed_images.find(UHDR_SDR_IMG) == handle->m_compressed_images.end()) {
           // api - 1

--- a/tests/jpegencoderhelper_test.cpp
+++ b/tests/jpegencoderhelper_test.cpp
@@ -111,7 +111,7 @@ TEST_F(JpegEncoderHelperTest, encodeAlignedImage) {
   const uint8_t* planes[3]{yPlane, uPlane, vPlane};
   const size_t strides[3]{mAlignedImage.width, mAlignedImage.width / 2, mAlignedImage.width / 2};
   EXPECT_TRUE(encoder.compressImage(planes, strides, mAlignedImage.width, mAlignedImage.height,
-                                    JpegEncoderHelper::YUV420, JPEG_QUALITY, NULL, 0));
+                                    UHDR_IMG_FMT_12bppYCbCr420, JPEG_QUALITY, NULL, 0));
   ASSERT_GT(encoder.getCompressedImageSize(), static_cast<uint32_t>(0));
 }
 
@@ -124,7 +124,7 @@ TEST_F(JpegEncoderHelperTest, encodeUnalignedImage) {
   const size_t strides[3]{mUnalignedImage.width, mUnalignedImage.width / 2,
                           mUnalignedImage.width / 2};
   EXPECT_TRUE(encoder.compressImage(planes, strides, mUnalignedImage.width, mUnalignedImage.height,
-                                    JpegEncoderHelper::YUV420, JPEG_QUALITY, NULL, 0));
+                                    UHDR_IMG_FMT_12bppYCbCr420, JPEG_QUALITY, NULL, 0));
   ASSERT_GT(encoder.getCompressedImageSize(), static_cast<uint32_t>(0));
 }
 
@@ -134,7 +134,7 @@ TEST_F(JpegEncoderHelperTest, encodeSingleChannelImage) {
   const uint8_t* planes[1]{yPlane};
   const size_t strides[1]{mSingleChannelImage.width};
   EXPECT_TRUE(encoder.compressImage(planes, strides, mSingleChannelImage.width,
-                                    mSingleChannelImage.height, JpegEncoderHelper::GRAYSCALE,
+                                    mSingleChannelImage.height, UHDR_IMG_FMT_8bppYCbCr400,
                                     JPEG_QUALITY, NULL, 0));
   ASSERT_GT(encoder.getCompressedImageSize(), static_cast<uint32_t>(0));
 }
@@ -145,7 +145,7 @@ TEST_F(JpegEncoderHelperTest, encodeRGBImage) {
   const uint8_t* planes[1]{rgbPlane};
   const size_t strides[1]{mRgbImage.width * 3};
   EXPECT_TRUE(encoder.compressImage(planes, strides, mRgbImage.width, mRgbImage.height,
-                                    JpegEncoderHelper::RGB, JPEG_QUALITY, NULL, 0));
+                                    UHDR_IMG_FMT_24bppRGB888, JPEG_QUALITY, NULL, 0));
   ASSERT_GT(encoder.getCompressedImageSize(), static_cast<uint32_t>(0));
 }
 

--- a/tests/jpegr_test.cpp
+++ b/tests/jpegr_test.cpp
@@ -2263,7 +2263,7 @@ TEST(JpegRTest, ProfileGainMapFuncs) {
   map.width = 0;
   map.height = 0;
   map.colorGamut = ULTRAHDR_COLORGAMUT_UNSPECIFIED;
-  map.pixelFormat = ULTRAHDR_PIX_FMT_MONOCHROME;
+  map.pixelFormat = UHDR_IMG_FMT_8bppYCbCr400;
 
   {
     auto rawImg = rawImgP010.getImageHandle();

--- a/ultrahdr_api.h
+++ b/ultrahdr_api.h
@@ -50,46 +50,54 @@
 
 /*!\brief List of supported image formats */
 typedef enum uhdr_img_fmt {
-  UHDR_IMG_FMT_UNSPECIFIED = -1, /**< Unspecified */
-  UHDR_IMG_FMT_24bppYCbCrP010,   /**< 10-bit-per component 4:2:0 YCbCr semiplanar format.
-                                 Each chroma and luma component has 16 allocated bits in
-                                 little-endian configuration with 10 MSB of actual data.*/
-  UHDR_IMG_FMT_12bppYCbCr420,    /**< 8-bit-per component 4:2:0 YCbCr planar format */
-  UHDR_IMG_FMT_8bppYCbCr400,     /**< 8-bit-per component Monochrome format */
-  UHDR_IMG_FMT_32bppRGBA8888, /**< 32 bits per pixel RGBA color format, with 8-bit red, green, blue
-                                 and alpha components. Using 32-bit little-endian representation,
-                                 colors stored as Red 7:0, Green 15:8, Blue 23:16, Alpha 31:24. */
-  UHDR_IMG_FMT_64bppRGBAHalfFloat, /**< 64 bits per pixel RGBA color format, with 16-bit signed
+  UHDR_IMG_FMT_UNSPECIFIED = -1,   /**< Unspecified */
+  UHDR_IMG_FMT_24bppYCbCrP010 = 0, /**< 10-bit-per component 4:2:0 YCbCr semiplanar format.
+                               Each chroma and luma component has 16 allocated bits in
+                               little-endian configuration with 10 MSB of actual data.*/
+  UHDR_IMG_FMT_12bppYCbCr420 = 1,  /**< 8-bit-per component 4:2:0 YCbCr planar format */
+  UHDR_IMG_FMT_8bppYCbCr400 = 2,   /**< 8-bit-per component Monochrome format */
+  UHDR_IMG_FMT_32bppRGBA8888 =
+      3, /**< 32 bits per pixel RGBA color format, with 8-bit red, green, blue
+        and alpha components. Using 32-bit little-endian representation,
+        colors stored as Red 7:0, Green 15:8, Blue 23:16, Alpha 31:24. */
+  UHDR_IMG_FMT_64bppRGBAHalfFloat = 4, /**< 64 bits per pixel RGBA color format, with 16-bit signed
                                    floating point red, green, blue, and alpha components */
-  UHDR_IMG_FMT_32bppRGBA1010102,   /**< 32 bits per pixel RGBA color format, with 10-bit red, green,
-                                      blue, and 2-bit alpha components. Using 32-bit little-endian
-                                      representation, colors stored as Red 9:0, Green 19:10, Blue
-                                      29:20, and Alpha 31:30. */
+  UHDR_IMG_FMT_32bppRGBA1010102 = 5,   /**< 32 bits per pixel RGBA color format, with 10-bit red,
+                                      green,   blue, and 2-bit alpha components. Using 32-bit
+                                      little-endian   representation, colors stored as Red 9:0, Green
+                                      19:10, Blue   29:20, and Alpha 31:30. */
+
+  UHDR_IMG_FMT_24bppYCbCr444 = 6,  /**< 8-bit-per component 4:4:4 YCbCr planar format */
+  UHDR_IMG_FMT_16bppYCbCr422 = 7,  /**< 8-bit-per component 4:2:2 YCbCr planar format */
+  UHDR_IMG_FMT_16bppYCbCr440 = 8,  /**< 8-bit-per component 4:4:0 YCbCr planar format */
+  UHDR_IMG_FMT_12bppYCbCr411 = 9,  /**< 8-bit-per component 4:1:1 YCbCr planar format */
+  UHDR_IMG_FMT_10bppYCbCr410 = 10, /**< 8-bit-per component 4:1:0 YCbCr planar format */
+  UHDR_IMG_FMT_24bppRGB888 = 11,   /**< 8-bit-per component RGB interleaved format */
 } uhdr_img_fmt_t;                  /**< alias for enum uhdr_img_fmt */
 
 /*!\brief List of supported color gamuts */
 typedef enum uhdr_color_gamut {
   UHDR_CG_UNSPECIFIED = -1, /**< Unspecified */
-  UHDR_CG_BT_709,           /**< BT.709 */
-  UHDR_CG_DISPLAY_P3,       /**< Display P3 */
-  UHDR_CG_BT_2100,          /**< BT.2100 */
+  UHDR_CG_BT_709 = 0,       /**< BT.709 */
+  UHDR_CG_DISPLAY_P3 = 1,   /**< Display P3 */
+  UHDR_CG_BT_2100 = 2,      /**< BT.2100 */
 } uhdr_color_gamut_t;       /**< alias for enum uhdr_color_gamut */
 
 /*!\brief List of supported color transfers */
 typedef enum uhdr_color_transfer {
   UHDR_CT_UNSPECIFIED = -1, /**< Unspecified */
-  UHDR_CT_LINEAR,           /**< Linear */
-  UHDR_CT_HLG,              /**< Hybrid log gamma */
-  UHDR_CT_PQ,               /**< Perceptual Quantizer */
-  UHDR_CT_SRGB,             /**< Gamma */
+  UHDR_CT_LINEAR = 0,       /**< Linear */
+  UHDR_CT_HLG = 1,          /**< Hybrid log gamma */
+  UHDR_CT_PQ = 2,           /**< Perceptual Quantizer */
+  UHDR_CT_SRGB = 3,         /**< Gamma */
 } uhdr_color_transfer_t;    /**< alias for enum uhdr_color_transfer */
 
 /*!\brief List of supported color ranges */
 typedef enum uhdr_color_range {
-  UHDR_CR_UNSPECIFIED = -1, /**< Unspecified */
-  UHDR_CR_LIMITED_RANGE,    /**< Y {[16..235], UV [16..240]} * pow(2, (bpc - 8)) */
-  UHDR_CR_FULL_RANGE,       /**< YUV/RGB {[0..255]} * pow(2, (bpc - 8)) */
-} uhdr_color_range_t;       /**< alias for enum uhdr_color_range */
+  UHDR_CR_UNSPECIFIED = -1,  /**< Unspecified */
+  UHDR_CR_LIMITED_RANGE = 0, /**< Y {[16..235], UV [16..240]} * pow(2, (bpc - 8)) */
+  UHDR_CR_FULL_RANGE = 1,    /**< YUV/RGB {[0..255]} * pow(2, (bpc - 8)) */
+} uhdr_color_range_t;        /**< alias for enum uhdr_color_range */
 
 /*!\brief List of supported codecs */
 typedef enum uhdr_codec {


### PR DESCRIPTION
ultrahdr_api.h, ultrahdr.h, jpegdecoderhelper.h, jpegencoderhelper.h are maintaining different enum classes for pixel formats local to their modules. All these are unified.

Test: ./ultrahdr_unit_test