### PR TITLE
add support for configuring min/max content boost

### DIFF
--- a/lib/include/ultrahdr/jpegr.h
+++ b/lib/include/ultrahdr/jpegr.h
@@ -77,7 +77,8 @@ class JpegR {
         size_t mapDimensionScaleFactor = kMapDimensionScaleFactorDefault,
         int mapCompressQuality = kMapCompressQualityDefault,
         bool useMultiChannelGainMap = kUseMultiChannelGainMapDefault,
-        float gamma = kGainMapGammaDefault, uhdr_enc_preset_t preset = UHDR_USAGE_REALTIME);
+        float gamma = kGainMapGammaDefault, uhdr_enc_preset_t preset = UHDR_USAGE_REALTIME,
+        float minContentBoost = FLT_MIN, float maxContentBoost = FLT_MAX);
 
   /*!\brief Encode API-0.
    *
@@ -242,7 +243,6 @@ class JpegR {
                                  jr_info_ptr uhdr_image_info);
 
   /*!\brief set gain map dimension scale factor
-   *
    * NOTE: Applicable only in encoding scenario
    *
    * \param[in]       mapDimensionScaleFactor      scale factor
@@ -254,7 +254,6 @@ class JpegR {
   }
 
   /*!\brief get gain map dimension scale factor
-   *
    * NOTE: Applicable only in encoding scenario
    *
    * \return mapDimensionScaleFactor
@@ -262,7 +261,6 @@ class JpegR {
   size_t getMapDimensionScaleFactor() { return this->mMapDimensionScaleFactor; }
 
   /*!\brief set gain map compression quality factor
-   *
    * NOTE: Applicable only in encoding scenario
    *
    * \param[in]       mapCompressQuality      quality factor for gain map image compression
@@ -274,7 +272,6 @@ class JpegR {
   }
 
   /*!\brief get gain map quality factor
-   *
    * NOTE: Applicable only in encoding scenario
    *
    * \return quality factor
@@ -282,7 +279,6 @@ class JpegR {
   int getMapCompressQuality() { return this->mMapCompressQuality; }
 
   /*!\brief set gain map gamma
-   *
    * NOTE: Applicable only in encoding scenario
    *
    * \param[in]       gamma      gamma parameter that is used for gain map calculation
@@ -292,7 +288,6 @@ class JpegR {
   void setGainMapGamma(float gamma) { this->mGamma = gamma; }
 
   /*!\brief get gain map gamma
-   *
    * NOTE: Applicable only in encoding scenario
    *
    * \return gamma parameter
@@ -300,7 +295,6 @@ class JpegR {
   float getGainMapGamma() { return this->mGamma; }
 
   /*!\brief enable / disable multi channel gain map
-   *
    * NOTE: Applicable only in encoding scenario
    *
    * \param[in]       useMultiChannelGainMap      enable / disable multi channel gain map
@@ -312,12 +306,37 @@ class JpegR {
   }
 
   /*!\brief check if multi channel gain map is enabled
-   *
    * NOTE: Applicable only in encoding scenario
    *
    * \return true if multi channel gain map is enabled, false otherwise
    */
   bool isUsingMultiChannelGainMap() { return this->mUseMultiChannelGainMap; }
+
+  /*!\brief set gain map min and max content boost
+   * NOTE: Applicable only in encoding scenario
+   *
+   * \param[in]       minBoost      gain map min content boost
+   * \param[in]       maxBoost      gain map max content boost
+   *
+   * \return none
+   */
+  void setGainMapMinMaxContentBoost(float minBoost, float maxBoost) {
+    this->mMinContentBoost = minBoost;
+    this->mMaxContentBoost = maxBoost;
+  }
+
+  /*!\brief get gain map min max content boost
+   * NOTE: Applicable only in encoding scenario
+   *
+   * \param[out]       minBoost      gain map min content boost
+   * \param[out]       maxBoost      gain map max content boost
+   *
+   * \return none
+   */
+  void getGainMapMinMaxContentBoost(float& minBoost, float& maxBoost) {
+    minBoost = this->mMinContentBoost;
+    maxBoost = this->mMaxContentBoost;
+  }
 
   /* \brief Alias of Encode API-0.
    *
@@ -572,6 +591,8 @@ class JpegR {
   bool mUseMultiChannelGainMap;     // enable multichannel gain map
   float mGamma;                     // gain map gamma parameter
   uhdr_enc_preset_t mEncPreset;     // encoding speed preset
+  float mMinContentBoost;           // min content boost recommendation
+  float mMaxContentBoost;           // max content boost recommendation
 };
 
 struct GlobalTonemapOutputs {

--- a/lib/include/ultrahdr/ultrahdrcommon.h
+++ b/lib/include/ultrahdr/ultrahdrcommon.h
@@ -353,6 +353,8 @@ struct uhdr_encoder_private : uhdr_codec_private {
   bool m_use_multi_channel_gainmap;
   float m_gamma;
   uhdr_enc_preset_t m_enc_preset;
+  float m_min_content_boost;
+  float m_max_content_boost;
 
   // internal data
   std::unique_ptr<ultrahdr::uhdr_compressed_image_ext_t> m_compressed_output_buffer;

--- a/ultrahdr_api.h
+++ b/ultrahdr_api.h
@@ -379,6 +379,20 @@ UHDR_EXTERN uhdr_error_info_t uhdr_enc_set_gainmap_scale_factor(uhdr_codec_priva
  */
 UHDR_EXTERN uhdr_error_info_t uhdr_enc_set_gainmap_gamma(uhdr_codec_private_t* enc, float gamma);
 
+/*!\brief Set min max content boost. This configuration is treated as a recommendation by the
+ * library. It is entirely possible for the library to use a different set of values. Value MUST be
+ * in linear scale.
+ *
+ * \param[in]  enc  encoder instance.
+ * \param[in]  min_boost min content boost. Any positive real number > 0.0f
+ * \param[in]  max_boost max content boost. Any positive real number >= min_boost
+ *
+ * \return uhdr_error_info_t #UHDR_CODEC_OK if operation succeeds,
+ *                           #UHDR_CODEC_INVALID_PARAM otherwise.
+ */
+UHDR_EXTERN uhdr_error_info_t uhdr_enc_set_min_max_content_boost(uhdr_codec_private_t* enc,
+                                                                 float min_boost, float max_boost);
+
 /*!\brief Set encoding preset. Tunes the encoder configurations for performance or quality. Default
  * configuration is #UHDR_USAGE_REALTIME.
  *


### PR DESCRIPTION
The min/max content boost for different encoding presets are computed internally basing on the input hdr and sdr intents. This change introduces an API to configure the values from the app side. If the library during its computations observes a small min-max range, then client recommendation is ignored. Otherwise, the configured values are selected.

fixes #160

Test: ./ultrahdr_app <options> -k 0.01 -K 8.0