### PR TITLE
Signal stride in pixel denomination and not bytes

### DIFF
--- a/lib/include/ultrahdr/jpegencoderhelper.h
+++ b/lib/include/ultrahdr/jpegencoderhelper.h
@@ -47,7 +47,6 @@ struct destination_mgr_impl : jpeg_destination_mgr {
 /*!\brief Encapsulates a converter from raw to jpg image format. This class is not thread-safe */
 class JpegEncoderHelper {
  public:
-
   JpegEncoderHelper() = default;
   ~JpegEncoderHelper() = default;
 

--- a/lib/src/jpegencoderhelper.cpp
+++ b/lib/src/jpegencoderhelper.cpp
@@ -106,9 +106,9 @@ static void outputErrorMessage(j_common_ptr cinfo) {
 }
 
 bool JpegEncoderHelper::compressImage(const uint8_t* planes[3], const size_t strides[3],
-                                      const int width, const int height, const uhdr_img_fmt_t format,
-                                      const int qfactor, const void* iccBuffer,
-                                      const unsigned int iccSize) {
+                                      const int width, const int height,
+                                      const uhdr_img_fmt_t format, const int qfactor,
+                                      const void* iccBuffer, const unsigned int iccSize) {
   return encode(planes, strides, width, height, format, qfactor, iccBuffer, iccSize);
 }
 
@@ -173,7 +173,8 @@ bool JpegEncoderHelper::encode(const uint8_t* planes[3], const size_t strides[3]
     }
     if (format == UHDR_IMG_FMT_24bppRGB888) {
       while (cinfo.next_scanline < cinfo.image_height) {
-        JSAMPROW row_pointer[]{const_cast<JSAMPROW>(&planes[0][cinfo.next_scanline * strides[0]])};
+        JSAMPROW row_pointer[]{
+            const_cast<JSAMPROW>(&planes[0][cinfo.next_scanline * strides[0] * 3])};
         JDIMENSION processed = jpeg_write_scanlines(&cinfo, row_pointer, 1);
         if (1 != processed) {
           ALOGE("jpeg_read_scanlines returned %d, expected %d", processed, 1);

--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -814,7 +814,7 @@ status_t JpegR::compressGainMap(jr_uncompressed_ptr gainmap_image_ptr,
 
   const uint8_t* planes[]{reinterpret_cast<uint8_t*>(gainmap_image_ptr->data)};
   if (kUseMultiChannelGainMap) {
-    const size_t strides[]{gainmap_image_ptr->width * 3};
+    const size_t strides[]{gainmap_image_ptr->width};
     if (!jpeg_enc_obj_ptr->compressImage(planes, strides, gainmap_image_ptr->width,
                                          gainmap_image_ptr->height, UHDR_IMG_FMT_24bppRGB888,
                                          kMapCompressQuality, nullptr, 0)) {

--- a/tests/jpegencoderhelper_test.cpp
+++ b/tests/jpegencoderhelper_test.cpp
@@ -143,7 +143,7 @@ TEST_F(JpegEncoderHelperTest, encodeRGBImage) {
   JpegEncoderHelper encoder;
   const uint8_t* rgbPlane = mRgbImage.buffer.get();
   const uint8_t* planes[1]{rgbPlane};
-  const size_t strides[1]{mRgbImage.width * 3};
+  const size_t strides[1]{mRgbImage.width};
   EXPECT_TRUE(encoder.compressImage(planes, strides, mRgbImage.width, mRgbImage.height,
                                     UHDR_IMG_FMT_24bppRGB888, JPEG_QUALITY, NULL, 0));
   ASSERT_GT(encoder.getCompressedImageSize(), static_cast<uint32_t>(0));


### PR DESCRIPTION
everywhere in the library stride is communicated in units of pixels. But during multi channel gainmap compression this is signalled in bytes. This is corrected.

Test: ./ultrahdr_unit_test