### PR TITLE
revisit gainmapmath constants

### DIFF
--- a/examples/ultrahdr_app.cpp
+++ b/examples/ultrahdr_app.cpp
@@ -32,23 +32,23 @@
 
 #include "ultrahdr_api.h"
 
-const float BT601YUVtoRGBMatrix[9] = {
-    1.f, 0.f, 1.402f, 1.f, (-0.202008f / 0.587f), (-0.419198f / 0.587f), 1.0f, 1.772f, 0.0f};
+const float DisplayP3YUVtoRGBMatrix[9] = {
+    1.f, 0.f, 1.542f, 1.f, (-0.146023f / 0.6917f), (-0.353118f / 0.6917f), 1.0f, 1.8414f, 0.0f};
 const float BT709YUVtoRGBMatrix[9] = {
     1.f,  0.f,     1.5748f, 1.f, (-0.13397432f / 0.7152f), (-0.33480248f / 0.7152f),
     1.0f, 1.8556f, 0.0f};
 const float BT2020YUVtoRGBMatrix[9] = {
     1.f, 0.f, 1.4746f, 1.f, (-0.11156702f / 0.6780f), (-0.38737742f / 0.6780f), 1.f, 1.8814f, 0.f};
 
-const float BT601RGBtoYUVMatrix[9] = {0.299f,
-                                      0.587f,
-                                      0.114f,
-                                      (-0.299f / 1.772f),
-                                      (-0.587f / 1.772f),
-                                      0.5f,
-                                      0.5f,
-                                      (-0.587f / 1.402f),
-                                      (-0.114f / 1.402f)};
+const float DisplayP3RGBtoYUVMatrix[9] = {0.229f,
+                                          0.6917f,
+                                          0.0793f,
+                                          (-0.229f / 1.8414f),
+                                          (-0.6917f / 1.8414f),
+                                          0.5f,
+                                          0.5f,
+                                          (-0.6917f / 1.542f),
+                                          (-0.0793f / 1.542f)};
 const float BT709RGBtoYUVMatrix[9] = {0.2126f,
                                       0.7152f,
                                       0.0722f,
@@ -863,7 +863,7 @@ bool UltraHdrAppInput::convertP010ToRGBImage() {
   } else if (mHdrCg == UHDR_CG_BT_2100) {
     coeffs = BT2020YUVtoRGBMatrix;
   } else if (mHdrCg == UHDR_CG_DISPLAY_P3) {
-    coeffs = BT601YUVtoRGBMatrix;
+    coeffs = DisplayP3YUVtoRGBMatrix;
   } else {
     std::cerr << "color matrix not present for gamut " << mHdrCg << " using BT2020Matrix"
               << std::endl;
@@ -955,15 +955,15 @@ bool UltraHdrAppInput::convertYuv420ToRGBImage() {
   uint8_t* u = static_cast<uint8_t*>(mRawYuv420Image.planes[UHDR_PLANE_U]);
   uint8_t* v = static_cast<uint8_t*>(mRawYuv420Image.planes[UHDR_PLANE_V]);
 
-  const float* coeffs = BT601YUVtoRGBMatrix;
+  const float* coeffs = BT709YUVtoRGBMatrix;
   if (mSdrCg == UHDR_CG_BT_709) {
     coeffs = BT709YUVtoRGBMatrix;
   } else if (mSdrCg == UHDR_CG_BT_2100) {
     coeffs = BT2020YUVtoRGBMatrix;
   } else if (mSdrCg == UHDR_CG_DISPLAY_P3) {
-    coeffs = BT601YUVtoRGBMatrix;
+    coeffs = DisplayP3YUVtoRGBMatrix;
   } else {
-    std::cerr << "color matrix not present for gamut " << mSdrCg << " using BT601Matrix"
+    std::cerr << "color matrix not present for gamut " << mSdrCg << " using BT709Matrix"
               << std::endl;
   }
   for (size_t i = 0; i < mRawYuv420Image.h; i++) {
@@ -1025,16 +1025,16 @@ bool UltraHdrAppInput::convertRgba8888ToYUV444Image() {
   uint8_t* uData = static_cast<uint8_t*>(mDecodedUhdrYuv444Image.planes[UHDR_PLANE_U]);
   uint8_t* vData = static_cast<uint8_t*>(mDecodedUhdrYuv444Image.planes[UHDR_PLANE_V]);
 
-  const float* coeffs = BT601RGBtoYUVMatrix;
+  const float* coeffs = BT709RGBtoYUVMatrix;
   if (mDecodedUhdrRgbImage.cg == UHDR_CG_BT_709) {
     coeffs = BT709RGBtoYUVMatrix;
   } else if (mDecodedUhdrRgbImage.cg == UHDR_CG_BT_2100) {
     coeffs = BT2020RGBtoYUVMatrix;
   } else if (mDecodedUhdrRgbImage.cg == UHDR_CG_DISPLAY_P3) {
-    coeffs = BT601RGBtoYUVMatrix;
+    coeffs = DisplayP3RGBtoYUVMatrix;
   } else {
     std::cerr << "color matrix not present for gamut " << mDecodedUhdrRgbImage.cg
-              << " using BT601Matrix" << std::endl;
+              << " using BT709Matrix" << std::endl;
   }
 
   for (size_t i = 0; i < mDecodedUhdrRgbImage.h; i++) {
@@ -1079,7 +1079,7 @@ bool UltraHdrAppInput::convertRgba1010102ToYUV444Image() {
   } else if (mDecodedUhdrRgbImage.cg == UHDR_CG_BT_2100) {
     coeffs = BT2020RGBtoYUVMatrix;
   } else if (mDecodedUhdrRgbImage.cg == UHDR_CG_DISPLAY_P3) {
-    coeffs = BT601RGBtoYUVMatrix;
+    coeffs = DisplayP3RGBtoYUVMatrix;
   } else {
     std::cerr << "color matrix not present for gamut " << mDecodedUhdrRgbImage.cg
               << " using BT2020Matrix" << std::endl;

--- a/lib/include/ultrahdr/gainmapmath.h
+++ b/lib/include/ultrahdr/gainmapmath.h
@@ -347,6 +347,13 @@ Color pqInvOetfLUT(Color e_gamma);
 constexpr int32_t kPqInvOETFPrecision = 12;
 constexpr int32_t kPqInvOETFNumEntries = 1 << kPqInvOETFPrecision;
 
+////////////////////////////////////////////////////////////////////////////////
+// BT.601 transformations
+
+// BT.601 rgb <-> yuv  conversion
+Color Bt601RgbToYuv(Color e_gamma);
+Color Bt601YuvToRgb(Color e_gamma);
+
 // util class to prepare look up tables for oetf/eotf functions
 class LookUpTable {
  public:
@@ -408,20 +415,26 @@ Color bt2100ToP3(Color e);
 
 // convert between yuv encodings
 extern const std::array<float, 9> kYuvBt709ToBt601;
+extern const std::array<float, 9> kYuvBt709ToDisplayP3;
 extern const std::array<float, 9> kYuvBt709ToBt2100;
-extern const std::array<float, 9> kYuvBt601ToBt709;
-extern const std::array<float, 9> kYuvBt601ToBt2100;
-extern const std::array<float, 9> kYuvBt2100ToBt709;
+extern const std::array<float, 9> kYuvDisplayP3ToBt601;
+extern const std::array<float, 9> kYuvDisplayP3ToBt709;
+extern const std::array<float, 9> kYuvDisplayP3ToBt2100;
 extern const std::array<float, 9> kYuvBt2100ToBt601;
+extern const std::array<float, 9> kYuvBt2100ToBt709;
+extern const std::array<float, 9> kYuvBt2100ToDisplayP3;
 
 #if (defined(UHDR_ENABLE_INTRINSICS) && (defined(__ARM_NEON__) || defined(__ARM_NEON)))
 
 extern const int16_t kYuv709To601_coeffs_neon[8];
+extern const int16_t kYuv709ToP3_coeffs_neon[8];
 extern const int16_t kYuv709To2100_coeffs_neon[8];
-extern const int16_t kYuv601To709_coeffs_neon[8];
-extern const int16_t kYuv601To2100_coeffs_neon[8];
-extern const int16_t kYuv2100To709_coeffs_neon[8];
+extern const int16_t kYuvP3To601_coeffs_neon[8];
+extern const int16_t kYuvP3To709_coeffs_neon[8];
+extern const int16_t kYuvP3To2100_coeffs_neon[8];
 extern const int16_t kYuv2100To601_coeffs_neon[8];
+extern const int16_t kYuv2100To709_coeffs_neon[8];
+extern const int16_t kYuv2100ToP3_coeffs_neon[8];
 
 /*
  * The Y values are provided at half the width of U & V values to allow use of the widening

--- a/lib/include/ultrahdr/gainmapmath.h
+++ b/lib/include/ultrahdr/gainmapmath.h
@@ -603,6 +603,8 @@ std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr(
 std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr_neon(uhdr_raw_image_t* src);
 #endif
 
+uhdr_error_info_t convert_ycbcr_input_to_rgb(uhdr_raw_image_t* src, uhdr_raw_image_t* dst);
+
 bool floatToSignedFraction(float v, int32_t* numerator, uint32_t* denominator);
 bool floatToUnsignedFraction(float v, uint32_t* numerator, uint32_t* denominator);
 

--- a/lib/include/ultrahdr/icc.h
+++ b/lib/include/ultrahdr/icc.h
@@ -103,6 +103,10 @@ static constexpr size_t kICCTagTableEntrySize = 12;
 // bytes for a single XYZ number type (4 bytes per coordinate).
 static constexpr size_t kColorantTagSize = 20;
 
+// size should be 12; 4 bytes for type descriptor, 4 bytes reserved, one
+// byte each for primaries, transfer, matrix, range.
+static constexpr size_t kCicpTagSize = 12;
+
 static constexpr uint32_t kDisplay_Profile = SetFourByteTag('m', 'n', 't', 'r');
 static constexpr uint32_t kRGB_ColorSpace = SetFourByteTag('R', 'G', 'B', ' ');
 static constexpr uint32_t kXYZ_PCSSpace = SetFourByteTag('X', 'Y', 'Z', ' ');
@@ -149,10 +153,12 @@ static constexpr Matrix3x3 kRec2020 = {{
     {-0.00193139f, 0.0299794f, 0.797162f},
 }};
 
+static constexpr uint32_t kCICPPrimariesUnSpecified = 2;
 static constexpr uint32_t kCICPPrimariesSRGB = 1;
 static constexpr uint32_t kCICPPrimariesP3 = 12;
 static constexpr uint32_t kCICPPrimariesRec2020 = 9;
 
+static constexpr uint32_t kCICPTrfnUnSpecified = 2;
 static constexpr uint32_t kCICPTrfnSRGB = 1;
 static constexpr uint32_t kCICPTrfnLinear = 8;
 static constexpr uint32_t kCICPTrfnPQ = 16;
@@ -238,7 +244,7 @@ struct ICCHeader {
 class IccHelper {
  private:
   static constexpr uint32_t kTrcTableSize = 65;
-  static constexpr uint32_t kGridSize = 17;
+  static constexpr uint32_t kGridSize = 11;
   static constexpr size_t kNumChannels = 3;
 
   static std::shared_ptr<DataStruct> write_text_tag(const char* text);

--- a/lib/include/ultrahdr/ultrahdrcommon.h
+++ b/lib/include/ultrahdr/ultrahdrcommon.h
@@ -159,6 +159,8 @@
 
 static const uhdr_error_info_t g_no_error = {UHDR_CODEC_OK, 0, ""};
 
+static const int UHDR_CG_BT_601 = 3; /**< BT.601 */
+
 namespace ultrahdr {
 
 // ===============================================================================================

--- a/lib/src/dsp/arm/gainmapmath_neon.cpp
+++ b/lib/src/dsp/arm/gainmapmath_neon.cpp
@@ -35,11 +35,18 @@ namespace ultrahdr {
 // {Y1, Y2, U1, U2, V1, V2, 0, 0}
 
 // Yuv Bt709 -> Yuv Bt601
-// Y' = (1.0f * Y) + ( 0.101579f * U) + ( 0.196076f * V)
-// U' = (0.0f * Y) + ( 0.989854f * U) + (-0.110653f * V)
-// V' = (0.0f * Y) + (-0.072453f * U) + ( 0.983398f * V)
+// Y' = (1.0 * Y) + ( 0.101579 * U) + ( 0.196076 * V)
+// U' = (0.0 * Y) + ( 0.989854 * U) + (-0.110653 * V)
+// V' = (0.0 * Y) + (-0.072453 * U) + ( 0.983398 * V)
 ALIGNED(16)
 const int16_t kYuv709To601_coeffs_neon[8] = {1664, 3213, 16218, -1813, -1187, 16112, 0, 0};
+
+// Yuv Bt709 -> Display P3
+// Y' = (1.0 * Y) + ( 0.017545 * U) + ( 0.03677 * V)
+// U' = (0.0 * Y) + ( 0.998169 * U) + (-0.019968 * V)
+// V' = (0.0 * Y) + (-0.011378 * U) + ( 0.997393 * V)
+ALIGNED(16)
+const int16_t kYuv709ToP3_coeffs_neon[8] = {287, 602, 16354, -327, -186, 16341, 0, 0};
 
 // Yuv Bt709 -> Yuv Bt2100
 // Y' = (1.0f * Y) + (-0.016969f * U) + ( 0.096312f * V)
@@ -48,33 +55,47 @@ const int16_t kYuv709To601_coeffs_neon[8] = {1664, 3213, 16218, -1813, -1187, 16
 ALIGNED(16)
 const int16_t kYuv709To2100_coeffs_neon[8] = {-278, 1578, 16307, -839, 189, 16427, 0, 0};
 
-// Yuv Bt601 -> Yuv Bt709
-// Y' = (1.0f * Y) + (-0.118188f * U) + (-0.212685f * V),
-// U' = (0.0f * Y) + ( 1.018640f * U) + ( 0.114618f * V),
-// V' = (0.0f * Y) + ( 0.075049f * U) + ( 1.025327f * V);
+// Yuv Display P3 -> Yuv Bt601
+// Y' = (1.0 * Y) + ( 0.086028 * U) + ( 0.161445 * V)
+// U' = (0.0 * Y) + ( 0.990631 * U) + (-0.091109 * V)
+// V' = (0.0 * Y) + (-0.061361 * U) + ( 0.98474 * V)
 ALIGNED(16)
-const int16_t kYuv601To709_coeffs_neon[8] = {-1936, -3485, 16689, 1878, 1230, 16799, 0, 0};
+const int16_t kYuvP3To601_coeffs_neon[8] = {1409, 2645, 16230, -1493, -1005, 16134, 0, 0};
 
-// Yuv Bt601 -> Yuv Bt2100
-// Y' = (1.0f * Y) + (-0.128245f * U) + (-0.115879f * V)
-// U' = (0.0f * Y) + ( 1.010016f * U) + ( 0.061592f * V)
-// V' = (0.0f * Y) + ( 0.086969f * U) + ( 1.029350f * V)
+// Yuv Display P3 -> Yuv Bt709
+// Y' = (1.0 * Y) + (-0.018002 * U) + (-0.037226 * V)
+// U' = (0.0 * Y) + ( 1.002063 * U) + ( 0.020061 * V)
+// V' = (0.0 * Y) + ( 0.011431 * U) + ( 1.002843 * V)
 ALIGNED(16)
-const int16_t kYuv601To2100_coeffs_neon[8] = {-2101, -1899, 16548, 1009, 1425, 16865, 0, 0};
+const int16_t kYuvP3To709_coeffs_neon[8] = {-295, -610, 16418, 329, 187, 16431, 0, 0};
+
+// Yuv Display P3 -> Yuv Bt2100
+// Y' = (1.0 * Y) + (-0.033905 * U) + ( 0.059019 * V)
+// U' = (0.0 * Y) + ( 0.996774 * U) + ( -0.03137 * V)
+// V' = (0.0 * Y) + ( 0.022992 * U) + ( 1.005718 * V)
+ALIGNED(16)
+const int16_t kYuvP3To2100_coeffs_neon[8] = {-555, 967, 16331, -514, 377, 16478, 0, 0};
+
+// Yuv Bt2100 -> Yuv Bt601
+// Y' = (1.0 * Y) + ( 0.117887 * U) + ( 0.105521 * V)
+// U' = (0.0 * Y) + ( 0.995211 * U) + (-0.059549 * V)
+// V' = (0.0 * Y) + (-0.084085 * U) + ( 0.976518 * V)
+ALIGNED(16)
+const int16_t kYuv2100To601_coeffs_neon[8] = {1931, 1729, 16306, -976, -1378, 15999, 0, 0};
 
 // Yuv Bt2100 -> Yuv Bt709
-// Y' = (1.0f * Y) + ( 0.018149f * U) + (-0.095132f * V)
-// U' = (0.0f * Y) + ( 1.004123f * U) + ( 0.051267f * V)
-// V' = (0.0f * Y) + (-0.011524f * U) + ( 0.996782f * V)
+// Y' = (1.0 * Y) + ( 0.018149 * U) + (-0.095132 * V)
+// U' = (0.0 * Y) + ( 1.004123 * U) + ( 0.051267 * V)
+// V' = (0.0 * Y) + (-0.011524 * U) + ( 0.996782 * V)
 ALIGNED(16)
 const int16_t kYuv2100To709_coeffs_neon[8] = {297, -1559, 16452, 840, -189, 16331, 0, 0};
 
-// Yuv Bt2100 -> Yuv Bt601
-// Y' = (1.0f * Y) + ( 0.117887f * U) + ( 0.105521f * V)
-// U' = (0.0f * Y) + ( 0.995211f * U) + (-0.059549f * V)
-// V' = (0.0f * Y) + (-0.084085f * U) + ( 0.976518f * V)
+// Yuv Bt2100 -> Yuv Display P3
+// Y' = (1.0 * Y) + ( 0.035343 * U) + ( -0.057581 * V)
+// U' = (0.0 * Y) + ( 1.002515 * U) + ( 0.03127 * V)
+// V' = (0.0 * Y) + (-0.022919 * U) + ( 0.9936 * V)
 ALIGNED(16)
-const int16_t kYuv2100To601_coeffs_neon[8] = {1931, 1729, 16306, -976, -1378, 15999, 0, 0};
+const int16_t kYuv2100ToP3_coeffs_neon[8] = {579, -943, 16425, 512, -376, 16279, 0, 0};
 
 static inline int16x8_t yConversion_neon(uint8x8_t y, int16x8_t u, int16x8_t v, int16x8_t coeffs) {
   int32x4_t lo = vmull_lane_s16(vget_low_s16(u), vget_low_s16(coeffs), 0);
@@ -240,11 +261,14 @@ uhdr_error_info_t convertYuv_neon(uhdr_raw_image_t* image, uhdr_color_gamut_t sr
 
   switch (src_encoding) {
     case UHDR_CG_BT_709:
-      switch (dst_encoding) {
+      switch ((int)dst_encoding) {
+        case UHDR_CG_BT_601:
+          coeffs = kYuv709To601_coeffs_neon;
+          break;
         case UHDR_CG_BT_709:
           return status;
         case UHDR_CG_DISPLAY_P3:
-          coeffs = kYuv709To601_coeffs_neon;
+          coeffs = kYuv709ToP3_coeffs_neon;
           break;
         case UHDR_CG_BT_2100:
           coeffs = kYuv709To2100_coeffs_neon;
@@ -258,14 +282,17 @@ uhdr_error_info_t convertYuv_neon(uhdr_raw_image_t* image, uhdr_color_gamut_t sr
       }
       break;
     case UHDR_CG_DISPLAY_P3:
-      switch (dst_encoding) {
+      switch ((int)dst_encoding) {
+        case UHDR_CG_BT_601:
+          coeffs = kYuvP3To601_coeffs_neon;
+          break;
         case UHDR_CG_BT_709:
-          coeffs = kYuv601To709_coeffs_neon;
+          coeffs = kYuvP3To709_coeffs_neon;
           break;
         case UHDR_CG_DISPLAY_P3:
           return status;
         case UHDR_CG_BT_2100:
-          coeffs = kYuv601To2100_coeffs_neon;
+          coeffs = kYuvP3To2100_coeffs_neon;
           break;
         default:
           status.error_code = UHDR_CODEC_INVALID_PARAM;
@@ -276,12 +303,15 @@ uhdr_error_info_t convertYuv_neon(uhdr_raw_image_t* image, uhdr_color_gamut_t sr
       }
       break;
     case UHDR_CG_BT_2100:
-      switch (dst_encoding) {
+      switch ((int)dst_encoding) {
+        case UHDR_CG_BT_601:
+          coeffs = kYuv2100To601_coeffs_neon;
+          break;
         case UHDR_CG_BT_709:
           coeffs = kYuv2100To709_coeffs_neon;
           break;
         case UHDR_CG_DISPLAY_P3:
-          coeffs = kYuv2100To601_coeffs_neon;
+          coeffs = kYuv2100ToP3_coeffs_neon;
           break;
         case UHDR_CG_BT_2100:
           return status;

--- a/lib/src/icc.cpp
+++ b/lib/src/icc.cpp
@@ -602,7 +602,7 @@ std::shared_ptr<DataStruct> IccHelper::writeIccProfile(uhdr_color_transfer_t tf,
 
 bool IccHelper::tagsEqualToMatrix(const Matrix3x3& matrix, const uint8_t* red_tag,
                                   const uint8_t* green_tag, const uint8_t* blue_tag) {
-  const float tolerance = 0.001;
+  const float tolerance = 0.001f;
   Fixed r_x_fixed = Endian_SwapBE32(reinterpret_cast<int32_t*>(const_cast<uint8_t*>(red_tag))[2]);
   Fixed r_y_fixed = Endian_SwapBE32(reinterpret_cast<int32_t*>(const_cast<uint8_t*>(red_tag))[3]);
   Fixed r_z_fixed = Endian_SwapBE32(reinterpret_cast<int32_t*>(const_cast<uint8_t*>(red_tag))[4]);

--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -49,7 +49,7 @@ namespace ultrahdr {
 uhdr_error_info_t applyGainMapGLES(uhdr_raw_image_t* sdr_intent, uhdr_raw_image_t* gainmap_img,
                                    uhdr_gainmap_metadata_ext_t* gainmap_metadata,
                                    uhdr_color_transfer_t output_ct, float display_boost,
-                                   uhdr_raw_image_t* dest, uhdr_opengl_ctxt_t* opengl_ctxt);
+                                   uhdr_opengl_ctxt_t* opengl_ctxt);
 #endif
 
 // Gain map metadata
@@ -552,7 +552,9 @@ uhdr_error_info_t JpegR::convertYuv(uhdr_raw_image_t* image, uhdr_color_gamut_t 
 
 uhdr_error_info_t JpegR::compressGainMap(uhdr_raw_image_t* gainmap_img,
                                          JpegEncoderHelper* jpeg_enc_obj) {
-  return jpeg_enc_obj->compressImage(gainmap_img, mMapCompressQuality, nullptr, 0);
+  std::shared_ptr<DataStruct> icc = IccHelper::writeIccProfile(gainmap_img->ct, gainmap_img->cg);
+  return jpeg_enc_obj->compressImage(gainmap_img, mMapCompressQuality, icc->getData(),
+                                     icc->getLength());
 }
 
 uhdr_error_info_t JpegR::generateGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_image_t* hdr_intent,
@@ -719,7 +721,7 @@ uhdr_error_info_t JpegR::generateGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_
 
   gainmap_img = std::make_unique<uhdr_raw_image_ext_t>(
       mUseMultiChannelGainMap ? UHDR_IMG_FMT_24bppRGB888 : UHDR_IMG_FMT_8bppYCbCr400,
-      UHDR_CG_UNSPECIFIED, UHDR_CT_UNSPECIFIED, UHDR_CR_UNSPECIFIED, map_width, map_height, 64);
+      hdr_intent->cg, hdr_intent->ct, hdr_intent->range, map_width, map_height, 64);
   uhdr_raw_image_ext_t* dest = gainmap_img.get();
 
   auto generateGainMapOnePass = [this, sdr_intent, hdr_intent, gainmap_metadata, dest, map_height,
@@ -1380,6 +1382,8 @@ uhdr_error_info_t JpegR::decodeJPEGR(uhdr_compressed_image_t* uhdr_compressed_im
     if (gainmap_img != nullptr) {
       UHDR_ERR_CHECK(copy_raw_image(&gainmap, gainmap_img));
     }
+    gainmap.cg =
+        IccHelper::readIccColorGamut(jpeg_dec_obj_gm.getICCPtr(), jpeg_dec_obj_gm.getICCSize());
   }
 
   uhdr_gainmap_metadata_ext_t uhdr_metadata;
@@ -1455,6 +1459,13 @@ uhdr_error_info_t JpegR::applyGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_ima
     return status;
   }
 
+  uhdr_color_gamut_t base_cg =
+      sdr_intent->cg == UHDR_CG_UNSPECIFIED ? UHDR_CG_BT_709 : sdr_intent->cg;
+  uhdr_color_gamut_t gainmap_cg =
+      gainmap_img->cg == UHDR_CG_UNSPECIFIED ? base_cg : gainmap_img->cg;
+  ColorTransformFn hdrGamutConversionFn = getGamutConversionFn(gainmap_cg, base_cg);
+  dest->cg = gainmap_cg;
+
 #ifdef UHDR_ENABLE_GLES
   if (mUhdrGLESCtxt != nullptr) {
     if (((sdr_intent->fmt == UHDR_IMG_FMT_12bppYCbCr420 && sdr_intent->w % 2 == 0 &&
@@ -1468,7 +1479,7 @@ uhdr_error_info_t JpegR::applyGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_ima
       float display_boost = (std::min)(max_display_boost, gainmap_metadata->hdr_capacity_max);
 
       return applyGainMapGLES(sdr_intent, gainmap_img, gainmap_metadata, output_ct, display_boost,
-                              dest, static_cast<uhdr_opengl_ctxt_t*>(mUhdrGLESCtxt));
+                              static_cast<uhdr_opengl_ctxt_t*>(mUhdrGLESCtxt));
     }
   }
 #endif
@@ -1498,7 +1509,6 @@ uhdr_error_info_t JpegR::applyGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_ima
   float map_scale_factor = (float)sdr_intent->w / gainmap_img->w;
   int map_scale_factor_rnd = (std::max)(1, (int)std::roundf(map_scale_factor));
 
-  dest->cg = sdr_intent->cg == UHDR_CG_UNSPECIFIED ? UHDR_CG_BT_709 : sdr_intent->cg;
   // Table will only be used when map scale factor is integer.
   ShepardsIDW idwTable(map_scale_factor_rnd);
   float display_boost = (std::min)(max_display_boost, gainmap_metadata->hdr_capacity_max);
@@ -1533,7 +1543,7 @@ uhdr_error_info_t JpegR::applyGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_ima
 
   JobQueue jobQueue;
   std::function<void()> applyRecMap = [sdr_intent, gainmap_img, dest, &jobQueue, &idwTable,
-                                       output_ct, &gainLUT, gainmap_metadata,
+                                       output_ct, &gainLUT, gainmap_metadata, hdrGamutConversionFn,
 #if !USE_APPLY_GAIN_LUT
                                        gainmap_weight,
 #endif
@@ -1589,6 +1599,8 @@ uhdr_error_info_t JpegR::applyGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_ima
 
           switch (output_ct) {
             case UHDR_CT_LINEAR: {
+              rgb_hdr = hdrGamutConversionFn(rgb_hdr);
+              rgb_hdr = clampPixelFloatLinear(rgb_hdr);
               uint64_t rgba_f16 = colorToRgbaF16(rgb_hdr);
               reinterpret_cast<uint64_t*>(dest->planes[UHDR_PLANE_PACKED])[pixel_idx] = rgba_f16;
               break;
@@ -1600,6 +1612,8 @@ uhdr_error_info_t JpegR::applyGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_ima
               ColorTransformFn hdrOetf = hlgOetf;
 #endif
               rgb_hdr = rgb_hdr * kSdrWhiteNits / kHlgMaxNits;
+              rgb_hdr = hdrGamutConversionFn(rgb_hdr);
+              rgb_hdr = clampPixelFloat(rgb_hdr);
               rgb_hdr = hlgInverseOotfApprox(rgb_hdr);
               Color rgb_gamma_hdr = hdrOetf(rgb_hdr);
               uint32_t rgba_1010102 = colorToRgba1010102(rgb_gamma_hdr);
@@ -1614,6 +1628,8 @@ uhdr_error_info_t JpegR::applyGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_ima
               ColorTransformFn hdrOetf = pqOetf;
 #endif
               rgb_hdr = rgb_hdr * kSdrWhiteNits / kPqMaxNits;
+              rgb_hdr = hdrGamutConversionFn(rgb_hdr);
+              rgb_hdr = clampPixelFloat(rgb_hdr);
               Color rgb_gamma_hdr = hdrOetf(rgb_hdr);
               uint32_t rgba_1010102 = colorToRgba1010102(rgb_gamma_hdr);
               reinterpret_cast<uint32_t*>(dest->planes[UHDR_PLANE_PACKED])[pixel_idx] =

--- a/tests/gainmapmath_test.cpp
+++ b/tests/gainmapmath_test.cpp
@@ -91,9 +91,9 @@ class GainMapMathTest : public testing::Test {
   Color SrgbYuvGreen() { return {{{0.7152f, -0.38543f, -0.45415f}}}; }
   Color SrgbYuvBlue() { return {{{0.0722f, 0.5f, -0.04585f}}}; }
 
-  Color P3YuvRed() { return {{{0.299f, -0.16874f, 0.5f}}}; }
-  Color P3YuvGreen() { return {{{0.587f, -0.33126f, -0.41869f}}}; }
-  Color P3YuvBlue() { return {{{0.114f, 0.5f, -0.08131f}}}; }
+  Color P3YuvRed() { return {{{0.229f, -0.124362f, 0.5f}}}; }
+  Color P3YuvGreen() { return {{{0.6917f, -0.375638f, -0.448573f}}}; }
+  Color P3YuvBlue() { return {{{0.0793f, 0.5f, -0.051427f}}}; }
 
   Color Bt2100YuvRed() { return {{{0.2627f, -0.13963f, 0.5f}}}; }
   Color Bt2100YuvGreen() { return {{{0.6780f, -0.36037f, -0.45979f}}}; }
@@ -116,9 +116,9 @@ class GainMapMathTest : public testing::Test {
   Pixel SrgbYuvGreenPixel() { return {182, -98, -116}; }
   Pixel SrgbYuvBluePixel() { return {18, 128, -12}; }
 
-  Pixel P3YuvRedPixel() { return {76, -43, 128}; }
-  Pixel P3YuvGreenPixel() { return {150, -84, -107}; }
-  Pixel P3YuvBluePixel() { return {29, 128, -21}; }
+  Pixel P3YuvRedPixel() { return {58, -32, 128}; }
+  Pixel P3YuvGreenPixel() { return {176, -96, -114}; }
+  Pixel P3YuvBluePixel() { return {20, 128, -13}; }
 
   Pixel Bt2100YuvRedPixel() { return {67, -36, 128}; }
   Pixel Bt2100YuvGreenPixel() { return {173, -92, -117}; }
@@ -540,9 +540,9 @@ TEST_F(GainMapMathTest, ColorDivideFloat) {
 TEST_F(GainMapMathTest, SrgbLuminance) {
   EXPECT_FLOAT_EQ(srgbLuminance(RgbBlack()), 0.0f);
   EXPECT_FLOAT_EQ(srgbLuminance(RgbWhite()), 1.0f);
-  EXPECT_FLOAT_EQ(srgbLuminance(RgbRed()), 0.2126f);
-  EXPECT_FLOAT_EQ(srgbLuminance(RgbGreen()), 0.7152f);
-  EXPECT_FLOAT_EQ(srgbLuminance(RgbBlue()), 0.0722f);
+  EXPECT_FLOAT_EQ(srgbLuminance(RgbRed()), 0.212639f);
+  EXPECT_FLOAT_EQ(srgbLuminance(RgbGreen()), 0.715169f);
+  EXPECT_FLOAT_EQ(srgbLuminance(RgbBlue()), 0.072192f);
 }
 
 TEST_F(GainMapMathTest, SrgbYuvToRgb) {
@@ -607,9 +607,9 @@ TEST_F(GainMapMathTest, SrgbTransferFunction) {
 TEST_F(GainMapMathTest, P3Luminance) {
   EXPECT_FLOAT_EQ(p3Luminance(RgbBlack()), 0.0f);
   EXPECT_FLOAT_EQ(p3Luminance(RgbWhite()), 1.0f);
-  EXPECT_FLOAT_EQ(p3Luminance(RgbRed()), 0.20949f);
-  EXPECT_FLOAT_EQ(p3Luminance(RgbGreen()), 0.72160f);
-  EXPECT_FLOAT_EQ(p3Luminance(RgbBlue()), 0.06891f);
+  EXPECT_FLOAT_EQ(p3Luminance(RgbRed()), 0.2289746f);
+  EXPECT_FLOAT_EQ(p3Luminance(RgbGreen()), 0.6917385f);
+  EXPECT_FLOAT_EQ(p3Luminance(RgbBlue()), 0.0792869f);
 }
 
 TEST_F(GainMapMathTest, P3YuvToRgb) {
@@ -666,8 +666,8 @@ TEST_F(GainMapMathTest, Bt2100Luminance) {
   EXPECT_FLOAT_EQ(bt2100Luminance(RgbBlack()), 0.0f);
   EXPECT_FLOAT_EQ(bt2100Luminance(RgbWhite()), 1.0f);
   EXPECT_FLOAT_EQ(bt2100Luminance(RgbRed()), 0.2627f);
-  EXPECT_FLOAT_EQ(bt2100Luminance(RgbGreen()), 0.6780f);
-  EXPECT_FLOAT_EQ(bt2100Luminance(RgbBlue()), 0.0593f);
+  EXPECT_FLOAT_EQ(bt2100Luminance(RgbGreen()), 0.677998f);
+  EXPECT_FLOAT_EQ(bt2100Luminance(RgbBlue()), 0.059302f);
 }
 
 TEST_F(GainMapMathTest, Bt2100YuvToRgb) {
@@ -740,12 +740,12 @@ TEST_F(GainMapMathTest, YuvColorGamutConversion) {
                               const std::array<Color, 5>>,
                    6>
       coeffs_setup_expected{{
-          {kYuvBt709ToBt601, SrgbYuvColors, P3YuvColors},
+          {kYuvBt709ToDisplayP3, SrgbYuvColors, P3YuvColors},
           {kYuvBt709ToBt2100, SrgbYuvColors, Bt2100YuvColors},
-          {kYuvBt601ToBt709, P3YuvColors, SrgbYuvColors},
-          {kYuvBt601ToBt2100, P3YuvColors, Bt2100YuvColors},
+          {kYuvDisplayP3ToBt709, P3YuvColors, SrgbYuvColors},
+          {kYuvDisplayP3ToBt2100, P3YuvColors, Bt2100YuvColors},
           {kYuvBt2100ToBt709, Bt2100YuvColors, SrgbYuvColors},
-          {kYuvBt2100ToBt601, Bt2100YuvColors, P3YuvColors},
+          {kYuvBt2100ToDisplayP3, Bt2100YuvColors, P3YuvColors},
       }};
 
   for (const auto& [coeffs, input, expected] : coeffs_setup_expected) {
@@ -788,12 +788,12 @@ TEST_F(GainMapMathTest, YuvConversionNeon) {
   const std::array<
       std::tuple<const int16_t*, const std::array<Pixel, 5>, const std::array<Pixel, 5>>, 6>
       coeffs_setup_correct{{
-          {kYuv709To601_coeffs_neon, SrgbYuvColors, P3YuvColors},
+          {kYuv709ToP3_coeffs_neon, SrgbYuvColors, P3YuvColors},
           {kYuv709To2100_coeffs_neon, SrgbYuvColors, Bt2100YuvColors},
-          {kYuv601To709_coeffs_neon, P3YuvColors, SrgbYuvColors},
-          {kYuv601To2100_coeffs_neon, P3YuvColors, Bt2100YuvColors},
+          {kYuvP3To709_coeffs_neon, P3YuvColors, SrgbYuvColors},
+          {kYuvP3To2100_coeffs_neon, P3YuvColors, Bt2100YuvColors},
           {kYuv2100To709_coeffs_neon, Bt2100YuvColors, SrgbYuvColors},
-          {kYuv2100To601_coeffs_neon, Bt2100YuvColors, P3YuvColors},
+          {kYuv2100ToP3_coeffs_neon, Bt2100YuvColors, P3YuvColors},
       }};
 
   for (const auto& [coeff_ptr, input, expected] : coeffs_setup_correct) {
@@ -889,8 +889,8 @@ TEST_F(GainMapMathTest, TransformYuv420) {
   uint8_t* cr = cb + input.w * input.h / 4;
 
   const std::array<std::array<float, 9>, 6> conversion_coeffs = {
-      kYuvBt709ToBt601,  kYuvBt709ToBt2100, kYuvBt601ToBt709,
-      kYuvBt601ToBt2100, kYuvBt2100ToBt709, kYuvBt2100ToBt601};
+      kYuvBt709ToDisplayP3,  kYuvBt709ToBt2100, kYuvDisplayP3ToBt709,
+      kYuvDisplayP3ToBt2100, kYuvBt2100ToBt709, kYuvBt2100ToDisplayP3};
 
   for (size_t coeffs_idx = 0; coeffs_idx < conversion_coeffs.size(); ++coeffs_idx) {
     auto output = Yuv420Image();
@@ -958,12 +958,12 @@ TEST_F(GainMapMathTest, TransformYuv420) {
 #if (defined(UHDR_ENABLE_INTRINSICS) && (defined(__ARM_NEON__) || defined(__ARM_NEON)))
 TEST_F(GainMapMathTest, TransformYuv420Neon) {
   const std::array<std::pair<const int16_t*, const std::array<float, 9>>, 6> fixed_floating_coeffs{
-      {{kYuv709To601_coeffs_neon, kYuvBt709ToBt601},
+      {{kYuv709ToP3_coeffs_neon, kYuvBt709ToDisplayP3},
        {kYuv709To2100_coeffs_neon, kYuvBt709ToBt2100},
-       {kYuv601To709_coeffs_neon, kYuvBt601ToBt709},
-       {kYuv601To2100_coeffs_neon, kYuvBt601ToBt2100},
+       {kYuvP3To709_coeffs_neon, kYuvDisplayP3ToBt709},
+       {kYuvP3To2100_coeffs_neon, kYuvDisplayP3ToBt2100},
        {kYuv2100To709_coeffs_neon, kYuvBt2100ToBt709},
-       {kYuv2100To601_coeffs_neon, kYuvBt2100ToBt601}}};
+       {kYuv2100ToP3_coeffs_neon, kYuvBt2100ToDisplayP3}}};
 
   for (const auto& [neon_coeffs_ptr, floating_point_coeffs] : fixed_floating_coeffs) {
     uhdr_raw_image_t input = Yuv420Image32x4();

--- a/tests/jpegr_test.cpp
+++ b/tests/jpegr_test.cpp
@@ -96,6 +96,7 @@ class UhdrCompressedStructWrapper {
   ~UhdrCompressedStructWrapper() = default;
 
   bool allocateMemory();
+  bool setImageColorGamut(ultrahdr_color_gamut colorGamut);
   jr_compressed_ptr getImageHandle();
 
  private:
@@ -272,6 +273,11 @@ bool UhdrCompressedStructWrapper::allocateMemory() {
   mImg.data = mData.get();
   mImg.length = 0;
   mImg.maxLength = maxLength;
+  return true;
+}
+
+bool UhdrCompressedStructWrapper::setImageColorGamut(ultrahdr_color_gamut colorGamut) {
+  mImg.colorGamut = colorGamut;
   return true;
 }
 
@@ -1852,6 +1858,7 @@ TEST_P(JpegRAPIEncodeAndDecodeTest, EncodeAPI2AndDecodeTest) {
   ASSERT_TRUE(jpgImg.allocateMemory());
   UhdrCompressedStructWrapper jpgSdr(kImageWidth, kImageHeight);
   ASSERT_TRUE(jpgSdr.allocateMemory());
+  ASSERT_TRUE(jpgSdr.setImageColorGamut(mYuv420ColorGamut));
   auto sdr = jpgSdr.getImageHandle();
   ASSERT_TRUE(readFile(kSdrJpgFileName, sdr->data, sdr->maxLength, sdr->length));
   JpegR uHdrLib;
@@ -2054,6 +2061,7 @@ TEST_P(JpegRAPIEncodeAndDecodeTest, EncodeAPI3AndDecodeTest) {
   ASSERT_TRUE(jpgImg.allocateMemory());
   UhdrCompressedStructWrapper jpgSdr(kImageWidth, kImageHeight);
   ASSERT_TRUE(jpgSdr.allocateMemory());
+  ASSERT_TRUE(jpgSdr.setImageColorGamut(mYuv420ColorGamut));
   auto sdr = jpgSdr.getImageHandle();
   ASSERT_TRUE(readFile(kSdrJpgFileName, sdr->data, sdr->maxLength, sdr->length));
   JpegR uHdrLib;


### PR DESCRIPTION
- luminance function for p3 gamut is using weights of DCI P3 instead of Display P3. This is corrected. Accordingly, the gamut conversions involving Display P3 are updated.
- Increased precision of some constants used in csc, oetf and eotf functions.

Test: ./ultrahdr_unit_test