### PR TITLE
Modify few default encoding configurations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ option_if_not_defined(UHDR_BUILD_DEPS "Build deps and not use pre-installed pack
 option_if_not_defined(UHDR_ENABLE_LOGS "Build with verbose logging " FALSE)
 option_if_not_defined(UHDR_ENABLE_INSTALL "Enable install and uninstall targets for libuhdr package " TRUE)
 option_if_not_defined(UHDR_ENABLE_INTRINSICS "Build with SIMD acceleration " TRUE)
-option_if_not_defined(UHDR_ENABLE_GLES "Build with GPU acceleration " TRUE)
+option_if_not_defined(UHDR_ENABLE_GLES "Build with GPU acceleration " FALSE)
 option_if_not_defined(UHDR_BUILD_JAVA "Build JNI wrapper and Java front-end classes " FALSE)
 
 # pre-requisites

--- a/examples/ultrahdr_app.cpp
+++ b/examples/ultrahdr_app.cpp
@@ -256,9 +256,9 @@ class UltraHdrAppInput {
                    uhdr_color_transfer_t hdrTf = UHDR_CT_HLG, int quality = 95,
                    uhdr_color_transfer_t oTf = UHDR_CT_HLG,
                    uhdr_img_fmt_t oFmt = UHDR_IMG_FMT_32bppRGBA1010102, bool isHdrCrFull = false,
-                   int gainmapScaleFactor = 4, int gainmapQuality = 85,
-                   bool enableMultiChannelGainMap = false, float gamma = 1.0f,
-                   bool enableGLES = false, uhdr_enc_preset_t encPreset = UHDR_USAGE_REALTIME,
+                   int gainmapScaleFactor = 1, int gainmapQuality = 95,
+                   bool enableMultiChannelGainMap = true, float gamma = 1.0f,
+                   bool enableGLES = false, uhdr_enc_preset_t encPreset = UHDR_USAGE_BEST_QUALITY,
                    float minContentBoost = FLT_MIN, float maxContentBoost = FLT_MAX)
       : mHdrIntentRawFile(hdrIntentRawFile),
         mSdrIntentRawFile(sdrIntentRawFile),
@@ -311,12 +311,12 @@ class UltraHdrAppInput {
         mOTf(oTf),
         mOfmt(oFmt),
         mFullRange(UHDR_CR_UNSPECIFIED),
-        mMapDimensionScaleFactor(4),
-        mMapCompressQuality(85),
-        mUseMultiChannelGainMap(false),
+        mMapDimensionScaleFactor(1),
+        mMapCompressQuality(95),
+        mUseMultiChannelGainMap(true),
         mGamma(1.0f),
         mEnableGLES(enableGLES),
-        mEncPreset(UHDR_USAGE_REALTIME),
+        mEncPreset(UHDR_USAGE_BEST_QUALITY),
         mMinContentBoost(FLT_MIN),
         mMaxContentBoost(FLT_MAX),
         mMode(1){};
@@ -1357,18 +1357,18 @@ static void usage(const char* name) {
           "1:full-range]. \n");
   fprintf(stderr,
           "    -s    gainmap image downsample factor, optional. [integer values in range [1 - 128] "
-          "(4 : default)]. \n");
+          "(1 : default)]. \n");
   fprintf(stderr,
           "    -Q    quality factor to be used while encoding gain map image, optional. [0-100], "
-          "85 : default. \n");
+          "95 : default. \n");
   fprintf(stderr,
           "    -G    gamma correction to be applied on the gainmap image, optional. [any positive "
           "real number (1.0 : default)].\n");
   fprintf(stderr,
-          "    -M    select multi channel gain map, optional. [0:disable (default), 1:enable]. \n");
+          "    -M    select multi channel gain map, optional. [0:disable, 1:enable (default)]. \n");
   fprintf(
       stderr,
-      "    -D    select encoding preset, optional. [0:real time (default), 1:best quality]. \n");
+      "    -D    select encoding preset, optional. [0:real time, 1:best quality (default)]. \n");
   fprintf(stderr,
           "    -k    min content boost recommendation, must be in linear scale, optional \n");
   fprintf(stderr,
@@ -1474,14 +1474,14 @@ int main(int argc, char* argv[]) {
   uhdr_color_transfer_t out_tf = UHDR_CT_HLG;
   uhdr_img_fmt_t out_cf = UHDR_IMG_FMT_32bppRGBA1010102;
   int mode = -1;
-  int gainmap_scale_factor = 4;
-  bool use_multi_channel_gainmap = false;
+  int gainmap_scale_factor = 1;
+  bool use_multi_channel_gainmap = true;
   bool use_full_range_color_hdr = false;
-  int gainmap_compression_quality = 85;
+  int gainmap_compression_quality = 95;
   int compute_psnr = 0;
   float gamma = 1.0f;
   bool enable_gles = false;
-  uhdr_enc_preset_t enc_preset = UHDR_USAGE_REALTIME;
+  uhdr_enc_preset_t enc_preset = UHDR_USAGE_BEST_QUALITY;
   float min_content_boost = FLT_MIN;
   float max_content_boost = FLT_MAX;
   int ch;

--- a/java/com/google/media/codecs/ultrahdr/UltraHDREncoder.java
+++ b/java/com/google/media/codecs/ultrahdr/UltraHDREncoder.java
@@ -312,7 +312,7 @@ public class UltraHDREncoder implements AutoCloseable {
 
     /**
      * Set quality factor for compressing base image and/or gainmap image. Default configured
-     * quality factor of base image and gainmap image are 95 and 85 respectively.
+     * quality factor of base image and gainmap image are 95 and 95 respectively.
      *
      * @param qualityFactor Any integer in range [0 - 100]
      * @param intent        {@link UltraHDRCommon#UHDR_BASE_IMG} or
@@ -372,7 +372,7 @@ public class UltraHDREncoder implements AutoCloseable {
 
     /**
      * Set encoding preset. Tunes the encoder configurations for performance or quality. Default
-     * configuration is {@link UltraHDREncoder#UHDR_USAGE_REALTIME}.
+     * configuration is {@link UltraHDREncoder#UHDR_USAGE_BEST_QUALITY}.
      *
      * @param preset encoding preset. {@link UltraHDREncoder#UHDR_USAGE_REALTIME} for best
      *               performance {@link UltraHDREncoder#UHDR_USAGE_BEST_QUALITY} for best quality

--- a/lib/include/ultrahdr/jpegr.h
+++ b/lib/include/ultrahdr/jpegr.h
@@ -29,19 +29,29 @@
 namespace ultrahdr {
 
 // Default configurations
-// Map is quarter res / sixteenth size
-static const size_t kMapDimensionScaleFactorDefault = 4;
+// gainmap image downscale factor
+static const size_t kMapDimensionScaleFactorDefault = 1;
+static const size_t kMapDimensionScaleFactorAndroidDefault = 4;
+
+// JPEG compress quality (0 ~ 100) for base image
+static const int kBaseCompressQualityDefault = 95;
 
 // JPEG compress quality (0 ~ 100) for gain map
-static const int kMapCompressQualityDefault = 85;
+static const int kMapCompressQualityDefault = 95;
+static const int kMapCompressQualityAndroidDefault = 85;
 
 // Gain map calculation
-static const bool kUseMultiChannelGainMapDefault = false;
+static const bool kUseMultiChannelGainMapDefault = true;
+static const bool kUseMultiChannelGainMapAndroidDefault = false;
+
+// encoding preset
+static const uhdr_enc_preset_t kEncSpeedPresetDefault = UHDR_USAGE_BEST_QUALITY;
+static const uhdr_enc_preset_t kEncSpeedPresetAndroidDefault = UHDR_USAGE_REALTIME;
+
 // Default gamma value for gain map
 static const float kGainMapGammaDefault = 1.0f;
 
 // The current JPEGR version that we encode to
-static const char* const kGainMapVersion = "1.0";
 static const char* const kJpegrVersion = "1.0";
 
 /*
@@ -74,11 +84,12 @@ typedef struct jpegr_info_struct* jr_info_ptr;
 class JpegR {
  public:
   JpegR(void* uhdrGLESCtxt = nullptr,
-        size_t mapDimensionScaleFactor = kMapDimensionScaleFactorDefault,
-        int mapCompressQuality = kMapCompressQualityDefault,
-        bool useMultiChannelGainMap = kUseMultiChannelGainMapDefault,
-        float gamma = kGainMapGammaDefault, uhdr_enc_preset_t preset = UHDR_USAGE_REALTIME,
-        float minContentBoost = FLT_MIN, float maxContentBoost = FLT_MAX);
+        size_t mapDimensionScaleFactor = kMapDimensionScaleFactorAndroidDefault,
+        int mapCompressQuality = kMapCompressQualityAndroidDefault,
+        bool useMultiChannelGainMap = kUseMultiChannelGainMapAndroidDefault,
+        float gamma = kGainMapGammaDefault,
+        uhdr_enc_preset_t preset = kEncSpeedPresetAndroidDefault, float minContentBoost = FLT_MIN,
+        float maxContentBoost = FLT_MAX);
 
   /*!\brief Encode API-0.
    *

--- a/lib/src/gainmapmetadata.cpp
+++ b/lib/src/gainmapmetadata.cpp
@@ -283,7 +283,7 @@ uhdr_error_info_t uhdr_gainmap_metadata_frac::gainmapMetadataFractionToFloat(
     UHDR_CHECK_NON_ZERO(from->baseOffsetD[i], "baseOffset denominator");
     UHDR_CHECK_NON_ZERO(from->alternateOffsetD[i], "alternateOffset denominator");
   }
-  to->version = kGainMapVersion;
+  to->version = kJpegrVersion;
   to->max_content_boost = (float)from->gainMapMaxN[0] / from->gainMapMaxD[0];
   to->min_content_boost = (float)from->gainMapMinN[0] / from->gainMapMinD[0];
   to->gamma = (float)from->gainMapGammaN[0] / from->gainMapGammaD[0];

--- a/lib/src/ultrahdr_api.cpp
+++ b/lib/src/ultrahdr_api.cpp
@@ -1188,16 +1188,16 @@ void uhdr_reset_encoder(uhdr_codec_private_t* enc) {
     handle->m_raw_images.clear();
     handle->m_compressed_images.clear();
     handle->m_quality.clear();
-    handle->m_quality.emplace(UHDR_HDR_IMG, 95);
-    handle->m_quality.emplace(UHDR_SDR_IMG, 95);
-    handle->m_quality.emplace(UHDR_BASE_IMG, 95);
+    handle->m_quality.emplace(UHDR_HDR_IMG, ultrahdr::kBaseCompressQualityDefault);
+    handle->m_quality.emplace(UHDR_SDR_IMG, ultrahdr::kBaseCompressQualityDefault);
+    handle->m_quality.emplace(UHDR_BASE_IMG, ultrahdr::kBaseCompressQualityDefault);
     handle->m_quality.emplace(UHDR_GAIN_MAP_IMG, ultrahdr::kMapCompressQualityDefault);
     handle->m_exif.clear();
     handle->m_output_format = UHDR_CODEC_JPG;
     handle->m_gainmap_scale_factor = ultrahdr::kMapDimensionScaleFactorDefault;
     handle->m_use_multi_channel_gainmap = ultrahdr::kUseMultiChannelGainMapDefault;
     handle->m_gamma = ultrahdr::kGainMapGammaDefault;
-    handle->m_enc_preset = UHDR_USAGE_REALTIME;
+    handle->m_enc_preset = ultrahdr::kEncSpeedPresetDefault;
     handle->m_min_content_boost = FLT_MIN;
     handle->m_max_content_boost = FLT_MAX;
 

--- a/tests/jpegr_test.cpp
+++ b/tests/jpegr_test.cpp
@@ -1474,6 +1474,14 @@ TEST_P(JpegRAPIEncodeAndDecodeTest, EncodeAPI0AndDecodeTest) {
   ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
   status = uhdr_enc_set_quality(obj, kQuality, UHDR_BASE_IMG);
   ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+  status = uhdr_enc_set_using_multi_channel_gainmap(obj, false);
+  ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+  status = uhdr_enc_set_gainmap_scale_factor(obj, 4);
+  ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+  status = uhdr_enc_set_quality(obj, 85, UHDR_GAIN_MAP_IMG);
+  ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+  status = uhdr_enc_set_preset(obj, UHDR_USAGE_REALTIME);
+  ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
   status = uhdr_encode(obj);
   ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
   uhdr_compressed_image_t* compressedImage = uhdr_get_encoded_stream(obj);
@@ -1535,6 +1543,14 @@ TEST_P(JpegRAPIEncodeAndDecodeTest, EncodeAPI0AndDecodeTest) {
     uhdr_error_info_t status = uhdr_enc_set_raw_image(obj, &uhdrRawImg, UHDR_HDR_IMG);
     ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
     status = uhdr_enc_set_quality(obj, kQuality, UHDR_BASE_IMG);
+    ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+    status = uhdr_enc_set_using_multi_channel_gainmap(obj, false);
+    ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+    status = uhdr_enc_set_gainmap_scale_factor(obj, 4);
+    ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+    status = uhdr_enc_set_quality(obj, 85, UHDR_GAIN_MAP_IMG);
+    ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+    status = uhdr_enc_set_preset(obj, UHDR_USAGE_REALTIME);
     ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
     status = uhdr_encode(obj);
     ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
@@ -1754,6 +1770,14 @@ TEST_P(JpegRAPIEncodeAndDecodeTest, EncodeAPI1AndDecodeTest) {
 
     status = uhdr_enc_set_quality(obj, kQuality, UHDR_BASE_IMG);
     ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+    status = uhdr_enc_set_using_multi_channel_gainmap(obj, false);
+    ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+    status = uhdr_enc_set_gainmap_scale_factor(obj, 4);
+    ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+    status = uhdr_enc_set_quality(obj, 85, UHDR_GAIN_MAP_IMG);
+    ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+    status = uhdr_enc_set_preset(obj, UHDR_USAGE_REALTIME);
+    ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
     status = uhdr_encode(obj);
     ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
     uhdr_compressed_image_t* compressedImage = uhdr_get_encoded_stream(obj);
@@ -1970,6 +1994,14 @@ TEST_P(JpegRAPIEncodeAndDecodeTest, EncodeAPI2AndDecodeTest) {
 
     status = uhdr_enc_set_quality(obj, kQuality, UHDR_BASE_IMG);
     ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+    status = uhdr_enc_set_using_multi_channel_gainmap(obj, false);
+    ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+    status = uhdr_enc_set_gainmap_scale_factor(obj, 4);
+    ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+    status = uhdr_enc_set_quality(obj, 85, UHDR_GAIN_MAP_IMG);
+    ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+    status = uhdr_enc_set_preset(obj, UHDR_USAGE_REALTIME);
+    ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
     status = uhdr_encode(obj);
     ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
     uhdr_compressed_image_t* compressedImage = uhdr_get_encoded_stream(obj);
@@ -2130,6 +2162,14 @@ TEST_P(JpegRAPIEncodeAndDecodeTest, EncodeAPI3AndDecodeTest) {
     ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
 
     status = uhdr_enc_set_quality(obj, kQuality, UHDR_BASE_IMG);
+    ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+    status = uhdr_enc_set_using_multi_channel_gainmap(obj, false);
+    ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+    status = uhdr_enc_set_gainmap_scale_factor(obj, 4);
+    ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+    status = uhdr_enc_set_quality(obj, 85, UHDR_GAIN_MAP_IMG);
+    ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
+    status = uhdr_enc_set_preset(obj, UHDR_USAGE_REALTIME);
     ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;
     status = uhdr_encode(obj);
     ASSERT_EQ(UHDR_CODEC_OK, status.error_code) << status.detail;

--- a/ultrahdr_api.h
+++ b/ultrahdr_api.h
@@ -321,7 +321,7 @@ UHDR_EXTERN uhdr_error_info_t uhdr_enc_set_gainmap_image(uhdr_codec_private_t* e
                                                          uhdr_gainmap_metadata_t* metadata);
 
 /*!\brief Set quality factor for compressing base image and/or gainmap image. Default configured
- * quality factor of base image and gainmap image are 95 and 85 respectively.
+ * quality factor of base image and gainmap image are 95 and 95 respectively.
  *
  * \param[in]  enc  encoder instance.
  * \param[in]  quality  quality factor. Any integer in range [0 - 100].
@@ -346,7 +346,7 @@ UHDR_EXTERN uhdr_error_info_t uhdr_enc_set_quality(uhdr_codec_private_t* enc, in
 UHDR_EXTERN uhdr_error_info_t uhdr_enc_set_exif_data(uhdr_codec_private_t* enc,
                                                      uhdr_mem_block_t* exif);
 
-/*!\brief Enable/Disable multi-channel gainmap. By default single-channel gainmap is enabled.
+/*!\brief Enable/Disable multi-channel gainmap. By default multi-channel gainmap is enabled.
  *
  * \param[in]  enc  encoder instance.
  * \param[in]  use_multi_channel_gainmap  enable/disable multichannel gain map.
@@ -363,7 +363,7 @@ uhdr_enc_set_using_multi_channel_gainmap(uhdr_codec_private_t* enc, int use_mult
  * image instead of full resolution. This setting controls the factor by which the renditions are
  * downscaled. For instance, gain_map_scale_factor = 2 implies gainmap_image_width =
  * primary_image_width / 2 and gainmap image height = primary_image_height / 2.
- * Default gain map scaling factor is 4.
+ * Default gain map scaling factor is 1.
  * NOTE: This has no effect on base image rendition. Base image is signalled in full resolution
  * always.
  *
@@ -402,7 +402,7 @@ UHDR_EXTERN uhdr_error_info_t uhdr_enc_set_min_max_content_boost(uhdr_codec_priv
                                                                  float min_boost, float max_boost);
 
 /*!\brief Set encoding preset. Tunes the encoder configurations for performance or quality. Default
- * configuration is #UHDR_USAGE_REALTIME.
+ * configuration is #UHDR_USAGE_BEST_QUALITY.
  *
  * \param[in]  enc  encoder instance.
  * \param[in]  preset  encoding preset. #UHDR_USAGE_REALTIME - Tune settings for best performance


### PR DESCRIPTION
By default gainmap scale factor is set to 1, multi-channel gainmap encoding is enabled.

Test: ./ultrahdr_unit_test