### PR TITLE
Enable Windows build for libultrahdr

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -62,6 +62,12 @@ cc_library {
     ],
     rtti: true,
 
+    target: {
+        windows: {
+            enabled: true,
+        },
+    },
+
     arch: {
         arm: {
             srcs: ["lib/src/dsp/arm/editorhelper_neon.cpp",],
@@ -87,6 +93,12 @@ cc_library {
     srcs: [
         "lib/src/jpegencoderhelper.cpp",
     ],
+
+    target: {
+        windows: {
+            enabled: true,
+        },
+    },
 }
 
 cc_library {
@@ -104,4 +116,10 @@ cc_library {
     srcs: [
         "lib/src/jpegdecoderhelper.cpp",
     ],
+
+    target: {
+        windows: {
+            enabled: true,
+        },
+    },
 }

--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -15,7 +15,7 @@
  */
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #include <sysinfoapi.h>
 #else
 #include <unistd.h>


### PR DESCRIPTION
This is working towards supporting a Windows build of libandroid_runtime.

Bug: 340885449
Test: build libultrahdr for Windows