### PR TITLE
configure hdr display max brightness

### DIFF
--- a/lib/include/ultrahdr/gainmapmath.h
+++ b/lib/include/ultrahdr/gainmapmath.h
@@ -491,11 +491,6 @@ PutPixelFn putPixelFn(uhdr_img_fmt_t format);
 bool isPixelFormatRgb(uhdr_img_fmt_t format);
 
 /*
- * Get max display mastering luminance in nits
- */
-float getMaxDisplayMasteringLuminance(uhdr_color_transfer_t transfer);
-
-/*
  * Convert between YUV encodings, according to ITU-R BT.709-6, ITU-R BT.601-7, and ITU-R BT.2100-2.
  *
  * Bt.709 and Bt.2100 have well-defined YUV encodings; Display-P3's is less well defined, but is

--- a/lib/include/ultrahdr/jpegr.h
+++ b/lib/include/ultrahdr/jpegr.h
@@ -78,7 +78,8 @@ class JpegR {
         int mapCompressQuality = kMapCompressQualityDefault,
         bool useMultiChannelGainMap = kUseMultiChannelGainMapDefault,
         float gamma = kGainMapGammaDefault, uhdr_enc_preset_t preset = UHDR_USAGE_REALTIME,
-        float minContentBoost = FLT_MIN, float maxContentBoost = FLT_MAX);
+        float minContentBoost = FLT_MIN, float maxContentBoost = FLT_MAX,
+        float maxDispBrightness = -1.0f);
 
   /*!\brief Encode API-0.
    *
@@ -547,6 +548,14 @@ class JpegR {
   uhdr_error_info_t convertYuv(uhdr_raw_image_t* image, uhdr_color_gamut_t src_encoding,
                                uhdr_color_gamut_t dst_encoding);
 
+  /*!\brief Get max display brightness in nits
+   *
+   * \param[in]  transfer       intent's color transfer characteristics
+   *
+   * \return max display brightness in nits
+   */
+  float getMasteringDisplayMaxLuminance(uhdr_color_transfer_t transfer);
+
   /*
    * This method will check the validity of the input arguments.
    *
@@ -593,6 +602,7 @@ class JpegR {
   uhdr_enc_preset_t mEncPreset;     // encoding speed preset
   float mMinContentBoost;           // min content boost recommendation
   float mMaxContentBoost;           // max content boost recommendation
+  float mMaxDispBrightness;         // mastering display max luminance in nits
 };
 
 struct GlobalTonemapOutputs {

--- a/lib/include/ultrahdr/ultrahdrcommon.h
+++ b/lib/include/ultrahdr/ultrahdrcommon.h
@@ -355,6 +355,7 @@ struct uhdr_encoder_private : uhdr_codec_private {
   uhdr_enc_preset_t m_enc_preset;
   float m_min_content_boost;
   float m_max_content_boost;
+  float m_max_disp_brightness;
 
   // internal data
   std::unique_ptr<ultrahdr::uhdr_compressed_image_ext_t> m_compressed_output_buffer;

--- a/lib/src/gainmapmath.cpp
+++ b/lib/src/gainmapmath.cpp
@@ -512,23 +512,6 @@ bool isPixelFormatRgb(uhdr_img_fmt_t format) {
          format == UHDR_IMG_FMT_32bppRGBA1010102;
 }
 
-float getMaxDisplayMasteringLuminance(uhdr_color_transfer_t transfer) {
-  switch (transfer) {
-    case UHDR_CT_LINEAR:
-      // TODO: configure MDML correctly for linear tf
-      return kHlgMaxNits;
-    case UHDR_CT_HLG:
-      return kHlgMaxNits;
-    case UHDR_CT_PQ:
-      return kPqMaxNits;
-    case UHDR_CT_SRGB:
-      return kSdrWhiteNits;
-    case UHDR_CT_UNSPECIFIED:
-      return -1.0f;
-  }
-  return -1.0f;
-}
-
 // All of these conversions are derived from the respective input YUV->RGB conversion followed by
 // the RGB->YUV for the receiving encoding. They are consistent with the RGB<->YUV functions in
 // gainmapmath.cpp, given that we use BT.709 encoding for sRGB and BT.601 encoding for Display-P3,

--- a/lib/src/gpu/applygainmap_gl.cpp
+++ b/lib/src/gpu/applygainmap_gl.cpp
@@ -136,13 +136,13 @@ static const std::string applyGainMapShader = R"__SHADER__(
   uniform float logMinBoost;
   uniform float logMaxBoost;
   uniform float weight;
-  uniform float displayBoost;
+  uniform float hdrCapacityMax;
 
   float applyGainMapSample(const float channel, float gain) {
     gain = pow(gain, 1.0f / gamma);
     float logBoost = logMinBoost * (1.0f - gain) + logMaxBoost * gain;
     logBoost = exp2(logBoost * weight);
-    return channel * logBoost / displayBoost;
+    return channel * logBoost / hdrCapacityMax;
   }
 
   vec3 applyGain(const vec3 color, const vec3 gain) {
@@ -302,7 +302,7 @@ uhdr_error_info_t applyGainMapGLES(uhdr_raw_image_t* sdr_intent, uhdr_raw_image_
   GLint logMinBoostLocation = glGetUniformLocation(shaderProgram, "logMinBoost");
   GLint logMaxBoostLocation = glGetUniformLocation(shaderProgram, "logMaxBoost");
   GLint weightLocation = glGetUniformLocation(shaderProgram, "weight");
-  GLint displayBoostLocation = glGetUniformLocation(shaderProgram, "displayBoost");
+  GLint hdrCapacityMaxLocation = glGetUniformLocation(shaderProgram, "hdrCapacityMax");
 
   glUniform1i(pWidthLocation, sdr_intent->w);
   glUniform1i(pHeightLocation, sdr_intent->h);
@@ -310,7 +310,8 @@ uhdr_error_info_t applyGainMapGLES(uhdr_raw_image_t* sdr_intent, uhdr_raw_image_
   glUniform1f(logMinBoostLocation, log2(gainmap_metadata->min_content_boost));
   glUniform1f(logMaxBoostLocation, log2(gainmap_metadata->max_content_boost));
   glUniform1f(weightLocation, display_boost / gainmap_metadata->hdr_capacity_max);
-  glUniform1f(displayBoostLocation, display_boost);
+  glUniform1f(hdrCapacityMaxLocation, output_ct == UHDR_CT_PQ ? (kSdrWhiteNits / kPqMaxNits)
+                                                              : gainmap_metadata->hdr_capacity_max);
 
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_2D, yuvTexture);

--- a/ultrahdr_api.h
+++ b/ultrahdr_api.h
@@ -425,6 +425,19 @@ UHDR_EXTERN uhdr_error_info_t uhdr_enc_set_preset(uhdr_codec_private_t* enc,
 UHDR_EXTERN uhdr_error_info_t uhdr_enc_set_output_format(uhdr_codec_private_t* enc,
                                                          uhdr_codec_t media_type);
 
+/*!\brief Set maximum hdr display brightness in nits. For #UHDR_CT_HLG content, this defaults to
+ * 1000 nits. For #UHDR_CT_PQ content, this defaults to 10000 nits. This configuration is required
+ * if the hdr intent color transfer is #UHDR_CT_LINEAR.
+ *
+ * \param[in]  enc  encoder instance.
+ * \param[in]  nits  max display brightness in nits. Any positive real number in range [203, 10000]
+ *
+ * \return uhdr_error_info_t #UHDR_CODEC_OK if operation succeeds,
+ *                           #UHDR_CODEC_INVALID_PARAM otherwise.
+ */
+UHDR_EXTERN uhdr_error_info_t uhdr_enc_set_max_display_brightness(uhdr_codec_private_t* enc,
+                                                                  float nits);
+
 /*!\brief Encode process call
  * After initializing the encoder context, call to this function will submit data for encoding. If
  * the call is successful, the encoded output is stored internally and is accessible via


### PR DESCRIPTION
If the input color transfer is linear, there is no proper peak brightness configuration. Also hlg is not absolute standard allowing room for different peak brightness levels. This change addresses this.

Test: ./ultrahdr_unit_test