### PR TITLE
Reuse applyGainMap GL textures if effects are to be applied

### DIFF
--- a/lib/include/ultrahdr/ultrahdrcommon.h
+++ b/lib/include/ultrahdr/ultrahdrcommon.h
@@ -227,9 +227,10 @@ typedef struct uhdr_opengl_ctxt {
   EGLConfig mEGLConfig;   /**< EGL frame buffer configuration */
 
   // GLES Context
-  GLuint mQuadVAO, mQuadVBO, mQuadEBO;    /**< GL objects */
-  GLuint mShaderProgram[UHDR_RESIZE + 1]; /**< Shader programs */
-  uhdr_error_info_t mErrorStatus;         /**< Context status */
+  GLuint mQuadVAO, mQuadVBO, mQuadEBO;           /**< GL objects */
+  GLuint mShaderProgram[UHDR_RESIZE + 1];        /**< Shader programs */
+  GLuint mDecodedImgTexture, mGainmapImgTexture; /**< GL Textures */
+  uhdr_error_info_t mErrorStatus;                /**< Context status */
 
   uhdr_opengl_ctxt();
   ~uhdr_opengl_ctxt();

--- a/lib/src/editorhelper.cpp
+++ b/lib/src/editorhelper.cpp
@@ -192,7 +192,7 @@ std::unique_ptr<uhdr_raw_image_ext_t> apply_rotate(ultrahdr::uhdr_rotate_effect_
 #ifdef UHDR_ENABLE_GLES
   if ((src->fmt == UHDR_IMG_FMT_32bppRGBA1010102 || src->fmt == UHDR_IMG_FMT_32bppRGBA8888 ||
        src->fmt == UHDR_IMG_FMT_64bppRGBAHalfFloat || src->fmt == UHDR_IMG_FMT_8bppYCbCr400) &&
-      isBufferDataContiguous(src) && gl_ctxt != nullptr) {
+      gl_ctxt != nullptr && *static_cast<GLuint*>(texture) != 0) {
     return apply_rotate_gles(desc, src, static_cast<ultrahdr::uhdr_opengl_ctxt*>(gl_ctxt),
                              static_cast<GLuint*>(texture));
   }
@@ -267,7 +267,7 @@ std::unique_ptr<uhdr_raw_image_ext_t> apply_mirror(ultrahdr::uhdr_mirror_effect_
 #ifdef UHDR_ENABLE_GLES
   if ((src->fmt == UHDR_IMG_FMT_32bppRGBA1010102 || src->fmt == UHDR_IMG_FMT_32bppRGBA8888 ||
        src->fmt == UHDR_IMG_FMT_64bppRGBAHalfFloat || src->fmt == UHDR_IMG_FMT_8bppYCbCr400) &&
-      isBufferDataContiguous(src) && gl_ctxt != nullptr) {
+      gl_ctxt != nullptr && *static_cast<GLuint*>(texture) != 0) {
     return apply_mirror_gles(desc, src, static_cast<ultrahdr::uhdr_opengl_ctxt*>(gl_ctxt),
                              static_cast<GLuint*>(texture));
   }
@@ -331,7 +331,7 @@ void apply_crop(uhdr_raw_image_t* src, int left, int top, int wd, int ht,
 #ifdef UHDR_ENABLE_GLES
   if ((src->fmt == UHDR_IMG_FMT_32bppRGBA1010102 || src->fmt == UHDR_IMG_FMT_32bppRGBA8888 ||
        src->fmt == UHDR_IMG_FMT_64bppRGBAHalfFloat || src->fmt == UHDR_IMG_FMT_8bppYCbCr400) &&
-      isBufferDataContiguous(src) && gl_ctxt != nullptr) {
+      gl_ctxt != nullptr && *static_cast<GLuint*>(texture) != 0) {
     return apply_crop_gles(src, left, top, wd, ht,
                            static_cast<ultrahdr::uhdr_opengl_ctxt*>(gl_ctxt),
                            static_cast<GLuint*>(texture));
@@ -380,7 +380,7 @@ std::unique_ptr<uhdr_raw_image_ext_t> apply_resize(ultrahdr::uhdr_resize_effect_
 #ifdef UHDR_ENABLE_GLES
   if ((src->fmt == UHDR_IMG_FMT_32bppRGBA1010102 || src->fmt == UHDR_IMG_FMT_32bppRGBA8888 ||
        src->fmt == UHDR_IMG_FMT_64bppRGBAHalfFloat || src->fmt == UHDR_IMG_FMT_8bppYCbCr400) &&
-      isBufferDataContiguous(src) && gl_ctxt != nullptr) {
+      gl_ctxt != nullptr && *static_cast<GLuint*>(texture) != 0) {
     return apply_resize_gles(src, dst_w, dst_h, static_cast<ultrahdr::uhdr_opengl_ctxt*>(gl_ctxt),
                              static_cast<GLuint*>(texture));
   }

--- a/lib/src/gpu/uhdr_gl_utils.cpp
+++ b/lib/src/gpu/uhdr_gl_utils.cpp
@@ -27,6 +27,8 @@ uhdr_opengl_ctxt::uhdr_opengl_ctxt() {
   mQuadVBO = 0;
   mQuadEBO = 0;
   mErrorStatus = g_no_error;
+  mDecodedImgTexture = 0;
+  mGainmapImgTexture = 0;
   for (int i = 0; i < UHDR_RESIZE + 1; i++) {
     mShaderProgram[i] = 0;
   }
@@ -385,6 +387,14 @@ void uhdr_opengl_ctxt::delete_opengl_ctxt() {
   if (mEGLDisplay != EGL_NO_DISPLAY) {
     eglTerminate(mEGLDisplay);
     mEGLDisplay = EGL_NO_DISPLAY;
+  }
+  if (mDecodedImgTexture) {
+    glDeleteTextures(1, &mDecodedImgTexture);
+    mDecodedImgTexture = 0;
+  }
+  if (mGainmapImgTexture) {
+    glDeleteTextures(1, &mGainmapImgTexture);
+    mGainmapImgTexture = 0;
   }
   for (int i = 0; i < UHDR_RESIZE + 1; i++) {
     if (mShaderProgram[i]) {

--- a/lib/src/ultrahdr_api.cpp
+++ b/lib/src/ultrahdr_api.cpp
@@ -216,20 +216,31 @@ uhdr_error_info_t apply_effects(uhdr_encoder_private* enc) {
   return g_no_error;
 }
 
+bool is_resize_effect(const ultrahdr::uhdr_effect_desc_t* effect) {
+  return dynamic_cast<const ultrahdr::uhdr_resize_effect_t*>(effect) != nullptr;
+}
+
 uhdr_error_info_t apply_effects(uhdr_decoder_private* dec) {
   void *gl_ctxt = nullptr, *disp_texture_ptr = nullptr, *gm_texture_ptr = nullptr;
 #ifdef UHDR_ENABLE_GLES
-  GLuint pm_texture = 0, gm_texture = 0;
   if (dec->m_enable_gles) {
     gl_ctxt = &dec->m_uhdr_gl_ctxt;
-    auto decoded_img = dec->m_decoded_img_buffer.get();
-    auto gainmap_img = dec->m_gainmap_img_buffer.get();
-    pm_texture = dec->m_uhdr_gl_ctxt.create_texture(decoded_img->fmt, decoded_img->w,
-                                                    decoded_img->h, decoded_img->planes[0]);
-    disp_texture_ptr = static_cast<void*>(&pm_texture);
-    gm_texture = dec->m_uhdr_gl_ctxt.create_texture(gainmap_img->fmt, gainmap_img->w,
-                                                    gainmap_img->h, gainmap_img->planes[0]);
-    gm_texture_ptr = static_cast<void*>(&gm_texture);
+    bool texture_created =
+        dec->m_uhdr_gl_ctxt.mDecodedImgTexture != 0 && dec->m_uhdr_gl_ctxt.mGainmapImgTexture != 0;
+    bool resize_effect_present = std::find_if(dec->m_effects.begin(), dec->m_effects.end(),
+                                              is_resize_effect) != dec->m_effects.end();
+    if (!texture_created && resize_effect_present &&
+        isBufferDataContiguous(dec->m_decoded_img_buffer.get()) &&
+        isBufferDataContiguous(dec->m_gainmap_img_buffer.get())) {
+      dec->m_uhdr_gl_ctxt.mDecodedImgTexture = dec->m_uhdr_gl_ctxt.create_texture(
+          dec->m_decoded_img_buffer->fmt, dec->m_decoded_img_buffer->w,
+          dec->m_decoded_img_buffer->h, dec->m_decoded_img_buffer->planes[0]);
+      dec->m_uhdr_gl_ctxt.mGainmapImgTexture = dec->m_uhdr_gl_ctxt.create_texture(
+          dec->m_gainmap_img_buffer->fmt, dec->m_gainmap_img_buffer->w,
+          dec->m_gainmap_img_buffer->h, dec->m_gainmap_img_buffer->planes[0]);
+    }
+    disp_texture_ptr = &dec->m_uhdr_gl_ctxt.mDecodedImgTexture;
+    gm_texture_ptr = &dec->m_uhdr_gl_ctxt.mGainmapImgTexture;
   }
 #endif
   for (auto& it : dec->m_effects) {
@@ -346,18 +357,6 @@ uhdr_error_info_t apply_effects(uhdr_decoder_private* dec) {
     dec->m_decoded_img_buffer = std::move(disp_img);
     dec->m_gainmap_img_buffer = std::move(gm_img);
   }
-#ifdef UHDR_ENABLE_GLES
-  if (dec->m_enable_gles) {
-    auto decoded_img = dec->m_decoded_img_buffer.get();
-    auto gainmap_img = dec->m_gainmap_img_buffer.get();
-    dec->m_uhdr_gl_ctxt.read_texture(static_cast<GLuint*>(disp_texture_ptr), decoded_img->fmt,
-                                     decoded_img->w, decoded_img->h, decoded_img->planes[0]);
-    dec->m_uhdr_gl_ctxt.read_texture(static_cast<GLuint*>(gm_texture_ptr), gainmap_img->fmt,
-                                     gainmap_img->w, gainmap_img->h, gainmap_img->planes[0]);
-    if (pm_texture) glDeleteTextures(1, &pm_texture);
-    if (gm_texture) glDeleteTextures(1, &gm_texture);
-  }
-#endif
   return g_no_error;
 }
 
@@ -1606,6 +1605,22 @@ uhdr_error_info_t uhdr_decode(uhdr_codec_private_t* dec) {
     status = ultrahdr::apply_effects(handle);
   }
 
+#ifdef UHDR_ENABLE_GLES
+  if (handle->m_enable_gles) {
+    if (handle->m_uhdr_gl_ctxt.mDecodedImgTexture != 0) {
+      handle->m_uhdr_gl_ctxt.read_texture(
+          &handle->m_uhdr_gl_ctxt.mDecodedImgTexture, handle->m_decoded_img_buffer->fmt,
+          handle->m_decoded_img_buffer->w, handle->m_decoded_img_buffer->h,
+          handle->m_decoded_img_buffer->planes[0]);
+    }
+    if (handle->m_uhdr_gl_ctxt.mGainmapImgTexture != 0) {
+      handle->m_uhdr_gl_ctxt.read_texture(
+          &handle->m_uhdr_gl_ctxt.mGainmapImgTexture, handle->m_gainmap_img_buffer->fmt,
+          handle->m_gainmap_img_buffer->w, handle->m_gainmap_img_buffer->h,
+          handle->m_gainmap_img_buffer->planes[0]);
+    }
+  }
+#endif
   return status;
 }
 


### PR DESCRIPTION
After applyGainMap, the frame buffers are copied to CPU. If image editing effects are to be applied, these are again copied to GPU. This consumes time and can be avoided. The current change defers GPU to CPU transfer to the end after all GL processing is done.

Test: ./ultrahdr_app -m 1 -j input_uhdr.jpg -o 1 -O 5
Test: ./ultrahdr_unit_test

Change-Id: I9b3e401027ab9d44e2c6aeb664fb10aee2496b52