### PR TITLE
Enable convertYuv_neon in 32bit builds

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -72,6 +72,7 @@ cc_library {
         arm: {
             srcs: [
                 "lib/src/dsp/arm/editorhelper_neon.cpp",
+                "lib/src/dsp/arm/gainmapmath_neon.cpp",
             ],
         },
         arm64: {

--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -223,8 +223,7 @@ uhdr_error_info_t JpegR::encodeJPEGR(uhdr_raw_image_t* hdr_intent, uhdr_raw_imag
   std::shared_ptr<DataStruct> icc = IccHelper::writeIccProfile(UHDR_CT_SRGB, sdr_intent->cg);
 
   // convert to bt601 YUV encoding for JPEG encode
-#if (defined(UHDR_ENABLE_INTRINSICS) && (defined(__ARM_NEON__) || defined(__ARM_NEON)) && \
-     defined(__aarch64__))
+#if (defined(UHDR_ENABLE_INTRINSICS) && (defined(__ARM_NEON__) || defined(__ARM_NEON)))
   UHDR_ERR_CHECK(convertYuv_neon(sdr_intent, sdr_intent->cg, UHDR_CG_DISPLAY_P3));
 #else
   UHDR_ERR_CHECK(convertYuv(sdr_intent, sdr_intent->cg, UHDR_CG_DISPLAY_P3));


### PR DESCRIPTION
The issues that were seen earlier when compiling convertYuv_neon in 32 bit build are now fixed.