### PR TITLE
Add upper limit to gainmap scale factor

### DIFF
--- a/fuzzer/ultrahdr_enc_fuzzer.cpp
+++ b/fuzzer/ultrahdr_enc_fuzzer.cpp
@@ -111,7 +111,7 @@ void UltraHdrEncFuzzer::process() {
     height = (height >> 1) << 1;
 
     // gainmap scale factor
-    auto gm_scale_factor = mFdp.ConsumeIntegralInRange<int>(1, std::min(width, height));
+    auto gm_scale_factor = mFdp.ConsumeIntegralInRange<int>(1, 128);
 
     std::unique_ptr<uint32_t[]> bufferHdr = nullptr;
     std::unique_ptr<uint16_t[]> bufferYHdr = nullptr;
@@ -119,7 +119,6 @@ void UltraHdrEncFuzzer::process() {
     std::unique_ptr<uint8_t[]> bufferYSdr = nullptr;
     std::unique_ptr<uint8_t[]> bufferUVSdr = nullptr;
     std::unique_ptr<uint8_t[]> gainMapImageRaw = nullptr;
-    std::unique_ptr<uint8_t[]> jpegBufferRaw = nullptr;
     uhdr_codec_private_t* enc_handle = uhdr_create_encoder();
     if (!enc_handle) {
       ALOGE("Failed to create encoder");

--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -612,7 +612,7 @@ uhdr_error_info_t JpegR::generateGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_
     scaleFactor = (scaleFactor >= DCTSIZE) ? (scaleFactor / DCTSIZE) : 1;
     ALOGW(
         "configured gainmap scale factor is resulting in gainmap width and/or height to be zero, "
-        "image width %d, image height %d, scale factor %d. Modiyfing gainmap scale factor to %d ",
+        "image width %d, image height %d, scale factor %d. Modifying gainmap scale factor to %d ",
         (int)image_width, (int)image_height, (int)mMapDimensionScaleFactor, scaleFactor);
     setMapDimensionScaleFactor(scaleFactor);
     map_width = image_width / mMapDimensionScaleFactor;

--- a/lib/src/ultrahdr_api.cpp
+++ b/lib/src/ultrahdr_api.cpp
@@ -470,11 +470,12 @@ UHDR_EXTERN uhdr_error_info_t uhdr_enc_set_gainmap_scale_factor(uhdr_codec_priva
     return status;
   }
 
-  if (gainmap_scale_factor <= 0) {
+  if (gainmap_scale_factor <= 0 || gainmap_scale_factor > 128) {
     status.error_code = UHDR_CODEC_INVALID_PARAM;
     status.has_detail = 1;
     snprintf(status.detail, sizeof status.detail,
-             "unsupported gainmap scale factor %d, expects to be > 0", gainmap_scale_factor);
+             "gainmap scale factor is expected to be in range (0, 128], received %d",
+             gainmap_scale_factor);
     return status;
   }
 


### PR DESCRIPTION
very large gainmap scale factors result in large heap requirements during ShepardsIDW instantiation. As large downsample factors are not beneficial from quality stand point and also for embedded devices profile point of view, add an upper bound to the config

fixes oss-fuzz:	70927

Test: ./ultrahdr_unit_test