### PR TITLE
Allow for larger excursions of min, max content boost

### DIFF
--- a/fuzzer/ultrahdr_enc_fuzzer.cpp
+++ b/fuzzer/ultrahdr_enc_fuzzer.cpp
@@ -113,6 +113,9 @@ void UltraHdrEncFuzzer::process() {
     // gainmap scale factor
     auto gm_scale_factor = mFdp.ConsumeIntegralInRange<int>(1, 128);
 
+    // encoding speed preset
+    auto enc_preset = static_cast<uhdr_enc_preset_t>(mFdp.ConsumeIntegralInRange<int>(0, 1));
+
     std::unique_ptr<uint32_t[]> bufferHdr = nullptr;
     std::unique_ptr<uint16_t[]> bufferYHdr = nullptr;
     std::unique_ptr<uint16_t[]> bufferUVHdr = nullptr;
@@ -265,6 +268,7 @@ void UltraHdrEncFuzzer::process() {
     ON_ERR(uhdr_enc_set_quality(enc_handle, gainmap_quality, UHDR_GAIN_MAP_IMG))
     ON_ERR(uhdr_enc_set_gainmap_scale_factor(enc_handle, gm_scale_factor))
     ON_ERR(uhdr_enc_set_using_multi_channel_gainmap(enc_handle, multi_channel_gainmap))
+    ON_ERR(uhdr_enc_set_preset(enc_handle, enc_preset))
 
     uhdr_error_info_t status = {UHDR_CODEC_OK, 0, ""};
     if (muxSwitch == 0 || muxSwitch == 1) {  // api 0 or api 1

--- a/lib/include/ultrahdr/gainmapmath.h
+++ b/lib/include/ultrahdr/gainmapmath.h
@@ -194,7 +194,7 @@ struct GainLUT {
 
   GainLUT(uhdr_gainmap_metadata_ext_t* metadata, float displayBoost) {
     this->mGammaInv = 1.0f / metadata->gamma;
-    float boostFactor = displayBoost > 0 ? displayBoost / metadata->max_content_boost : 1.0f;
+    float boostFactor = displayBoost > 0 ? displayBoost / metadata->hdr_capacity_max : 1.0f;
     for (int32_t idx = 0; idx < kGainFactorNumEntries; idx++) {
       float value = static_cast<float>(idx) / static_cast<float>(kGainFactorNumEntries - 1);
       float logBoost = log2(metadata->min_content_boost) * (1.0f - value) +
@@ -540,23 +540,17 @@ void transformYuv444(uhdr_raw_image_t* image, const std::array<float, 9>& coeffs
 
 /*
  * Calculate the 8-bit unsigned integer gain value for the given SDR and HDR
- * luminances in linear space, and the hdr ratio to encode against.
- *
- * Note: since this library always uses gamma of 1.0, offsetSdr of 0.0, and
- * offsetHdr of 0.0, this function doesn't handle different metadata values for
- * these fields.
+ * luminances in linear space and gainmap metadata fields.
  */
 uint8_t encodeGain(float y_sdr, float y_hdr, uhdr_gainmap_metadata_ext_t* metadata);
 uint8_t encodeGain(float y_sdr, float y_hdr, uhdr_gainmap_metadata_ext_t* metadata,
                    float log2MinContentBoost, float log2MaxContentBoost);
+float computeGain(float sdr, float hdr);
+uint8_t affineMapGain(float gainlog2, float mingainlog2, float maxgainlog2, float gamma);
 
 /*
  * Calculates the linear luminance in nits after applying the given gain
  * value, with the given hdr ratio, to the given sdr input in the range [0, 1].
- *
- * Note: similar to encodeGain(), this function only supports gamma 1.0,
- * offsetSdr 0.0, offsetHdr 0.0, hdrCapacityMin 1.0, and hdrCapacityMax equal to
- * gainMapMax, as this library encodes.
  */
 Color applyGain(Color e, float gain, uhdr_gainmap_metadata_ext_t* metadata);
 Color applyGain(Color e, float gain, uhdr_gainmap_metadata_ext_t* metadata, float displayBoost);
@@ -565,10 +559,6 @@ Color applyGainLUT(Color e, float gain, GainLUT& gainLUT);
 /*
  * Apply gain in R, G and B channels, with the given hdr ratio, to the given sdr input
  * in the range [0, 1].
- *
- * Note: similar to encodeGain(), this function only supports gamma 1.0,
- * offsetSdr 0.0, offsetHdr 0.0, hdrCapacityMin 1.0, and hdrCapacityMax equal to
- * gainMapMax, as this library encodes.
  */
 Color applyGain(Color e, Color gain, uhdr_gainmap_metadata_ext_t* metadata);
 Color applyGain(Color e, Color gain, uhdr_gainmap_metadata_ext_t* metadata, float displayBoost);

--- a/lib/include/ultrahdr/jpegr.h
+++ b/lib/include/ultrahdr/jpegr.h
@@ -77,7 +77,7 @@ class JpegR {
         size_t mapDimensionScaleFactor = kMapDimensionScaleFactorDefault,
         int mapCompressQuality = kMapCompressQualityDefault,
         bool useMultiChannelGainMap = kUseMultiChannelGainMapDefault,
-        float gamma = kGainMapGammaDefault);
+        float gamma = kGainMapGammaDefault, uhdr_enc_preset_t preset = UHDR_USAGE_REALTIME);
 
   /*!\brief Encode API-0.
    *
@@ -571,6 +571,7 @@ class JpegR {
   int mMapCompressQuality;          // gain map quality factor
   bool mUseMultiChannelGainMap;     // enable multichannel gain map
   float mGamma;                     // gain map gamma parameter
+  uhdr_enc_preset_t mEncPreset;     // encoding speed preset
 };
 
 struct GlobalTonemapOutputs {

--- a/lib/include/ultrahdr/ultrahdrcommon.h
+++ b/lib/include/ultrahdr/ultrahdrcommon.h
@@ -327,6 +327,7 @@ struct uhdr_encoder_private : uhdr_codec_private {
   int m_gainmap_scale_factor;
   bool m_use_multi_channel_gainmap;
   float m_gamma;
+  uhdr_enc_preset_t m_enc_preset;
 
   // internal data
   std::unique_ptr<ultrahdr::uhdr_compressed_image_ext_t> m_compressed_output_buffer;

--- a/lib/src/ultrahdr_api.cpp
+++ b/lib/src/ultrahdr_api.cpp
@@ -529,6 +529,41 @@ UHDR_EXTERN uhdr_error_info_t uhdr_enc_set_gainmap_gamma(uhdr_codec_private_t* e
   return status;
 }
 
+uhdr_error_info_t uhdr_enc_set_preset(uhdr_codec_private_t* enc, uhdr_enc_preset_t preset) {
+  uhdr_error_info_t status = g_no_error;
+
+  if (dynamic_cast<uhdr_encoder_private*>(enc) == nullptr) {
+    status.error_code = UHDR_CODEC_INVALID_PARAM;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail, "received nullptr for uhdr codec instance");
+    return status;
+  }
+
+  if (preset != UHDR_USAGE_REALTIME && preset != UHDR_USAGE_BEST_QUALITY) {
+    status.error_code = UHDR_CODEC_INVALID_PARAM;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail,
+             "invalid preset %d, expects one of {UHDR_USAGE_REALTIME, UHDR_USAGE_BEST_QUALITY}",
+             preset);
+    return status;
+  }
+
+  uhdr_encoder_private* handle = dynamic_cast<uhdr_encoder_private*>(enc);
+
+  if (handle->m_sailed) {
+    status.error_code = UHDR_CODEC_INVALID_OPERATION;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail,
+             "An earlier call to uhdr_encode() has switched the context from configurable state to "
+             "end state. The context is no longer configurable. To reuse, call reset()");
+    return status;
+  }
+
+  handle->m_enc_preset = preset;
+
+  return status;
+}
+
 uhdr_error_info_t uhdr_enc_set_raw_image(uhdr_codec_private_t* enc, uhdr_raw_image_t* img,
                                          uhdr_img_label_t intent) {
   uhdr_error_info_t status = g_no_error;
@@ -984,9 +1019,9 @@ uhdr_error_info_t uhdr_encode(uhdr_codec_private_t* enc) {
       exif.capacity = exif.data_sz = handle->m_exif.size();
     }
 
-    ultrahdr::JpegR jpegr(nullptr, handle->m_gainmap_scale_factor,
-                          handle->m_quality.find(UHDR_GAIN_MAP_IMG)->second,
-                          handle->m_use_multi_channel_gainmap, handle->m_gamma);
+    ultrahdr::JpegR jpegr(
+        nullptr, handle->m_gainmap_scale_factor, handle->m_quality.find(UHDR_GAIN_MAP_IMG)->second,
+        handle->m_use_multi_channel_gainmap, handle->m_gamma, handle->m_enc_preset);
     if (handle->m_compressed_images.find(UHDR_BASE_IMG) != handle->m_compressed_images.end() &&
         handle->m_compressed_images.find(UHDR_GAIN_MAP_IMG) != handle->m_compressed_images.end()) {
       auto& base_entry = handle->m_compressed_images.find(UHDR_BASE_IMG)->second;
@@ -1086,6 +1121,7 @@ void uhdr_reset_encoder(uhdr_codec_private_t* enc) {
     handle->m_gainmap_scale_factor = ultrahdr::kMapDimensionScaleFactorDefault;
     handle->m_use_multi_channel_gainmap = ultrahdr::kUseMultiChannelGainMapDefault;
     handle->m_gamma = ultrahdr::kGainMapGammaDefault;
+    handle->m_enc_preset = UHDR_USAGE_REALTIME;
 
     handle->m_compressed_output_buffer.reset();
     handle->m_encode_call_status = g_no_error;

--- a/ultrahdr_api.h
+++ b/ultrahdr_api.h
@@ -115,6 +115,12 @@ typedef enum uhdr_img_label {
   UHDR_GAIN_MAP_IMG, /**< Gain map image */
 } uhdr_img_label_t;  /**< alias for enum uhdr_img_label */
 
+/*!\brief uhdr encoder usage parameter */
+typedef enum uhdr_enc_preset {
+  UHDR_USAGE_REALTIME,     /**< real time preset */
+  UHDR_USAGE_BEST_QUALITY, /**< best encoding quality preset */
+} uhdr_enc_preset_t;       /**< alias for enum uhdr_img_label */
+
 /*!\brief Algorithm return codes */
 typedef enum uhdr_codec_err {
 
@@ -351,6 +357,17 @@ UHDR_EXTERN uhdr_error_info_t uhdr_enc_set_gainmap_scale_factor(uhdr_codec_priva
  *                           #UHDR_CODEC_INVALID_PARAM otherwise.
  */
 UHDR_EXTERN uhdr_error_info_t uhdr_enc_set_gainmap_gamma(uhdr_codec_private_t* enc, float gamma);
+
+/*!\brief Set encoding preset. Tunes the encoder configurations for performance or quality.
+ *
+ * \param[in]  enc  encoder instance.
+ * \param[in]  preset  encoding preset
+ *
+ * \return uhdr_error_info_t #UHDR_CODEC_OK if operation succeeds,
+ *                           #UHDR_CODEC_INVALID_PARAM otherwise.
+ */
+UHDR_EXTERN uhdr_error_info_t uhdr_enc_set_preset(uhdr_codec_private_t* enc,
+                                                  uhdr_enc_preset_t preset);
 
 /*!\brief Set output image compression format.
  *


### PR DESCRIPTION
Current implementation clips min/max content boost to a smaller range. Allow for larger excursions for better hdr intent representation.

Also, fixed round factor before encoding gainmap coefficient

Test: ./ultrahdr_unit_test