### PR TITLE
add support for iso metadata parsing in probe path

### DIFF
--- a/lib/include/ultrahdr/jpegr.h
+++ b/lib/include/ultrahdr/jpegr.h
@@ -56,6 +56,7 @@ struct jpeg_info_struct {
   std::vector<uint8_t> iccData = std::vector<uint8_t>(0);
   std::vector<uint8_t> exifData = std::vector<uint8_t>(0);
   std::vector<uint8_t> xmpData = std::vector<uint8_t>(0);
+  std::vector<uint8_t> isoData = std::vector<uint8_t>(0);
   size_t width;
   size_t height;
   size_t numComponents;
@@ -76,7 +77,6 @@ typedef struct jpegr_info_struct* jr_info_ptr;
 
 class JpegR {
  public:
-
   JpegR(size_t mapDimensionScaleFactor = kMapDimensionScaleFactorDefault,
         int mapCompressQuality = kMapCompressQualityDefault,
         bool useMultiChannelGainMap = kUseMultiChannelGainMapDefault);
@@ -356,6 +356,21 @@ class JpegR {
    * \deprecated This function is deprecated. Use its actual
    */
   status_t getJPEGRInfo(jr_compressed_ptr jpegr_image_ptr, jr_info_ptr jpegr_image_info_ptr);
+
+  /*!\brief This function receives iso block and / or xmp block and parses gainmap metadata and fill
+   * the output descriptor. If both iso block and xmp block are available, then iso block is
+   * preferred over xmp.
+   *
+   * \param[in]       iso_data                  iso memory block
+   * \param[in]       iso_size                  iso block size
+   * \param[in]       xmp_data                  xmp memory block
+   * \param[in]       xmp_size                  xmp block size
+   * \param[in, out]  gainmap_metadata          gainmap metadata descriptor
+   *
+   * \return uhdr_error_info_t #UHDR_CODEC_OK if operation succeeds, uhdr_codec_err_t otherwise.
+   */
+  uhdr_error_info_t parseGainMapMetadata(uint8_t* iso_data, int iso_size, uint8_t* xmp_data,
+                                         int xmp_size, uhdr_gainmap_metadata_ext_t* uhdr_metadata);
 
  protected:
   /*!\brief This method takes hdr intent and sdr intent and computes gainmap coefficient.

--- a/lib/include/ultrahdr/ultrahdrcommon.h
+++ b/lib/include/ultrahdr/ultrahdrcommon.h
@@ -289,8 +289,6 @@ struct uhdr_decoder_private : uhdr_codec_private {
   uhdr_mem_block_t m_exif_block;
   std::vector<uint8_t> m_icc;
   uhdr_mem_block_t m_icc_block;
-  std::vector<uint8_t> m_base_xmp;
-  std::vector<uint8_t> m_gainmap_xmp;
   uhdr_gainmap_metadata_t m_metadata;
   uhdr_error_info_t m_probe_call_status;
   uhdr_error_info_t m_decode_call_status;

--- a/lib/src/ultrahdr_api.cpp
+++ b/lib/src/ultrahdr_api.cpp
@@ -1216,8 +1216,9 @@ uhdr_error_info_t uhdr_dec_probe(uhdr_codec_private_t* dec) {
     if (status.error_code != UHDR_CODEC_OK) return status;
 
     ultrahdr::uhdr_gainmap_metadata_ext_t metadata;
-    status = ultrahdr::getMetadataFromXMP(gainmap_image.xmpData.data(),
-                                          gainmap_image.xmpData.size(), &metadata);
+    status = jpegr.parseGainMapMetadata(gainmap_image.isoData.data(), gainmap_image.isoData.size(),
+                                        gainmap_image.xmpData.data(), gainmap_image.xmpData.size(),
+                                        &metadata);
     if (status.error_code != UHDR_CODEC_OK) return status;
     handle->m_metadata.max_content_boost = metadata.max_content_boost;
     handle->m_metadata.min_content_boost = metadata.min_content_boost;
@@ -1238,8 +1239,6 @@ uhdr_error_info_t uhdr_dec_probe(uhdr_codec_private_t* dec) {
     handle->m_icc = std::move(primary_image.iccData);
     handle->m_icc_block.data = handle->m_icc.data();
     handle->m_icc_block.data_sz = handle->m_icc_block.capacity = handle->m_icc.size();
-    handle->m_base_xmp = std::move(primary_image.xmpData);
-    handle->m_gainmap_xmp = std::move(gainmap_image.xmpData);
   }
 
   return status;
@@ -1443,8 +1442,6 @@ void uhdr_reset_decoder(uhdr_codec_private_t* dec) {
     memset(&handle->m_exif_block, 0, sizeof handle->m_exif_block);
     handle->m_icc.clear();
     memset(&handle->m_icc_block, 0, sizeof handle->m_icc_block);
-    handle->m_base_xmp.clear();
-    handle->m_gainmap_xmp.clear();
     memset(&handle->m_metadata, 0, sizeof handle->m_metadata);
     handle->m_probe_call_status = g_no_error;
     handle->m_decode_call_status = g_no_error;


### PR DESCRIPTION
uhdr_dec_probe() parses gainmap metadata present in xmp block only. If iso block contains gainmap metadata this is not handled. Add support for same.

Test:./ultrahdr_unit_test