### PR TITLE
Add support for 444 subsampling format in uhdr encoder

### DIFF
--- a/lib/include/ultrahdr/gainmapmath.h
+++ b/lib/include/ultrahdr/gainmapmath.h
@@ -69,8 +69,8 @@ struct Color {
 
 typedef Color (*ColorTransformFn)(Color);
 typedef float (*ColorCalculationFn)(Color);
-typedef Color (*getPixelFn)(uhdr_raw_image_t*, size_t, size_t);
-typedef Color (*samplePixelFn)(uhdr_raw_image_t*, size_t, size_t, size_t);
+typedef Color (*GetPixelFn)(uhdr_raw_image_t*, size_t, size_t);
+typedef Color (*SamplePixelFn)(uhdr_raw_image_t*, size_t, size_t, size_t);
 
 static inline float clampPixelFloat(float value) {
   return (value < 0.0f) ? 0.0f : (value > kMaxPixelFloat) ? kMaxPixelFloat : value;
@@ -467,7 +467,17 @@ ColorCalculationFn getLuminanceFn(uhdr_color_gamut_t gamut);
 /*
  * Get function to linearize transfer characteristics
  */
-ColorTransformFn getInverseOetf(uhdr_color_transfer_t transfer);
+ColorTransformFn getInverseOetfFn(uhdr_color_transfer_t transfer);
+
+/*
+ * Get function to read pixels from raw image for a given color format
+ */
+GetPixelFn getPixelFn(uhdr_img_fmt_t format);
+
+/*
+ * Get function to sample pixels from raw image for a given color format
+ */
+SamplePixelFn getSamplePixelFn(uhdr_img_fmt_t format);
 
 /*
  * Get max display mastering luminance in nits
@@ -506,6 +516,8 @@ int16x8x3_t yuvConversion_neon(uint8x8_t y, int16x8_t u, int16x8_t v, int16x8_t 
 
 void transformYuv420_neon(uhdr_raw_image_t* image, const int16_t* coeffs_ptr);
 
+void transformYuv444_neon(uhdr_raw_image_t* image, const int16_t* coeffs_ptr);
+
 uhdr_error_info_t convertYuv_neon(uhdr_raw_image_t* image, uhdr_color_gamut_t src_encoding,
                                   uhdr_color_gamut_t dst_encoding);
 #endif
@@ -515,11 +527,13 @@ uhdr_error_info_t convertYuv_neon(uhdr_raw_image_t* image, uhdr_color_gamut_t sr
  *
  * Apply the transformation by determining transformed YUV for each of the 4 Y + 1 UV; each Y gets
  * this result, and UV gets the averaged result.
- *
- * The chroma channels should be less than or equal to half the image's width and height
- * respectively, since input is 4:2:0 subsampled.
  */
 void transformYuv420(uhdr_raw_image_t* image, const std::array<float, 9>& coeffs);
+
+/*
+ * Performs a color gamut transformation on an entire YUV444 image.
+ */
+void transformYuv444(uhdr_raw_image_t* image, const std::array<float, 9>& coeffs);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Gain map calculations
@@ -561,16 +575,13 @@ Color applyGain(Color e, Color gain, uhdr_gainmap_metadata_ext_t* metadata, floa
 Color applyGainLUT(Color e, Color gain, GainLUT& gainLUT);
 
 /*
- * Helper for sampling from YUV 4ab images.
+ * Get pixel from the image at the provided location.
  */
 Color getYuv444Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
 Color getYuv422Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
 Color getYuv420Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
-
-/*
- * Helper for sampling from P010 images.
- */
 Color getP010Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
+Color getYuv444Pixel10bit(uhdr_raw_image_t* image, size_t x, size_t y);
 
 /*
  * Sample the image at the provided location, with a weighting based on nearby
@@ -579,14 +590,8 @@ Color getP010Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
 Color sampleYuv444(uhdr_raw_image_t* map, size_t map_scale_factor, size_t x, size_t y);
 Color sampleYuv422(uhdr_raw_image_t* map, size_t map_scale_factor, size_t x, size_t y);
 Color sampleYuv420(uhdr_raw_image_t* map, size_t map_scale_factor, size_t x, size_t y);
-
-/*
- * Sample the image at the provided location, with a weighting based on nearby
- * pixels and the map scale factor.
- *
- * Expect narrow-range image data for P010.
- */
 Color sampleP010(uhdr_raw_image_t* map, size_t map_scale_factor, size_t x, size_t y);
+Color sampleYuv44410bit(uhdr_raw_image_t* image, size_t map_scale_factor, size_t x, size_t y);
 
 /*
  * Sample the gain value for the map from a given x,y coordinate on a scale
@@ -622,7 +627,8 @@ uhdr_error_info_t copy_raw_image(uhdr_raw_image_t* src, uhdr_raw_image_t* dst);
 /*
  * Helper for preparing encoder raw inputs for encoding
  */
-std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr(uhdr_raw_image_t* src);
+std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr(
+    uhdr_raw_image_t* src, bool chroma_sampling_enabled = false);
 
 /*
  * Helper for converting float to fraction

--- a/lib/src/editorhelper.cpp
+++ b/lib/src/editorhelper.cpp
@@ -232,6 +232,20 @@ std::unique_ptr<uhdr_raw_image_ext_t> apply_rotate(ultrahdr::uhdr_rotate_effect_
     uint64_t* dst_buffer = static_cast<uint64_t*>(dst->planes[UHDR_PLANE_PACKED]);
     desc->m_rotate_uint64_t(src_buffer, dst_buffer, src->w, src->h, src->stride[UHDR_PLANE_PACKED],
                             dst->stride[UHDR_PLANE_PACKED], desc->m_degree);
+  } else if (src->fmt == UHDR_IMG_FMT_24bppYCbCr444) {
+    for (int i = 0; i < 3; i++) {
+      uint8_t* src_buffer = static_cast<uint8_t*>(src->planes[i]);
+      uint8_t* dst_buffer = static_cast<uint8_t*>(dst->planes[i]);
+      desc->m_rotate_uint8_t(src_buffer, dst_buffer, src->w, src->h, src->stride[i], dst->stride[i],
+                             desc->m_degree);
+    }
+  } else if (src->fmt == UHDR_IMG_FMT_30bppYCbCr444) {
+    for (int i = 0; i < 3; i++) {
+      uint16_t* src_buffer = static_cast<uint16_t*>(src->planes[i]);
+      uint16_t* dst_buffer = static_cast<uint16_t*>(dst->planes[i]);
+      desc->m_rotate_uint16_t(src_buffer, dst_buffer, src->w, src->h, src->stride[i],
+                              dst->stride[i], desc->m_degree);
+    }
   }
   return dst;
 }
@@ -274,6 +288,20 @@ std::unique_ptr<uhdr_raw_image_ext_t> apply_mirror(ultrahdr::uhdr_mirror_effect_
     uint64_t* dst_buffer = static_cast<uint64_t*>(dst->planes[UHDR_PLANE_PACKED]);
     desc->m_mirror_uint64_t(src_buffer, dst_buffer, src->w, src->h, src->stride[UHDR_PLANE_PACKED],
                             dst->stride[UHDR_PLANE_PACKED], desc->m_direction);
+  } else if (src->fmt == UHDR_IMG_FMT_24bppYCbCr444) {
+    for (int i = 0; i < 3; i++) {
+      uint8_t* src_buffer = static_cast<uint8_t*>(src->planes[i]);
+      uint8_t* dst_buffer = static_cast<uint8_t*>(dst->planes[i]);
+      desc->m_mirror_uint8_t(src_buffer, dst_buffer, src->w, src->h, src->stride[i], dst->stride[i],
+                             desc->m_direction);
+    }
+  } else if (src->fmt == UHDR_IMG_FMT_30bppYCbCr444) {
+    for (int i = 0; i < 3; i++) {
+      uint16_t* src_buffer = static_cast<uint16_t*>(src->planes[i]);
+      uint16_t* dst_buffer = static_cast<uint16_t*>(dst->planes[i]);
+      desc->m_mirror_uint16_t(src_buffer, dst_buffer, src->w, src->h, src->stride[i],
+                              dst->stride[i], desc->m_direction);
+    }
   }
   return dst;
 }
@@ -300,6 +328,16 @@ void apply_crop(uhdr_raw_image_t* src, int left, int top, int wd, int ht) {
   } else if (src->fmt == UHDR_IMG_FMT_64bppRGBAHalfFloat) {
     uint64_t* src_buffer = static_cast<uint64_t*>(src->planes[UHDR_PLANE_PACKED]);
     src->planes[UHDR_PLANE_PACKED] = &src_buffer[top * src->stride[UHDR_PLANE_PACKED] + left];
+  } else if (src->fmt == UHDR_IMG_FMT_24bppYCbCr444) {
+    for (int i = 0; i < 3; i++) {
+      uint8_t* src_buffer = static_cast<uint8_t*>(src->planes[i]);
+      src->planes[i] = &src_buffer[top * src->stride[i] + left];
+    }
+  } else if (src->fmt == UHDR_IMG_FMT_30bppYCbCr444) {
+    for (int i = 0; i < 3; i++) {
+      uint16_t* src_buffer = static_cast<uint16_t*>(src->planes[i]);
+      src->planes[i] = &src_buffer[top * src->stride[i] + left];
+    }
   }
   src->w = wd;
   src->h = ht;
@@ -343,6 +381,20 @@ std::unique_ptr<uhdr_raw_image_ext_t> apply_resize(ultrahdr::uhdr_resize_effect_
     uint64_t* dst_buffer = static_cast<uint64_t*>(dst->planes[UHDR_PLANE_PACKED]);
     desc->m_resize_uint64_t(src_buffer, dst_buffer, src->w, src->h, dst->w, dst->h,
                             src->stride[UHDR_PLANE_PACKED], dst->stride[UHDR_PLANE_PACKED]);
+  } else if (src->fmt == UHDR_IMG_FMT_24bppYCbCr444) {
+    for (int i = 0; i < 3; i++) {
+      uint8_t* src_buffer = static_cast<uint8_t*>(src->planes[i]);
+      uint8_t* dst_buffer = static_cast<uint8_t*>(dst->planes[i]);
+      desc->m_resize_uint8_t(src_buffer, dst_buffer, src->w, src->h, dst->w, dst->h, src->stride[i],
+                             dst->stride[i]);
+    }
+  } else if (src->fmt == UHDR_IMG_FMT_30bppYCbCr444) {
+    for (int i = 0; i < 3; i++) {
+      uint16_t* src_buffer = static_cast<uint16_t*>(src->planes[i]);
+      uint16_t* dst_buffer = static_cast<uint16_t*>(dst->planes[i]);
+      desc->m_resize_uint16_t(src_buffer, dst_buffer, src->w, src->h, dst->w, dst->h,
+                              src->stride[i], dst->stride[i]);
+    }
   }
   return dst;
 }

--- a/lib/src/gainmapmath.cpp
+++ b/lib/src/gainmapmath.cpp
@@ -432,7 +432,7 @@ ColorCalculationFn getLuminanceFn(uhdr_color_gamut_t gamut) {
   return nullptr;
 }
 
-ColorTransformFn getInverseOetf(uhdr_color_transfer_t transfer) {
+ColorTransformFn getInverseOetfFn(uhdr_color_transfer_t transfer) {
   switch (transfer) {
     case UHDR_CT_LINEAR:
       return identityConversion;
@@ -455,6 +455,42 @@ ColorTransformFn getInverseOetf(uhdr_color_transfer_t transfer) {
       return srgbInvOetf;
 #endif
     case UHDR_CT_UNSPECIFIED:
+      return nullptr;
+  }
+  return nullptr;
+}
+
+GetPixelFn getPixelFn(uhdr_img_fmt_t format) {
+  switch (format) {
+    case UHDR_IMG_FMT_24bppYCbCr444:
+      return getYuv444Pixel;
+    case UHDR_IMG_FMT_16bppYCbCr422:
+      return getYuv422Pixel;
+    case UHDR_IMG_FMT_12bppYCbCr420:
+      return getYuv420Pixel;
+    case UHDR_IMG_FMT_24bppYCbCrP010:
+      return getP010Pixel;
+    case UHDR_IMG_FMT_30bppYCbCr444:
+      return getYuv444Pixel10bit;
+    default:
+      return nullptr;
+  }
+  return nullptr;
+}
+
+SamplePixelFn getSamplePixelFn(uhdr_img_fmt_t format) {
+  switch (format) {
+    case UHDR_IMG_FMT_24bppYCbCr444:
+      return sampleYuv444;
+    case UHDR_IMG_FMT_16bppYCbCr422:
+      return sampleYuv422;
+    case UHDR_IMG_FMT_12bppYCbCr420:
+      return sampleYuv420;
+    case UHDR_IMG_FMT_24bppYCbCrP010:
+      return sampleP010;
+    case UHDR_IMG_FMT_30bppYCbCr444:
+      return sampleYuv44410bit;
+    default:
       return nullptr;
   }
   return nullptr;
@@ -576,6 +612,28 @@ void transformYuv420(uhdr_raw_image_t* image, const std::array<float, 9>& coeffs
   }
 }
 
+void transformYuv444(uhdr_raw_image_t* image, const std::array<float, 9>& coeffs) {
+  for (size_t y = 0; y < image->h; ++y) {
+    for (size_t x = 0; x < image->w; ++x) {
+      Color yuv = getYuv444Pixel(image, x, y);
+      yuv = yuvColorGamutConversion(yuv, coeffs);
+
+      size_t pixel_y_idx = x + y * image->stride[UHDR_PLANE_Y];
+      uint8_t& y1_uint = reinterpret_cast<uint8_t*>(image->planes[UHDR_PLANE_Y])[pixel_y_idx];
+
+      size_t pixel_u_idx = x + y * image->stride[UHDR_PLANE_U];
+      uint8_t& u_uint = reinterpret_cast<uint8_t*>(image->planes[UHDR_PLANE_U])[pixel_u_idx];
+
+      size_t pixel_v_idx = x + y * image->stride[UHDR_PLANE_V];
+      uint8_t& v_uint = reinterpret_cast<uint8_t*>(image->planes[UHDR_PLANE_V])[pixel_v_idx];
+
+      y1_uint = static_cast<uint8_t>(CLIP3((yuv.y * 255.0f + 0.5f), 0, 255));
+      u_uint = static_cast<uint8_t>(CLIP3((yuv.u * 255.0f + 128.0f + 0.5f), 0, 255));
+      v_uint = static_cast<uint8_t>(CLIP3((yuv.v * 255.0f + 128.0f + 0.5f), 0, 255));
+    }
+  }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Gain map calculations
 uint8_t encodeGain(float y_sdr, float y_hdr, uhdr_gainmap_metadata_ext_t* metadata) {
@@ -687,6 +745,33 @@ Color getYuv420Pixel(uhdr_raw_image_t* image, size_t x, size_t y) {
   return getYuv4abPixel(image, x, y, 2, 2);
 }
 
+Color getYuv444Pixel10bit(uhdr_raw_image_t* image, size_t x, size_t y) {
+  uint16_t* luma_data = reinterpret_cast<uint16_t*>(image->planes[UHDR_PLANE_Y]);
+  size_t luma_stride = image->stride[UHDR_PLANE_Y];
+  uint16_t* cb_data = reinterpret_cast<uint16_t*>(image->planes[UHDR_PLANE_U]);
+  size_t cb_stride = image->stride[UHDR_PLANE_U];
+  uint16_t* cr_data = reinterpret_cast<uint16_t*>(image->planes[UHDR_PLANE_V]);
+  size_t cr_stride = image->stride[UHDR_PLANE_V];
+
+  size_t pixel_y_idx = y * luma_stride + x;
+  size_t pixel_u_idx = y * cb_stride + x;
+  size_t pixel_v_idx = y * cr_stride + x;
+
+  uint16_t y_uint = luma_data[pixel_y_idx];
+  uint16_t u_uint = cb_data[pixel_u_idx];
+  uint16_t v_uint = cr_data[pixel_v_idx];
+
+  if (image->range == UHDR_CR_FULL_RANGE) {
+    return {{{static_cast<float>(y_uint) / 1023.0f, static_cast<float>(u_uint) / 1023.0f - 0.5f,
+              static_cast<float>(v_uint) / 1023.0f - 0.5f}}};
+  }
+
+  // Conversions include taking narrow-range into account.
+  return {{{static_cast<float>(y_uint - 64) * (1 / 876.0f),
+            static_cast<float>(u_uint - 64) * (1 / 896.0f) - 0.5f,
+            static_cast<float>(v_uint - 64) * (1 / 896.0f) - 0.5f}}};
+}
+
 Color getP010Pixel(uhdr_raw_image_t* image, size_t x, size_t y) {
   uint16_t* luma_data = reinterpret_cast<uint16_t*>(image->planes[UHDR_PLANE_Y]);
   size_t luma_stride = image->stride[UHDR_PLANE_Y];
@@ -713,7 +798,7 @@ Color getP010Pixel(uhdr_raw_image_t* image, size_t x, size_t y) {
 }
 
 static Color samplePixels(uhdr_raw_image_t* image, size_t map_scale_factor, size_t x, size_t y,
-                          getPixelFn get_pixel_fn) {
+                          GetPixelFn get_pixel_fn) {
   Color e = {{{0.0f, 0.0f, 0.0f}}};
   for (size_t dy = 0; dy < map_scale_factor; ++dy) {
     for (size_t dx = 0; dx < map_scale_factor; ++dx) {
@@ -738,6 +823,10 @@ Color sampleYuv420(uhdr_raw_image_t* image, size_t map_scale_factor, size_t x, s
 
 Color sampleP010(uhdr_raw_image_t* image, size_t map_scale_factor, size_t x, size_t y) {
   return samplePixels(image, map_scale_factor, x, y, getP010Pixel);
+}
+
+Color sampleYuv44410bit(uhdr_raw_image_t* image, size_t map_scale_factor, size_t x, size_t y) {
+  return samplePixels(image, map_scale_factor, x, y, getYuv444Pixel10bit);
 }
 
 // TODO: do we need something more clever for filtering either the map or images
@@ -977,7 +1066,8 @@ uint64_t colorToRgbaF16(Color e_gamma) {
          (((uint64_t)floatToHalf(e_gamma.b)) << 32) | (((uint64_t)floatToHalf(1.0f)) << 48);
 }
 
-std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr(uhdr_raw_image_t* src) {
+std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr(uhdr_raw_image_t* src,
+                                                                 bool chroma_sampling_enabled) {
   std::unique_ptr<uhdr_raw_image_ext_t> dst = nullptr;
   Color (*rgbToyuv)(Color) = nullptr;
 
@@ -993,7 +1083,7 @@ std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr(uhdr_raw_image_
     }
   }
 
-  if (src->fmt == UHDR_IMG_FMT_32bppRGBA1010102) {
+  if (src->fmt == UHDR_IMG_FMT_32bppRGBA1010102 && chroma_sampling_enabled) {
     dst = std::make_unique<uhdr_raw_image_ext_t>(UHDR_IMG_FMT_24bppYCbCrP010, src->cg, src->ct,
                                                  UHDR_CR_FULL_RANGE, src->w, src->h, 64);
 
@@ -1051,7 +1141,45 @@ std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr(uhdr_raw_image_
         vData[dst->stride[UHDR_PLANE_UV] * (i / 2) + j] = uint16_t(pixel[0].v) << 6;
       }
     }
-  } else if (src->fmt == UHDR_IMG_FMT_32bppRGBA8888) {
+  } else if (src->fmt == UHDR_IMG_FMT_32bppRGBA1010102) {
+    dst = std::make_unique<uhdr_raw_image_ext_t>(UHDR_IMG_FMT_30bppYCbCr444, src->cg, src->ct,
+                                                 UHDR_CR_FULL_RANGE, src->w, src->h, 64);
+
+    uint32_t* rgbData = static_cast<uint32_t*>(src->planes[UHDR_PLANE_PACKED]);
+    unsigned int srcStride = src->stride[UHDR_PLANE_PACKED];
+
+    uint16_t* yData = static_cast<uint16_t*>(dst->planes[UHDR_PLANE_Y]);
+    uint16_t* uData = static_cast<uint16_t*>(dst->planes[UHDR_PLANE_U]);
+    uint16_t* vData = static_cast<uint16_t*>(dst->planes[UHDR_PLANE_V]);
+
+    for (size_t i = 0; i < dst->h; i++) {
+      for (size_t j = 0; j < dst->w; j++) {
+        Color pixel;
+
+        pixel.r = float(rgbData[srcStride * i + j] & 0x3ff);
+        pixel.g = float((rgbData[srcStride * i + j] >> 10) & 0x3ff);
+        pixel.b = float((rgbData[srcStride * i + j] >> 20) & 0x3ff);
+
+        // Now we only support the RGB input being full range
+        pixel /= 1023.0f;
+        pixel = (*rgbToyuv)(pixel);
+
+        pixel.y = (pixel.y * 1023.0f) + 0.5f;
+        pixel.y = CLIP3(pixel.y, 0.0f, 1023.0f);
+
+        yData[dst->stride[UHDR_PLANE_Y] * i + j] = uint16_t(pixel.y);
+
+        pixel.u = (pixel.u * 1023.0f) + 512.0f + 0.5f;
+        pixel.v = (pixel.v * 1023.0f) + 512.0f + 0.5f;
+
+        pixel.u = CLIP3(pixel.u, 0.0f, 1023.0f);
+        pixel.v = CLIP3(pixel.v, 0.0f, 1023.0f);
+
+        uData[dst->stride[UHDR_PLANE_U] * i + j] = uint16_t(pixel.u);
+        vData[dst->stride[UHDR_PLANE_V] * i + j] = uint16_t(pixel.v);
+      }
+    }
+  } else if (src->fmt == UHDR_IMG_FMT_32bppRGBA8888 && chroma_sampling_enabled) {
     dst = std::make_unique<uhdr_raw_image_ext_t>(UHDR_IMG_FMT_12bppYCbCr420, src->cg, src->ct,
                                                  UHDR_CR_FULL_RANGE, src->w, src->h, 64);
     uint32_t* rgbData = static_cast<uint32_t*>(src->planes[UHDR_PLANE_PACKED]);
@@ -1104,6 +1232,41 @@ std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr(uhdr_raw_image_
 
         uData[dst->stride[UHDR_PLANE_U] * (i / 2) + (j / 2)] = uint8_t(pixel[0].u);
         vData[dst->stride[UHDR_PLANE_V] * (i / 2) + (j / 2)] = uint8_t(pixel[0].v);
+      }
+    }
+  } else if (src->fmt == UHDR_IMG_FMT_32bppRGBA8888) {
+    dst = std::make_unique<uhdr_raw_image_ext_t>(UHDR_IMG_FMT_24bppYCbCr444, src->cg, src->ct,
+                                                 UHDR_CR_FULL_RANGE, src->w, src->h, 64);
+    uint32_t* rgbData = static_cast<uint32_t*>(src->planes[UHDR_PLANE_PACKED]);
+    unsigned int srcStride = src->stride[UHDR_PLANE_PACKED];
+
+    uint8_t* yData = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_Y]);
+    uint8_t* uData = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_U]);
+    uint8_t* vData = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_V]);
+    for (size_t i = 0; i < dst->h; i++) {
+      for (size_t j = 0; j < dst->w; j++) {
+        Color pixel;
+
+        pixel.r = float(rgbData[srcStride * i + j] & 0xff);
+        pixel.g = float((rgbData[srcStride * i + j] >> 8) & 0xff);
+        pixel.b = float((rgbData[srcStride * i + j] >> 16) & 0xff);
+
+        // Now we only support the RGB input being full range
+        pixel /= 255.0f;
+        pixel = (*rgbToyuv)(pixel);
+
+        pixel.y = pixel.y * 255.0f + 0.5f;
+        pixel.y = CLIP3(pixel.y, 0.0f, 255.0f);
+        yData[dst->stride[UHDR_PLANE_Y] * i + j] = uint8_t(pixel.y);
+
+        pixel.u = pixel.u * 255.0f + 0.5 + 128.0f;
+        pixel.v = pixel.v * 255.0f + 0.5 + 128.0f;
+
+        pixel.u = CLIP3(pixel.u, 0.0f, 255.0f);
+        pixel.v = CLIP3(pixel.v, 0.0f, 255.0f);
+
+        uData[dst->stride[UHDR_PLANE_U] * i + j] = uint8_t(pixel.u);
+        vData[dst->stride[UHDR_PLANE_V] * i + j] = uint8_t(pixel.v);
       }
     }
   } else if (src->fmt == UHDR_IMG_FMT_12bppYCbCr420 || src->fmt == UHDR_IMG_FMT_24bppYCbCrP010) {

--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -172,9 +172,22 @@ static void copyJpegWithoutExif(uhdr_compressed_image_t* pDest, uhdr_compressed_
 /* Encode API-0 */
 uhdr_error_info_t JpegR::encodeJPEGR(uhdr_raw_image_t* hdr_intent, uhdr_compressed_image_t* dest,
                                      int quality, uhdr_mem_block_t* exif) {
+  uhdr_img_fmt_t sdr_intent_fmt;
+  if (hdr_intent->fmt == UHDR_IMG_FMT_24bppYCbCrP010) {
+    sdr_intent_fmt = UHDR_IMG_FMT_12bppYCbCr420;
+  } else if (hdr_intent->fmt == UHDR_IMG_FMT_30bppYCbCr444) {
+    sdr_intent_fmt = UHDR_IMG_FMT_24bppYCbCr444;
+  } else {
+    uhdr_error_info_t status;
+    status.error_code = UHDR_CODEC_INVALID_PARAM;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail, "unsupported hdr intent color format %d",
+             hdr_intent->fmt);
+    return status;
+  }
   std::unique_ptr<uhdr_raw_image_ext_t> sdr_intent = std::make_unique<uhdr_raw_image_ext_t>(
-      UHDR_IMG_FMT_12bppYCbCr420, UHDR_CG_UNSPECIFIED, UHDR_CT_UNSPECIFIED, UHDR_CR_UNSPECIFIED,
-      hdr_intent->w, hdr_intent->h, 64);
+      sdr_intent_fmt, UHDR_CG_UNSPECIFIED, UHDR_CT_UNSPECIFIED, UHDR_CR_UNSPECIFIED, hdr_intent->w,
+      hdr_intent->h, 64);
 
   // tone map
   UHDR_ERR_CHECK(toneMap(hdr_intent, sdr_intent.get()));
@@ -421,7 +434,18 @@ uhdr_error_info_t JpegR::convertYuv(uhdr_raw_image_t* image, uhdr_color_gamut_t 
       return status;
   }
 
-  transformYuv420(image, *coeffs_ptr);
+  if (image->fmt == UHDR_IMG_FMT_12bppYCbCr420) {
+    transformYuv420(image, *coeffs_ptr);
+  } else if (image->fmt == UHDR_IMG_FMT_24bppYCbCr444) {
+    transformYuv444(image, *coeffs_ptr);
+  } else {
+    status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail,
+             "No implementation available for performing gamut conversion for color format %d",
+             image->fmt);
+    return status;
+  }
 
   return status;
 }
@@ -449,12 +473,13 @@ uhdr_error_info_t JpegR::generateGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_
              sdr_intent->fmt);
     return status;
   }
-  if (hdr_intent->fmt != UHDR_IMG_FMT_24bppYCbCrP010) {
+  if (hdr_intent->fmt != UHDR_IMG_FMT_24bppYCbCrP010 &&
+      hdr_intent->fmt != UHDR_IMG_FMT_30bppYCbCr444) {
     status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
     status.has_detail = 1;
     snprintf(status.detail, sizeof status.detail,
              "generate gainmap method expects hdr intent color format to be one of "
-             "{UHDR_IMG_FMT_24bppYCbCrP010}. Received %d",
+             "{UHDR_IMG_FMT_24bppYCbCrP010, UHDR_IMG_FMT_30bppYCbCr444}. Received %d",
              hdr_intent->fmt);
     return status;
   }
@@ -469,7 +494,7 @@ uhdr_error_info_t JpegR::generateGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_
     }
   }*/
 
-  ColorTransformFn hdrInvOetf = getInverseOetf(hdr_intent->ct);
+  ColorTransformFn hdrInvOetf = getInverseOetfFn(hdr_intent->ct);
   if (hdrInvOetf == nullptr) {
     status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
     status.has_detail = 1;
@@ -540,23 +565,22 @@ uhdr_error_info_t JpegR::generateGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_
     return status;
   }
 
-  samplePixelFn sdr_sample_pixel_fn = nullptr;
-  switch (sdr_intent->fmt) {
-    case UHDR_IMG_FMT_24bppYCbCr444:
-      sdr_sample_pixel_fn = sampleYuv444;
-      break;
-    case UHDR_IMG_FMT_16bppYCbCr422:
-      sdr_sample_pixel_fn = sampleYuv422;
-      break;
-    case UHDR_IMG_FMT_12bppYCbCr420:
-      sdr_sample_pixel_fn = sampleYuv420;
-      break;
-    default:
-      status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
-      status.has_detail = 1;
-      snprintf(status.detail, sizeof status.detail,
-               "Unsupported sdr intent color format in apply gainmap %d", sdr_intent->fmt);
-      return status;
+  SamplePixelFn sdr_sample_pixel_fn = getSamplePixelFn(sdr_intent->fmt);
+  if (sdr_sample_pixel_fn == nullptr) {
+    status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail,
+             "No implementation available for reading pixels for color format %d", sdr_intent->fmt);
+    return status;
+  }
+
+  SamplePixelFn hdr_sample_pixel_fn = getSamplePixelFn(hdr_intent->fmt);
+  if (hdr_sample_pixel_fn == nullptr) {
+    status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail,
+             "No implementation available for reading pixels for color format %d", hdr_intent->fmt);
+    return status;
   }
 
   if (sdr_is_601) {
@@ -590,8 +614,8 @@ uhdr_error_info_t JpegR::generateGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_
   JobQueue jobQueue;
   std::function<void()> generateMap =
       [this, sdr_intent, hdr_intent, gainmap_metadata, dest, hdrInvOetf, hdrGamutConversionFn,
-       luminanceFn, sdrYuvToRgbFn, hdrYuvToRgbFn, sdr_sample_pixel_fn, hdr_white_nits, log2MinBoost,
-       log2MaxBoost, use_luminance, &jobQueue]() -> void {
+       luminanceFn, sdrYuvToRgbFn, hdrYuvToRgbFn, sdr_sample_pixel_fn, hdr_sample_pixel_fn,
+       hdr_white_nits, log2MinBoost, log2MaxBoost, use_luminance, &jobQueue]() -> void {
     size_t rowStart, rowEnd;
     while (jobQueue.dequeueJob(rowStart, rowEnd)) {
       for (size_t y = rowStart; y < rowEnd; ++y) {
@@ -605,7 +629,7 @@ uhdr_error_info_t JpegR::generateGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_
           Color sdr_rgb = srgbInvOetf(sdr_rgb_gamma);
 #endif
 
-          Color hdr_yuv_gamma = sampleP010(hdr_intent, mMapDimensionScaleFactor, x, y);
+          Color hdr_yuv_gamma = hdr_sample_pixel_fn(hdr_intent, mMapDimensionScaleFactor, x, y);
           Color hdr_rgb_gamma = hdrYuvToRgbFn(hdr_yuv_gamma);
           Color hdr_rgb = hdrInvOetf(hdr_rgb_gamma);
           hdr_rgb = hdrGamutConversionFn(hdr_rgb);
@@ -1126,25 +1150,14 @@ uhdr_error_info_t JpegR::applyGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_ima
   float display_boost = (std::min)(max_display_boost, gainmap_metadata->max_content_boost);
   GainLUT gainLUT(gainmap_metadata, display_boost);
 
-  getPixelFn get_pixel_fn = nullptr;
-  switch (sdr_intent->fmt) {
-    case UHDR_IMG_FMT_24bppYCbCr444:
-      get_pixel_fn = getYuv444Pixel;
-      break;
-    case UHDR_IMG_FMT_16bppYCbCr422:
-      get_pixel_fn = getYuv422Pixel;
-      break;
-    case UHDR_IMG_FMT_12bppYCbCr420:
-      get_pixel_fn = getYuv420Pixel;
-      break;
-    default: {
-      uhdr_error_info_t status;
-      status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
-      status.has_detail = 1;
-      snprintf(status.detail, sizeof status.detail,
-               "Unsupported sdr intent color format in apply gainmap %d", sdr_intent->fmt);
-      return status;
-    }
+  GetPixelFn get_pixel_fn = getPixelFn(sdr_intent->fmt);
+  if (get_pixel_fn == nullptr) {
+    uhdr_error_info_t status;
+    status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail,
+             "No implementation available for reading pixels for color format %d", sdr_intent->fmt);
+    return status;
   }
 
   JobQueue jobQueue;
@@ -1416,24 +1429,39 @@ uint8_t ScaleTo8Bit(float value) {
 }
 
 uhdr_error_info_t JpegR::toneMap(uhdr_raw_image_t* hdr_intent, uhdr_raw_image_t* sdr_intent) {
-  if (sdr_intent->fmt != UHDR_IMG_FMT_12bppYCbCr420) {
-    uhdr_error_info_t status;
-    status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
-    status.has_detail = 1;
-    snprintf(status.detail, sizeof status.detail,
-             "tonemap method expects sdr intent color format to be one of "
-             "{UHDR_IMG_FMT_12bppYCbCr420}. Received %d",
-             sdr_intent->fmt);
-    return status;
-  }
-  if (hdr_intent->fmt != UHDR_IMG_FMT_24bppYCbCrP010) {
+  if (hdr_intent->fmt != UHDR_IMG_FMT_24bppYCbCrP010 &&
+      hdr_intent->fmt != UHDR_IMG_FMT_30bppYCbCr444) {
     uhdr_error_info_t status;
     status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
     status.has_detail = 1;
     snprintf(status.detail, sizeof status.detail,
              "tonemap method expects hdr intent color format to be one of "
-             "{UHDR_IMG_FMT_24bppYCbCrP010}. Received %d",
+             "{UHDR_IMG_FMT_24bppYCbCrP010, UHDR_IMG_FMT_30bppYCbCr444}. Received %d",
              hdr_intent->fmt);
+    return status;
+  }
+
+  if (hdr_intent->fmt == UHDR_IMG_FMT_24bppYCbCrP010 &&
+      sdr_intent->fmt != UHDR_IMG_FMT_12bppYCbCr420) {
+    uhdr_error_info_t status;
+    status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail,
+             "tonemap method expects sdr intent color format to be UHDR_IMG_FMT_12bppYCbCr420, if "
+             "hdr intent color format is UHDR_IMG_FMT_24bppYCbCrP010. Received %d",
+             sdr_intent->fmt);
+    return status;
+  }
+
+  if (hdr_intent->fmt == UHDR_IMG_FMT_30bppYCbCr444 &&
+      sdr_intent->fmt != UHDR_IMG_FMT_24bppYCbCr444) {
+    uhdr_error_info_t status;
+    status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail,
+             "tonemap method expects sdr intent color format to be UHDR_IMG_FMT_24bppYCbCr444, if "
+             "hdr intent color format is UHDR_IMG_FMT_30bppYCbCr444. Received %d",
+             sdr_intent->fmt);
     return status;
   }
 
@@ -1448,7 +1476,7 @@ uhdr_error_info_t JpegR::toneMap(uhdr_raw_image_t* hdr_intent, uhdr_raw_image_t*
     return status;
   }
 
-  ColorTransformFn hdrInvOetf = getInverseOetf(hdr_intent->ct);
+  ColorTransformFn hdrInvOetf = getInverseOetfFn(hdr_intent->ct);
   if (hdrInvOetf == nullptr) {
     uhdr_error_info_t status;
     status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
@@ -1470,6 +1498,16 @@ uhdr_error_info_t JpegR::toneMap(uhdr_raw_image_t* hdr_intent, uhdr_raw_image_t*
     return status;
   }
 
+  GetPixelFn get_pixel_fn = getPixelFn(hdr_intent->fmt);
+  if (get_pixel_fn == nullptr) {
+    uhdr_error_info_t status;
+    status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail,
+             "No implementation available for reading pixels for color format %d", hdr_intent->fmt);
+    return status;
+  }
+
   sdr_intent->cg = UHDR_CG_DISPLAY_P3;
   sdr_intent->ct = UHDR_CT_SRGB;
   sdr_intent->range = UHDR_CR_FULL_RANGE;
@@ -1483,25 +1521,29 @@ uhdr_error_info_t JpegR::toneMap(uhdr_raw_image_t* hdr_intent, uhdr_raw_image_t*
   size_t cr_stride = sdr_intent->stride[UHDR_PLANE_V];
   size_t height = hdr_intent->h;
   const int threads = (std::min)(GetCPUCoreCount(), 4);
-  const int jobSizeInRows = 2;  // 420 subsampling
+  // for 420 subsampling, process 2 rows at once
+  const int jobSizeInRows = hdr_intent->fmt == UHDR_IMG_FMT_24bppYCbCrP010 ? 2 : 1;
   size_t rowStep = threads == 1 ? height : jobSizeInRows;
   JobQueue jobQueue;
   std::function<void()> toneMapInternal;
 
   toneMapInternal = [hdr_intent, luma_data, cb_data, cr_data, hdrInvOetf, hdrGamutConversionFn,
-                     hdrYuvToRgbFn, luma_stride, cb_stride, cr_stride, hdr_white_nits,
+                     hdrYuvToRgbFn, get_pixel_fn, luma_stride, cb_stride, cr_stride, hdr_white_nits,
                      &jobQueue]() -> void {
     size_t rowStart, rowEnd;
+    int hfactor = hdr_intent->fmt == UHDR_IMG_FMT_24bppYCbCrP010 ? 2 : 1;
+    int vfactor = hdr_intent->fmt == UHDR_IMG_FMT_24bppYCbCrP010 ? 2 : 1;
+
     while (jobQueue.dequeueJob(rowStart, rowEnd)) {
-      for (size_t y = rowStart; y < rowEnd; y += 2) {
-        for (size_t x = 0; x < hdr_intent->w; x += 2) {
+      for (size_t y = rowStart; y < rowEnd; y += vfactor) {
+        for (size_t x = 0; x < hdr_intent->w; x += hfactor) {
           // We assume the input is P010, and output is YUV420
           float sdr_u_gamma = 0.0f;
           float sdr_v_gamma = 0.0f;
 
-          for (int i = 0; i < 2; i++) {
-            for (int j = 0; j < 2; j++) {
-              Color hdr_yuv_gamma = getP010Pixel(hdr_intent, x + j, y + i);
+          for (int i = 0; i < vfactor; i++) {
+            for (int j = 0; j < hfactor; j++) {
+              Color hdr_yuv_gamma = get_pixel_fn(hdr_intent, x + j, y + i);
               Color hdr_rgb_gamma = hdrYuvToRgbFn(hdr_yuv_gamma);
               Color hdr_rgb = hdrInvOetf(hdr_rgb_gamma);
 
@@ -1527,10 +1569,10 @@ uhdr_error_info_t JpegR::toneMap(uhdr_raw_image_t* hdr_intent, uhdr_raw_image_t*
               sdr_v_gamma += sdr_yuv_gamma.v;
             }
           }
-          sdr_u_gamma *= 0.25f;
-          sdr_v_gamma *= 0.25f;
-          cb_data[x / 2 + (y / 2) * cb_stride] = ScaleTo8Bit(sdr_u_gamma);
-          cr_data[x / 2 + (y / 2) * cr_stride] = ScaleTo8Bit(sdr_v_gamma);
+          sdr_u_gamma /= (hfactor * vfactor);
+          sdr_v_gamma /= (hfactor * vfactor);
+          cb_data[x / hfactor + (y / vfactor) * cb_stride] = ScaleTo8Bit(sdr_u_gamma);
+          cr_data[x / hfactor + (y / vfactor) * cr_stride] = ScaleTo8Bit(sdr_v_gamma);
         }
       }
     }

--- a/ultrahdr_api.h
+++ b/ultrahdr_api.h
@@ -73,6 +73,7 @@ typedef enum uhdr_img_fmt {
   UHDR_IMG_FMT_12bppYCbCr411 = 9,  /**< 8-bit-per component 4:1:1 YCbCr planar format */
   UHDR_IMG_FMT_10bppYCbCr410 = 10, /**< 8-bit-per component 4:1:0 YCbCr planar format */
   UHDR_IMG_FMT_24bppRGB888 = 11,   /**< 8-bit-per component RGB interleaved format */
+  UHDR_IMG_FMT_30bppYCbCr444 = 12, /**< 10-bit-per component 4:4:4 YCbCr planar format */
 } uhdr_img_fmt_t;                  /**< alias for enum uhdr_img_fmt */
 
 /*!\brief List of supported color gamuts */


### PR DESCRIPTION
Only encode api variant 3 has support for subsampling format 1x1. Extend this support for encode api variants 0 to 2.

fixes #202

Test: ./ultrahdr_unit_test