### PR TITLE
API: change a parameter type from bool to int

### DIFF
--- a/lib/src/ultrahdr_api.cpp
+++ b/lib/src/ultrahdr_api.cpp
@@ -496,7 +496,7 @@ void uhdr_release_encoder(uhdr_codec_private_t* enc) {
 }
 
 UHDR_EXTERN uhdr_error_info_t uhdr_enc_set_using_multi_channel_gainmap(uhdr_codec_private_t* enc,
-                                                                       bool use_multi_channel_gainmap) {
+                                                                       int use_multi_channel_gainmap) {
   uhdr_error_info_t status = g_no_error;
   uhdr_encoder_private* handle = dynamic_cast<uhdr_encoder_private*>(enc);
   if (handle == nullptr) {

--- a/ultrahdr_api.h
+++ b/ultrahdr_api.h
@@ -317,7 +317,7 @@ UHDR_EXTERN uhdr_error_info_t uhdr_enc_set_exif_data(uhdr_codec_private_t* enc,
  *                           #UHDR_CODEC_INVALID_PARAM otherwise.
  */
 UHDR_EXTERN uhdr_error_info_t uhdr_enc_set_using_multi_channel_gainmap(uhdr_codec_private_t* enc,
-                                                                       bool use_multi_channel_gainmap);
+                                                                       int use_multi_channel_gainmap);
 
 /*!\brief Set gain map scaling factor, default value is 4 (gain map dimension is 1/4 width and
  * 1/4 height in pixels of the primary image)


### PR DESCRIPTION
Commit 073d5c7580072c246e3d6f34eee2a9200b0d0d4e added the function `uhdr_enc_set_using_multi_channel_gainmap()` to the public API, which used a `bool` type in one of its parameters.

[But `bool` is a keyword only since C23](https://en.cppreference.com/w/c/keyword/bool). Before C23, `bool` is defined in the header `<stdbool.h>`, and this header is missing from the mentioned commit. Client applications that are not compiling in C23 (or later) mode will encounter an error when including the `<ultrahdr_api.h>` header, saying that `bool` is an unknown type.

For example, compiling ImageMagick with ultrahdr support gives the following error:

```
In file included from coders/uhdr.c:47:
/usr/include/ultrahdr_api.h:320:72: error: unknown type name 'bool'
  320 |                                                                        bool use_multi_channel_gainmap);
      |                                                                        ^~~~
/usr/include/ultrahdr_api.h:1:1: note: 'bool' is defined in header '<stdbool.h>'; this is probably fixable by adding '#include <stdbool.h>'
  +++ |+#include <stdbool.h>
    1 | /*
```

This can be fixed either by including the `<stdbool.h>` header after a positive check for pre-C23 mode, or by changing the argument type to  `int` like is made with other function declarations.
    
When compiling in C++ mode, this is not needed as `bool` is a keyword in C++.
