### PR TITLE
Updates towards 4ab sub-sampling format support

### DIFF
--- a/lib/include/ultrahdr/gainmapmath.h
+++ b/lib/include/ultrahdr/gainmapmath.h
@@ -64,6 +64,8 @@ struct Color {
 
 typedef Color (*ColorTransformFn)(Color);
 typedef float (*ColorCalculationFn)(Color);
+typedef Color (*getPixelFn)(uhdr_raw_image_t*, size_t, size_t);
+typedef Color (*samplePixelFn)(uhdr_raw_image_t*, size_t, size_t, size_t);
 
 static inline float clampPixelFloat(float value) {
   return (value < 0.0f) ? 0.0f : (value > kMaxPixelFloat) ? kMaxPixelFloat : value;
@@ -520,8 +522,10 @@ Color applyGain(Color e, Color gain, uhdr_gainmap_metadata_ext_t* metadata, floa
 Color applyGainLUT(Color e, Color gain, GainLUT& gainLUT);
 
 /*
- * Helper for sampling from YUV 420 images.
+ * Helper for sampling from YUV 4ab images.
  */
+Color getYuv444Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
+Color getYuv422Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
 Color getYuv420Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
 
 /*
@@ -533,6 +537,8 @@ Color getP010Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
  * Sample the image at the provided location, with a weighting based on nearby
  * pixels and the map scale factor.
  */
+Color sampleYuv444(uhdr_raw_image_t* map, size_t map_scale_factor, size_t x, size_t y);
+Color sampleYuv422(uhdr_raw_image_t* map, size_t map_scale_factor, size_t x, size_t y);
 Color sampleYuv420(uhdr_raw_image_t* map, size_t map_scale_factor, size_t x, size_t y);
 
 /*

--- a/lib/src/jpegdecoderhelper.cpp
+++ b/lib/src/jpegdecoderhelper.cpp
@@ -369,18 +369,6 @@ uhdr_error_info_t JpegDecoderHelper::decode(const void* image, int length, decod
         jpeg_destroy_decompress(&cinfo);
         return status;
       }
-      if (cinfo.jpeg_color_space == JCS_YCbCr) {
-        if (cinfo.comp_info[0].h_samp_factor != 2 || cinfo.comp_info[0].v_samp_factor != 2 ||
-            cinfo.comp_info[1].h_samp_factor != 1 || cinfo.comp_info[1].v_samp_factor != 1 ||
-            cinfo.comp_info[2].h_samp_factor != 1 || cinfo.comp_info[2].v_samp_factor != 1) {
-          status.error_code = UHDR_CODEC_ERROR;
-          status.has_detail = 1;
-          snprintf(status.detail, sizeof status.detail,
-                   "apply gainmap supports only 4:2:0 sub sampling format, stopping image decode");
-          jpeg_destroy_decompress(&cinfo);
-          return status;
-        }
-      }
       int size = 0;
       for (int i = 0; i < cinfo.num_components; i++) {
         mPlaneHStride[i] = ALIGNM(mPlaneWidth[i], cinfo.max_h_samp_factor);


### PR DESCRIPTION
- Update generateGainMap and applyRecMap to support sdr intent with sampling formats 444, 422.

This change does not enable 444, 422 support completely as hdr intents currently support only p010. More changes are required towards enabling 444, 422 support completely.

Fixes #69

Test: ultrahdr_app.exe -m 0 -p trin_rain_converted_using_ffmpeg.yuv -a 0 \ -i trin_rain_base_sdr_high_quality.jpeg -c 1 -w 1080 -h 1350