### PR TITLE
Improve rgb input handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 cmake_minimum_required(VERSION 3.13)
 
-project(libuhdr VERSION 1.8 LANGUAGES C CXX
+project(libuhdr VERSION 1.1.0 LANGUAGES C CXX
         DESCRIPTION "Library for encoding and decoding ultrahdr images")
 
 ###########################################################
@@ -617,7 +617,10 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Android")
   target_link_libraries(${UHDR_TARGET_NAME} PRIVATE ${log-lib})
 endif()
 target_link_libraries(${UHDR_TARGET_NAME} PRIVATE ${JPEG_LIBRARIES})
-set_target_properties(${UHDR_TARGET_NAME} PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR} PUBLIC_HEADER ultrahdr_api.h)
+set_target_properties(${UHDR_TARGET_NAME}
+                      PROPERTIES VERSION ${PROJECT_VERSION}
+                      SOVERSION ${PROJECT_VERSION_MAJOR}
+                      PUBLIC_HEADER ultrahdr_api.h)
 combine_static_libs(${UHDR_CORE_LIB_NAME} ${UHDR_TARGET_NAME})
 
 if(UHDR_ENABLE_INSTALL)

--- a/lib/include/ultrahdr/gainmapmath.h
+++ b/lib/include/ultrahdr/gainmapmath.h
@@ -71,6 +71,7 @@ typedef Color (*ColorTransformFn)(Color);
 typedef float (*ColorCalculationFn)(Color);
 typedef Color (*GetPixelFn)(uhdr_raw_image_t*, size_t, size_t);
 typedef Color (*SamplePixelFn)(uhdr_raw_image_t*, size_t, size_t, size_t);
+typedef void (*PutPixelFn)(uhdr_raw_image_t*, size_t, size_t, Color&);
 
 static inline float clampPixelFloat(float value) {
   return (value < 0.0f) ? 0.0f : (value > kMaxPixelFloat) ? kMaxPixelFloat : value;
@@ -480,6 +481,16 @@ GetPixelFn getPixelFn(uhdr_img_fmt_t format);
 SamplePixelFn getSamplePixelFn(uhdr_img_fmt_t format);
 
 /*
+ * Get function to put pixels to raw image for a given color format
+ */
+PutPixelFn putPixelFn(uhdr_img_fmt_t format);
+
+/*
+ * Returns true if the pixel format is rgb
+ */
+bool isPixelFormatRgb(uhdr_img_fmt_t format);
+
+/*
  * Get max display mastering luminance in nits
  */
 float getMaxDisplayMasteringLuminance(uhdr_color_transfer_t transfer);
@@ -572,6 +583,8 @@ Color getYuv422Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
 Color getYuv420Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
 Color getP010Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
 Color getYuv444Pixel10bit(uhdr_raw_image_t* image, size_t x, size_t y);
+Color getRgba8888Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
+Color getRgba1010102Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
 
 /*
  * Sample the image at the provided location, with a weighting based on nearby
@@ -582,6 +595,14 @@ Color sampleYuv422(uhdr_raw_image_t* map, size_t map_scale_factor, size_t x, siz
 Color sampleYuv420(uhdr_raw_image_t* map, size_t map_scale_factor, size_t x, size_t y);
 Color sampleP010(uhdr_raw_image_t* map, size_t map_scale_factor, size_t x, size_t y);
 Color sampleYuv44410bit(uhdr_raw_image_t* image, size_t map_scale_factor, size_t x, size_t y);
+Color sampleRgba8888(uhdr_raw_image_t* image, size_t map_scale_factor, size_t x, size_t y);
+Color sampleRgba1010102(uhdr_raw_image_t* image, size_t map_scale_factor, size_t x, size_t y);
+
+/*
+ * Put pixel in the image at the provided location.
+ */
+void putRgba8888Pixel(uhdr_raw_image_t* image, size_t x, size_t y, Color& pixel);
+void putYuv444Pixel(uhdr_raw_image_t* image, size_t x, size_t y, Color& pixel);
 
 /*
  * Sample the gain value for the map from a given x,y coordinate on a scale
@@ -612,6 +633,7 @@ uint64_t colorToRgbaF16(Color e_gamma);
 /*
  * Helper for copying raw image descriptor
  */
+std::unique_ptr<uhdr_raw_image_ext_t> copy_raw_image(uhdr_raw_image_t* src);
 uhdr_error_info_t copy_raw_image(uhdr_raw_image_t* src, uhdr_raw_image_t* dst);
 
 /*

--- a/lib/src/gpu/applygainmap_gl.cpp
+++ b/lib/src/gpu/applygainmap_gl.cpp
@@ -235,8 +235,9 @@ bool isBufferDataContiguous(uhdr_raw_image_t* img) {
     uint16_t* y = static_cast<uint16_t*>(img->planes[UHDR_PLANE_Y]);
     uint16_t* u = static_cast<uint16_t*>(img->planes[UHDR_PLANE_UV]);
     std::ptrdiff_t sz = u - y;
+    long pixels = img->w * img->h;
     return img->stride[UHDR_PLANE_Y] == img->w && img->stride[UHDR_PLANE_UV] == img->w &&
-           sz == img->w * img->h;
+           sz == pixels;
   } else if (img->fmt == UHDR_IMG_FMT_12bppYCbCr420 || img->fmt == UHDR_IMG_FMT_24bppYCbCr444 ||
              img->fmt == UHDR_IMG_FMT_16bppYCbCr422) {
     int h_samp_factor = img->fmt == UHDR_IMG_FMT_24bppYCbCr444 ? 1 : 2;
@@ -245,10 +246,11 @@ bool isBufferDataContiguous(uhdr_raw_image_t* img) {
     uint8_t* u = static_cast<uint8_t*>(img->planes[UHDR_PLANE_U]);
     uint8_t* v = static_cast<uint8_t*>(img->planes[UHDR_PLANE_V]);
     std::ptrdiff_t sz_a = u - y, sz_b = v - u;
+    long pixels = img->w * img->h;
     return img->stride[UHDR_PLANE_Y] == img->w &&
            img->stride[UHDR_PLANE_U] == img->w / h_samp_factor &&
-           img->stride[UHDR_PLANE_V] == img->w / h_samp_factor && sz_a == img->w * img->h &&
-           sz_b == img->w * img->h / (h_samp_factor * v_samp_factor);
+           img->stride[UHDR_PLANE_V] == img->w / h_samp_factor && sz_a == pixels &&
+           sz_b == pixels / (h_samp_factor * v_samp_factor);
   }
   return false;
 }

--- a/lib/src/gpu/uhdr_gl_utils.cpp
+++ b/lib/src/gpu/uhdr_gl_utils.cpp
@@ -93,12 +93,12 @@ GLuint uhdr_opengl_ctxt::compile_shader(GLenum type, const char* source) {
     // Info log length includes the null terminator, so 1 means that the info log is an empty
     // string.
     if (logLength > 1) {
-      char log[logLength];
-      glGetShaderInfoLog(shader, logLength, nullptr, log);
+      std::vector<char> log(logLength);
+      glGetShaderInfoLog(shader, logLength, nullptr, log.data());
       mErrorStatus.error_code = UHDR_CODEC_ERROR;
       mErrorStatus.has_detail = 1;
       snprintf(mErrorStatus.detail, sizeof mErrorStatus.detail,
-               "Unable to compile shader, error log: %s", log);
+               "Unable to compile shader, error log: %s", log.data());
     } else {
       mErrorStatus.error_code = UHDR_CODEC_ERROR;
       mErrorStatus.has_detail = 1;
@@ -160,12 +160,12 @@ GLuint uhdr_opengl_ctxt::create_shader_program(const char* vertex_source,
     // Info log length includes the null terminator, so 1 means that the info log is an empty
     // string.
     if (logLength > 1) {
-      char log[logLength];
-      glGetProgramInfoLog(program, logLength, nullptr, log);
+      std::vector<char> log(logLength);
+      glGetProgramInfoLog(program, logLength, nullptr, log.data());
       mErrorStatus.error_code = UHDR_CODEC_ERROR;
       mErrorStatus.has_detail = 1;
       snprintf(mErrorStatus.detail, sizeof mErrorStatus.detail,
-               "Unable to link shader program, error log: %s", log);
+               "Unable to link shader program, error log: %s", log.data());
     } else {
       mErrorStatus.error_code = UHDR_CODEC_ERROR;
       mErrorStatus.has_detail = 1;

--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -186,6 +186,8 @@ uhdr_error_info_t JpegR::encodeJPEGR(uhdr_raw_image_t* hdr_intent, uhdr_compress
     sdr_intent_fmt = UHDR_IMG_FMT_12bppYCbCr420;
   } else if (hdr_intent->fmt == UHDR_IMG_FMT_30bppYCbCr444) {
     sdr_intent_fmt = UHDR_IMG_FMT_24bppYCbCr444;
+  } else if (hdr_intent->fmt == UHDR_IMG_FMT_32bppRGBA1010102) {
+    sdr_intent_fmt = UHDR_IMG_FMT_32bppRGBA8888;
   } else {
     uhdr_error_info_t status;
     status.error_code = UHDR_CODEC_INVALID_PARAM;
@@ -220,11 +222,18 @@ uhdr_error_info_t JpegR::encodeJPEGR(uhdr_raw_image_t* hdr_intent, uhdr_compress
   std::shared_ptr<DataStruct> icc = IccHelper::writeIccProfile(UHDR_CT_SRGB, sdr_intent->cg);
 
   // compress sdr image
+  std::unique_ptr<uhdr_raw_image_ext_t> sdr_intent_yuv_ext;
+  uhdr_raw_image_t* sdr_intent_yuv = sdr_intent.get();
+  if (isPixelFormatRgb(sdr_intent->fmt)) {
+    sdr_intent_yuv_ext = convert_raw_input_to_ycbcr(sdr_intent.get());
+    sdr_intent_yuv = sdr_intent_yuv_ext.get();
+  }
+
   JpegEncoderHelper jpeg_enc_obj_sdr;
   UHDR_ERR_CHECK(
-      jpeg_enc_obj_sdr.compressImage(sdr_intent.get(), quality, icc->getData(), icc->getLength()));
+      jpeg_enc_obj_sdr.compressImage(sdr_intent_yuv, quality, icc->getData(), icc->getLength()));
   uhdr_compressed_image_t sdr_intent_compressed = jpeg_enc_obj_sdr.getCompressedImage();
-  sdr_intent_compressed.cg = sdr_intent->cg;
+  sdr_intent_compressed.cg = sdr_intent_yuv->cg;
 
   // append gain map, no ICC since JPEG encode already did it
   UHDR_ERR_CHECK(appendGainMap(&sdr_intent_compressed, &gainmap_compressed, exif, /* icc */ nullptr,
@@ -248,19 +257,26 @@ uhdr_error_info_t JpegR::encodeJPEGR(uhdr_raw_image_t* hdr_intent, uhdr_raw_imag
 
   std::shared_ptr<DataStruct> icc = IccHelper::writeIccProfile(UHDR_CT_SRGB, sdr_intent->cg);
 
+  std::unique_ptr<uhdr_raw_image_ext_t> sdr_intent_yuv_ext;
+  uhdr_raw_image_t* sdr_intent_yuv = sdr_intent;
+  if (isPixelFormatRgb(sdr_intent->fmt)) {
+    sdr_intent_yuv_ext = convert_raw_input_to_ycbcr(sdr_intent);
+    sdr_intent_yuv = sdr_intent_yuv_ext.get();
+  }
+
   // convert to bt601 YUV encoding for JPEG encode
 #if (defined(UHDR_ENABLE_INTRINSICS) && (defined(__ARM_NEON__) || defined(__ARM_NEON)))
-  UHDR_ERR_CHECK(convertYuv_neon(sdr_intent, sdr_intent->cg, UHDR_CG_DISPLAY_P3));
+  UHDR_ERR_CHECK(convertYuv_neon(sdr_intent_yuv, sdr_intent_yuv->cg, UHDR_CG_DISPLAY_P3));
 #else
-  UHDR_ERR_CHECK(convertYuv(sdr_intent, sdr_intent->cg, UHDR_CG_DISPLAY_P3));
+  UHDR_ERR_CHECK(convertYuv(sdr_intent_yuv, sdr_intent_yuv->cg, UHDR_CG_DISPLAY_P3));
 #endif
 
   // compress sdr image
   JpegEncoderHelper jpeg_enc_obj_sdr;
   UHDR_ERR_CHECK(
-      jpeg_enc_obj_sdr.compressImage(sdr_intent, quality, icc->getData(), icc->getLength()));
+      jpeg_enc_obj_sdr.compressImage(sdr_intent_yuv, quality, icc->getData(), icc->getLength()));
   uhdr_compressed_image_t sdr_intent_compressed = jpeg_enc_obj_sdr.getCompressedImage();
-  sdr_intent_compressed.cg = sdr_intent->cg;
+  sdr_intent_compressed.cg = sdr_intent_yuv->cg;
 
   // append gain map, no ICC since JPEG encode already did it
   UHDR_ERR_CHECK(appendGainMap(&sdr_intent_compressed, &gainmap_compressed, exif, /* icc */ nullptr,
@@ -476,23 +492,26 @@ uhdr_error_info_t JpegR::generateGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_
 
   if (sdr_intent->fmt != UHDR_IMG_FMT_24bppYCbCr444 &&
       sdr_intent->fmt != UHDR_IMG_FMT_16bppYCbCr422 &&
-      sdr_intent->fmt != UHDR_IMG_FMT_12bppYCbCr420) {
+      sdr_intent->fmt != UHDR_IMG_FMT_12bppYCbCr420 &&
+      sdr_intent->fmt != UHDR_IMG_FMT_32bppRGBA8888) {
     status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
     status.has_detail = 1;
     snprintf(status.detail, sizeof status.detail,
              "generate gainmap method expects sdr intent color format to be one of "
              "{UHDR_IMG_FMT_24bppYCbCr444, UHDR_IMG_FMT_16bppYCbCr422, "
-             "UHDR_IMG_FMT_12bppYCbCr420}. Received %d",
+             "UHDR_IMG_FMT_12bppYCbCr420, UHDR_IMG_FMT_32bppRGBA8888}. Received %d",
              sdr_intent->fmt);
     return status;
   }
   if (hdr_intent->fmt != UHDR_IMG_FMT_24bppYCbCrP010 &&
-      hdr_intent->fmt != UHDR_IMG_FMT_30bppYCbCr444) {
+      hdr_intent->fmt != UHDR_IMG_FMT_30bppYCbCr444 &&
+      hdr_intent->fmt != UHDR_IMG_FMT_32bppRGBA1010102) {
     status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
     status.has_detail = 1;
     snprintf(status.detail, sizeof status.detail,
              "generate gainmap method expects hdr intent color format to be one of "
-             "{UHDR_IMG_FMT_24bppYCbCrP010, UHDR_IMG_FMT_30bppYCbCr444}. Received %d",
+             "{UHDR_IMG_FMT_24bppYCbCrP010, UHDR_IMG_FMT_30bppYCbCr444, "
+             "UHDR_IMG_FMT_32bppRGBA1010102}. Received %d",
              hdr_intent->fmt);
     return status;
   }
@@ -634,11 +653,20 @@ uhdr_error_info_t JpegR::generateGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_
          luminanceFn, sdrYuvToRgbFn, hdrYuvToRgbFn, sdr_sample_pixel_fn, hdr_sample_pixel_fn,
          hdr_white_nits, log2MinBoost, log2MaxBoost, use_luminance, &jobQueue]() -> void {
       size_t rowStart, rowEnd;
+      const bool isHdrIntentRgb = isPixelFormatRgb(hdr_intent->fmt);
+      const bool isSdrIntentRgb = isPixelFormatRgb(sdr_intent->fmt);
       while (jobQueue.dequeueJob(rowStart, rowEnd)) {
         for (size_t y = rowStart; y < rowEnd; ++y) {
           for (size_t x = 0; x < dest->w; ++x) {
-            Color sdr_yuv_gamma = sdr_sample_pixel_fn(sdr_intent, mMapDimensionScaleFactor, x, y);
-            Color sdr_rgb_gamma = sdrYuvToRgbFn(sdr_yuv_gamma);
+            Color sdr_rgb_gamma;
+
+            if (isSdrIntentRgb) {
+              sdr_rgb_gamma = sdr_sample_pixel_fn(sdr_intent, mMapDimensionScaleFactor, x, y);
+            } else {
+              Color sdr_yuv_gamma = sdr_sample_pixel_fn(sdr_intent, mMapDimensionScaleFactor, x, y);
+              sdr_rgb_gamma = sdrYuvToRgbFn(sdr_yuv_gamma);
+            }
+
             // We are assuming the SDR input is always sRGB transfer.
 #if USE_SRGB_INVOETF_LUT
             Color sdr_rgb = srgbInvOetfLUT(sdr_rgb_gamma);
@@ -646,8 +674,14 @@ uhdr_error_info_t JpegR::generateGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_
             Color sdr_rgb = srgbInvOetf(sdr_rgb_gamma);
 #endif
 
-            Color hdr_yuv_gamma = hdr_sample_pixel_fn(hdr_intent, mMapDimensionScaleFactor, x, y);
-            Color hdr_rgb_gamma = hdrYuvToRgbFn(hdr_yuv_gamma);
+            Color hdr_rgb_gamma;
+
+            if (isHdrIntentRgb) {
+              hdr_rgb_gamma = hdr_sample_pixel_fn(hdr_intent, mMapDimensionScaleFactor, x, y);
+            } else {
+              Color hdr_yuv_gamma = hdr_sample_pixel_fn(hdr_intent, mMapDimensionScaleFactor, x, y);
+              hdr_rgb_gamma = hdrYuvToRgbFn(hdr_yuv_gamma);
+            }
             Color hdr_rgb = hdrInvOetf(hdr_rgb_gamma);
             hdr_rgb = hdrGamutConversionFn(hdr_rgb);
 
@@ -722,14 +756,23 @@ uhdr_error_info_t JpegR::generateGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_
          hdr_white_nits, use_luminance, &gainmap_min, &gainmap_max, &gainmap_minmax,
          &jobQueue]() -> void {
       size_t rowStart, rowEnd;
+      const bool isHdrIntentRgb = isPixelFormatRgb(hdr_intent->fmt);
+      const bool isSdrIntentRgb = isPixelFormatRgb(sdr_intent->fmt);
       float gainmap_min_th[3] = {127.0f, 127.0f, 127.0f};
       float gainmap_max_th[3] = {-128.0f, -128.0f, -128.0f};
 
       while (jobQueue.dequeueJob(rowStart, rowEnd)) {
         for (size_t y = rowStart; y < rowEnd; ++y) {
           for (size_t x = 0; x < map_width; ++x) {
-            Color sdr_yuv_gamma = sdr_sample_pixel_fn(sdr_intent, mMapDimensionScaleFactor, x, y);
-            Color sdr_rgb_gamma = sdrYuvToRgbFn(sdr_yuv_gamma);
+            Color sdr_rgb_gamma;
+
+            if (isSdrIntentRgb) {
+              sdr_rgb_gamma = sdr_sample_pixel_fn(sdr_intent, mMapDimensionScaleFactor, x, y);
+            } else {
+              Color sdr_yuv_gamma = sdr_sample_pixel_fn(sdr_intent, mMapDimensionScaleFactor, x, y);
+              sdr_rgb_gamma = sdrYuvToRgbFn(sdr_yuv_gamma);
+            }
+
             // We are assuming the SDR input is always sRGB transfer.
 #if USE_SRGB_INVOETF_LUT
             Color sdr_rgb = srgbInvOetfLUT(sdr_rgb_gamma);
@@ -737,8 +780,14 @@ uhdr_error_info_t JpegR::generateGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_
             Color sdr_rgb = srgbInvOetf(sdr_rgb_gamma);
 #endif
 
-            Color hdr_yuv_gamma = hdr_sample_pixel_fn(hdr_intent, mMapDimensionScaleFactor, x, y);
-            Color hdr_rgb_gamma = hdrYuvToRgbFn(hdr_yuv_gamma);
+            Color hdr_rgb_gamma;
+
+            if (isHdrIntentRgb) {
+              hdr_rgb_gamma = hdr_sample_pixel_fn(hdr_intent, mMapDimensionScaleFactor, x, y);
+            } else {
+              Color hdr_yuv_gamma = hdr_sample_pixel_fn(hdr_intent, mMapDimensionScaleFactor, x, y);
+              hdr_rgb_gamma = hdrYuvToRgbFn(hdr_yuv_gamma);
+            }
             Color hdr_rgb = hdrInvOetf(hdr_rgb_gamma);
             hdr_rgb = hdrGamutConversionFn(hdr_rgb);
 
@@ -1618,14 +1667,16 @@ uint8_t ScaleTo8Bit(float value) {
 
 uhdr_error_info_t JpegR::toneMap(uhdr_raw_image_t* hdr_intent, uhdr_raw_image_t* sdr_intent) {
   if (hdr_intent->fmt != UHDR_IMG_FMT_24bppYCbCrP010 &&
-      hdr_intent->fmt != UHDR_IMG_FMT_30bppYCbCr444) {
+      hdr_intent->fmt != UHDR_IMG_FMT_30bppYCbCr444 &&
+      hdr_intent->fmt != UHDR_IMG_FMT_32bppRGBA1010102) {
     uhdr_error_info_t status;
     status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
     status.has_detail = 1;
-    snprintf(status.detail, sizeof status.detail,
-             "tonemap method expects hdr intent color format to be one of "
-             "{UHDR_IMG_FMT_24bppYCbCrP010, UHDR_IMG_FMT_30bppYCbCr444}. Received %d",
-             hdr_intent->fmt);
+    snprintf(
+        status.detail, sizeof status.detail,
+        "tonemap method expects hdr intent color format to be one of {UHDR_IMG_FMT_24bppYCbCrP010, "
+        "UHDR_IMG_FMT_30bppYCbCr444, UHDR_IMG_FMT_32bppRGBA1010102}. Received %d",
+        hdr_intent->fmt);
     return status;
   }
 
@@ -1649,6 +1700,18 @@ uhdr_error_info_t JpegR::toneMap(uhdr_raw_image_t* hdr_intent, uhdr_raw_image_t*
     snprintf(status.detail, sizeof status.detail,
              "tonemap method expects sdr intent color format to be UHDR_IMG_FMT_24bppYCbCr444, if "
              "hdr intent color format is UHDR_IMG_FMT_30bppYCbCr444. Received %d",
+             sdr_intent->fmt);
+    return status;
+  }
+
+  if (hdr_intent->fmt == UHDR_IMG_FMT_32bppRGBA1010102 &&
+      sdr_intent->fmt != UHDR_IMG_FMT_32bppRGBA8888) {
+    uhdr_error_info_t status;
+    status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail,
+             "tonemap method expects sdr intent color format to be UHDR_IMG_FMT_32bppRGBA8888, if "
+             "hdr intent color format is UHDR_IMG_FMT_32bppRGBA1010102. Received %d",
              sdr_intent->fmt);
     return status;
   }
@@ -1707,17 +1770,24 @@ uhdr_error_info_t JpegR::toneMap(uhdr_raw_image_t* hdr_intent, uhdr_raw_image_t*
     return status;
   }
 
+  PutPixelFn put_pixel_fn = putPixelFn(sdr_intent->fmt);
+  // for subsampled formats, we are writing to raw image buffers directly instead of using
+  // put_pixel_fn
+  if (put_pixel_fn == nullptr && sdr_intent->fmt != UHDR_IMG_FMT_12bppYCbCr420) {
+    uhdr_error_info_t status;
+    status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail,
+             "No implementation available for writing pixels for color format %d", sdr_intent->fmt);
+    return status;
+  }
+
   sdr_intent->cg = UHDR_CG_DISPLAY_P3;
   sdr_intent->ct = UHDR_CT_SRGB;
   sdr_intent->range = UHDR_CR_FULL_RANGE;
 
   ColorTransformFn hdrGamutConversionFn = getGamutConversionFn(sdr_intent->cg, hdr_intent->cg);
-  uint8_t* luma_data = reinterpret_cast<uint8_t*>(sdr_intent->planes[UHDR_PLANE_Y]);
-  uint8_t* cb_data = reinterpret_cast<uint8_t*>(sdr_intent->planes[UHDR_PLANE_U]);
-  uint8_t* cr_data = reinterpret_cast<uint8_t*>(sdr_intent->planes[UHDR_PLANE_V]);
-  size_t luma_stride = sdr_intent->stride[UHDR_PLANE_Y];
-  size_t cb_stride = sdr_intent->stride[UHDR_PLANE_U];
-  size_t cr_stride = sdr_intent->stride[UHDR_PLANE_V];
+
   size_t height = hdr_intent->h;
   const int threads = (std::min)(GetCPUCoreCount(), 4);
   // for 420 subsampling, process 2 rows at once
@@ -1726,24 +1796,38 @@ uhdr_error_info_t JpegR::toneMap(uhdr_raw_image_t* hdr_intent, uhdr_raw_image_t*
   JobQueue jobQueue;
   std::function<void()> toneMapInternal;
 
-  toneMapInternal = [hdr_intent, luma_data, cb_data, cr_data, hdrInvOetf, hdrGamutConversionFn,
-                     hdrYuvToRgbFn, luma_stride, cb_stride, cr_stride, hdr_white_nits, get_pixel_fn,
-                     hdrLuminanceFn, &jobQueue]() -> void {
+  toneMapInternal = [hdr_intent, sdr_intent, hdrInvOetf, hdrGamutConversionFn, hdrYuvToRgbFn,
+                     hdr_white_nits, get_pixel_fn, put_pixel_fn, hdrLuminanceFn,
+                     &jobQueue]() -> void {
     size_t rowStart, rowEnd;
-    int hfactor = hdr_intent->fmt == UHDR_IMG_FMT_24bppYCbCrP010 ? 2 : 1;
-    int vfactor = hdr_intent->fmt == UHDR_IMG_FMT_24bppYCbCrP010 ? 2 : 1;
+    const int hfactor = hdr_intent->fmt == UHDR_IMG_FMT_24bppYCbCrP010 ? 2 : 1;
+    const int vfactor = hdr_intent->fmt == UHDR_IMG_FMT_24bppYCbCrP010 ? 2 : 1;
+    const bool isHdrIntentRgb = isPixelFormatRgb(hdr_intent->fmt);
+    const bool isSdrIntentRgb = isPixelFormatRgb(sdr_intent->fmt);
+    uint8_t* luma_data = reinterpret_cast<uint8_t*>(sdr_intent->planes[UHDR_PLANE_Y]);
+    uint8_t* cb_data = reinterpret_cast<uint8_t*>(sdr_intent->planes[UHDR_PLANE_U]);
+    uint8_t* cr_data = reinterpret_cast<uint8_t*>(sdr_intent->planes[UHDR_PLANE_V]);
+    size_t luma_stride = sdr_intent->stride[UHDR_PLANE_Y];
+    size_t cb_stride = sdr_intent->stride[UHDR_PLANE_U];
+    size_t cr_stride = sdr_intent->stride[UHDR_PLANE_V];
 
     while (jobQueue.dequeueJob(rowStart, rowEnd)) {
       for (size_t y = rowStart; y < rowEnd; y += vfactor) {
         for (size_t x = 0; x < hdr_intent->w; x += hfactor) {
-          // We assume the input is P010, and output is YUV420
+          // meant for p010 input
           float sdr_u_gamma = 0.0f;
           float sdr_v_gamma = 0.0f;
 
           for (int i = 0; i < vfactor; i++) {
             for (int j = 0; j < hfactor; j++) {
-              Color hdr_yuv_gamma = get_pixel_fn(hdr_intent, x + j, y + i);
-              Color hdr_rgb_gamma = hdrYuvToRgbFn(hdr_yuv_gamma);
+              Color hdr_rgb_gamma;
+
+              if (isHdrIntentRgb) {
+                hdr_rgb_gamma = get_pixel_fn(hdr_intent, x + j, y + i);
+              } else {
+                Color hdr_yuv_gamma = get_pixel_fn(hdr_intent, x + j, y + i);
+                hdr_rgb_gamma = hdrYuvToRgbFn(hdr_yuv_gamma);
+              }
               Color hdr_rgb = hdrInvOetf(hdr_rgb_gamma);
 
               GlobalTonemapOutputs tonemap_outputs =
@@ -1758,21 +1842,29 @@ uhdr_error_info_t JpegR::toneMap(uhdr_raw_image_t* hdr_intent, uhdr_raw_image_t*
               sdr_rgb = clampPixelFloat(sdr_rgb);
 
               Color sdr_rgb_gamma = srgbOetf(sdr_rgb);
-              Color sdr_yuv_gamma = p3RgbToYuv(sdr_rgb_gamma);
+              if (isSdrIntentRgb) {
+                put_pixel_fn(sdr_intent, (x + j), (y + i), sdr_rgb_gamma);
+              } else {
+                Color sdr_yuv_gamma = p3RgbToYuv(sdr_rgb_gamma);
+                sdr_yuv_gamma += {{{0.0f, 0.5f, 0.5f}}};
+                if (sdr_intent->fmt != UHDR_IMG_FMT_12bppYCbCr420) {
+                  put_pixel_fn(sdr_intent, (x + j), (y + i), sdr_yuv_gamma);
+                } else {
+                  size_t out_y_idx = (y + i) * luma_stride + x + j;
+                  luma_data[out_y_idx] = ScaleTo8Bit(sdr_yuv_gamma.y);
 
-              sdr_yuv_gamma += {{{0.0f, 0.5f, 0.5f}}};
-
-              size_t out_y_idx = (y + i) * luma_stride + x + j;
-              luma_data[out_y_idx] = ScaleTo8Bit(sdr_yuv_gamma.y);
-
-              sdr_u_gamma += sdr_yuv_gamma.u;
-              sdr_v_gamma += sdr_yuv_gamma.v;
+                  sdr_u_gamma += sdr_yuv_gamma.u;
+                  sdr_v_gamma += sdr_yuv_gamma.v;
+                }
+              }
             }
           }
-          sdr_u_gamma /= (hfactor * vfactor);
-          sdr_v_gamma /= (hfactor * vfactor);
-          cb_data[x / hfactor + (y / vfactor) * cb_stride] = ScaleTo8Bit(sdr_u_gamma);
-          cr_data[x / hfactor + (y / vfactor) * cr_stride] = ScaleTo8Bit(sdr_v_gamma);
+          if (sdr_intent->fmt == UHDR_IMG_FMT_12bppYCbCr420) {
+            sdr_u_gamma /= (hfactor * vfactor);
+            sdr_v_gamma /= (hfactor * vfactor);
+            cb_data[x / hfactor + (y / vfactor) * cb_stride] = ScaleTo8Bit(sdr_u_gamma);
+            cr_data[x / hfactor + (y / vfactor) * cr_stride] = ScaleTo8Bit(sdr_v_gamma);
+          }
         }
       }
     }

--- a/lib/src/ultrahdr_api.cpp
+++ b/lib/src/ultrahdr_api.cpp
@@ -783,7 +783,7 @@ uhdr_error_info_t uhdr_enc_set_raw_image(uhdr_codec_private_t* enc, uhdr_raw_ima
     return status;
   }
 
-  std::unique_ptr<ultrahdr::uhdr_raw_image_ext_t> entry = ultrahdr::convert_raw_input_to_ycbcr(img);
+  std::unique_ptr<ultrahdr::uhdr_raw_image_ext_t> entry = ultrahdr::copy_raw_image(img);
   if (entry == nullptr) {
     status.error_code = UHDR_CODEC_UNKNOWN_ERROR;
     status.has_detail = 1;


### PR DESCRIPTION
For rgb inputs, these are first converted to ycbcr inputs and stored internally. During gainmap generation, these are again converted back to rgb. These redundant color space conversions are removed.

fixed few compilation warnings

Test: ./ultrahdr_unit_test