### PR TITLE
cmake: add version to the shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -567,7 +567,7 @@ set(UHDR_TARGET_NAME uhdr)
 add_library(${UHDR_TARGET_NAME})
 add_dependencies(${UHDR_TARGET_NAME} ${UHDR_CORE_LIB_NAME})
 target_link_libraries(${UHDR_TARGET_NAME} PRIVATE ${JPEG_LIBRARIES})
-set_target_properties(${UHDR_TARGET_NAME} PROPERTIES PUBLIC_HEADER ultrahdr_api.h)
+set_target_properties(${UHDR_TARGET_NAME} PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR} PUBLIC_HEADER ultrahdr_api.h)
 combine_static_libs(${UHDR_CORE_LIB_NAME} ${UHDR_TARGET_NAME})
 
 if(UHDR_ENABLE_INSTALL)


### PR DESCRIPTION
If planned to add to major Linux distros, the shared library should be versioned, i.e. as described in [Debian policy](https://www.debian.org/doc/debian-policy/ch-sharedlibs#s-sharedlibs-runtime).
```shell
$ tree
.
├── include
│   └── ultrahdr_api.h
└── lib
    ├── libuhdr.so -> libuhdr.so.1
    ├── libuhdr.so.1 -> libuhdr.so.1.0
    ├── libuhdr.so.1.0
    └── pkgconfig
        └── libuhdr.pc
```