### PR TITLE
ossfuzz.sh: Opt out of shift sanitizer

### DIFF
--- a/fuzzer/ossfuzz.sh
+++ b/fuzzer/ossfuzz.sh
@@ -17,6 +17,12 @@
 test "${SRC}" != "" || exit 1
 test "${WORK}" != "" || exit 1
 
+#Opt out of shift sanitizer in undefined sanitizer
+if [[ $SANITIZER = *undefined* ]]; then
+  CFLAGS="$CFLAGS -fno-sanitize=shift"
+  CXXFLAGS="$CXXFLAGS -fno-sanitize=shift"
+fi
+
 # Build libultrahdr
 build_dir=$WORK/build
 rm -rf ${build_dir}


### PR DESCRIPTION
Shift sanitizer flags a few failures that prevent further fuzzing with other undefined behavior sanitizers enabled.
Disable shift sanitizer till the library is updated to avoid these undefined shift sanitizer issues.