### PR TITLE
Add round factor during float to int conversion

### DIFF
--- a/lib/src/gainmapmath.cpp
+++ b/lib/src/gainmapmath.cpp
@@ -966,10 +966,10 @@ Color sampleMap3Channel(uhdr_raw_image_t* map, size_t map_scale_factor, size_t x
 }
 
 uint32_t colorToRgba1010102(Color e_gamma) {
-  return (0x3ff & static_cast<uint32_t>(e_gamma.r * 1023.0f)) |
-         ((0x3ff & static_cast<uint32_t>(e_gamma.g * 1023.0f)) << 10) |
-         ((0x3ff & static_cast<uint32_t>(e_gamma.b * 1023.0f)) << 20) |
-         (0x3 << 30);  // Set alpha to 1.0
+  uint32_t r = CLIP3((e_gamma.r * 1023 + 0.5f), 0.0f, 1023.0f);
+  uint32_t g = CLIP3((e_gamma.g * 1023 + 0.5f), 0.0f, 1023.0f);
+  uint32_t b = CLIP3((e_gamma.b * 1023 + 0.5f), 0.0f, 1023.0f);
+  return (r | (g << 10) | (b << 20) | (0x3 << 30));  // Set alpha to 1.0
 }
 
 uint64_t colorToRgbaF16(Color e_gamma) {

--- a/tests/gainmapmath_test.cpp
+++ b/tests/gainmapmath_test.cpp
@@ -1516,9 +1516,9 @@ TEST_F(GainMapMathTest, ColorToRgba1010102) {
 
   Color e_gamma = {{{0.1f, 0.2f, 0.3f}}};
   EXPECT_EQ(colorToRgba1010102(e_gamma),
-            0x3 << 30 | static_cast<uint32_t>(0.1f * static_cast<float>(0x3ff)) |
-                static_cast<uint32_t>(0.2f * static_cast<float>(0x3ff)) << 10 |
-                static_cast<uint32_t>(0.3f * static_cast<float>(0x3ff)) << 20);
+            0x3 << 30 | static_cast<uint32_t>(0.1f * static_cast<float>(0x3ff) + 0.5) |
+                static_cast<uint32_t>(0.2f * static_cast<float>(0x3ff) + 0.5) << 10 |
+                static_cast<uint32_t>(0.3f * static_cast<float>(0x3ff) + 0.5) << 20);
 }
 
 TEST_F(GainMapMathTest, ColorToRgbaF16) {


### PR DESCRIPTION
The output of applyRecMap while converting to int, ensure a round factor is added for small error representation

Test: ./ultrahdr_unit_test