### PR TITLE
Handling non-integer gainmap scale factor

### DIFF
--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -726,7 +726,7 @@ status_t JpegR::decodeJPEGR(jr_compressed_ptr jpegr_image_ptr, jr_uncompressed_p
     if (gainmap_image_ptr != nullptr) {
       gainmap_image_ptr->pixelFormat = gainmap_image.pixelFormat;
       if (jpeg_dec_obj_yuv420.getDecompressedImageWidth() % gainmap_image.width == 0 &&
-          jpeg_dec_obj_yuv420.getDecompressedImageHeight() % gainmap_image.width == 0) {
+          jpeg_dec_obj_yuv420.getDecompressedImageHeight() % gainmap_image.height == 0) {
         gainmap_image_ptr->width = gainmap_image.width;
         gainmap_image_ptr->height = gainmap_image.height;
 

--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -709,16 +709,13 @@ status_t JpegR::decodeJPEGR(jr_compressed_ptr jpegr_image_ptr, jr_uncompressed_p
                                          DECODE_STREAM)) {
       return ERROR_JPEGR_DECODE_ERROR;
     }
-    auto gainmap_components = 0;
+
     if (jpeg_dec_obj_gm.getDecompressedImageFormat() == JpegDecoderHelper::GRAYSCALE) {
       gainmap_image.pixelFormat = ULTRAHDR_PIX_FMT_MONOCHROME;
-      gainmap_components = 1;
     } else if (jpeg_dec_obj_gm.getDecompressedImageFormat() == JpegDecoderHelper::RGB) {
       gainmap_image.pixelFormat = ULTRAHDR_PIX_FMT_RGB888;
-      gainmap_components = 3;
     } else if (jpeg_dec_obj_gm.getDecompressedImageFormat() == JpegDecoderHelper::RGBA) {
       gainmap_image.pixelFormat = ULTRAHDR_PIX_FMT_RGBA8888;
-      gainmap_components = 4;
     } else {
       return ERROR_JPEGR_GAIN_MAP_SIZE_ERROR;
     }

--- a/lib/src/ultrahdr_api.cpp
+++ b/lib/src/ultrahdr_api.cpp
@@ -1488,9 +1488,21 @@ uhdr_error_info_t uhdr_decode(uhdr_codec_private_t* dec) {
   dest.data = handle->m_decoded_img_buffer->planes[UHDR_PLANE_PACKED];
   dest.colorGamut = ultrahdr::ULTRAHDR_COLORGAMUT_UNSPECIFIED;
 
-  handle->m_gainmap_img_buffer = std::make_unique<ultrahdr::uhdr_raw_image_ext_t>(
-      UHDR_IMG_FMT_8bppYCbCr400, UHDR_CG_UNSPECIFIED, UHDR_CT_UNSPECIFIED, UHDR_CR_UNSPECIFIED,
-      handle->m_gainmap_wd, handle->m_gainmap_ht, 1);
+  if (handle->m_img_wd % handle->m_gainmap_wd == 0 && handle->m_img_ht % handle->m_gainmap_ht == 0) {
+    // no problem, proceed as normal
+    handle->m_gainmap_img_buffer = std::make_unique<ultrahdr::uhdr_raw_image_ext_t>(
+        UHDR_IMG_FMT_8bppYCbCr400, UHDR_CG_UNSPECIFIED, UHDR_CT_UNSPECIFIED, UHDR_CR_UNSPECIFIED,
+        handle->m_gainmap_wd, handle->m_gainmap_ht, 1);
+
+  } 
+  else {
+    // Gain map dimensions scale factor value is not an integer
+    // So we will upscale gainmap to same dimensions as image
+    handle->m_gainmap_img_buffer = std::make_unique<ultrahdr::uhdr_raw_image_ext_t>(
+        UHDR_IMG_FMT_8bppYCbCr400, UHDR_CG_UNSPECIFIED, UHDR_CT_UNSPECIFIED, UHDR_CR_UNSPECIFIED,
+        handle->m_img_wd, handle->m_img_ht, 1);
+  }
+
   // alias
   ultrahdr::jpegr_uncompressed_struct dest_gainmap;
   dest_gainmap.data = handle->m_gainmap_img_buffer->planes[UHDR_PLANE_Y];


### PR DESCRIPTION
Fixes #152 by upscaling the gainmap to the same dimensions as the primary image.

This allows the library to successfully open images generated with Pixel8 Pro camera.