### PR TITLE
Reuse applyGainMap GL textures if effects are to be applied

### DIFF
--- a/lib/include/ultrahdr/ultrahdrcommon.h
+++ b/lib/include/ultrahdr/ultrahdrcommon.h
@@ -227,9 +227,10 @@ typedef struct uhdr_opengl_ctxt {
   EGLConfig mEGLConfig;   /**< EGL frame buffer configuration */
 
   // GLES Context
-  GLuint mQuadVAO, mQuadVBO, mQuadEBO;    /**< GL objects */
-  GLuint mShaderProgram[UHDR_RESIZE + 1]; /**< Shader programs */
-  uhdr_error_info_t mErrorStatus;         /**< Context status */
+  GLuint mQuadVAO, mQuadVBO, mQuadEBO;           /**< GL objects */
+  GLuint mShaderProgram[UHDR_RESIZE + 1];        /**< Shader programs */
+  GLuint mDecodedImgTexture, mGainmapImgTexture; /**< GL Textures */
+  uhdr_error_info_t mErrorStatus;                /**< Context status */
 
   uhdr_opengl_ctxt();
   ~uhdr_opengl_ctxt();

--- a/lib/src/editorhelper.cpp
+++ b/lib/src/editorhelper.cpp
@@ -192,7 +192,7 @@ std::unique_ptr<uhdr_raw_image_ext_t> apply_rotate(ultrahdr::uhdr_rotate_effect_
 #ifdef UHDR_ENABLE_GLES
   if ((src->fmt == UHDR_IMG_FMT_32bppRGBA1010102 || src->fmt == UHDR_IMG_FMT_32bppRGBA8888 ||
        src->fmt == UHDR_IMG_FMT_64bppRGBAHalfFloat || src->fmt == UHDR_IMG_FMT_8bppYCbCr400) &&
-      isBufferDataContiguous(src) && gl_ctxt != nullptr) {
+      gl_ctxt != nullptr && *static_cast<GLuint*>(texture) != 0) {
     return apply_rotate_gles(desc, src, static_cast<ultrahdr::uhdr_opengl_ctxt*>(gl_ctxt),
                              static_cast<GLuint*>(texture));
   }
@@ -267,7 +267,7 @@ std::unique_ptr<uhdr_raw_image_ext_t> apply_mirror(ultrahdr::uhdr_mirror_effect_
 #ifdef UHDR_ENABLE_GLES
   if ((src->fmt == UHDR_IMG_FMT_32bppRGBA1010102 || src->fmt == UHDR_IMG_FMT_32bppRGBA8888 ||
        src->fmt == UHDR_IMG_FMT_64bppRGBAHalfFloat || src->fmt == UHDR_IMG_FMT_8bppYCbCr400) &&
-      isBufferDataContiguous(src) && gl_ctxt != nullptr) {
+      gl_ctxt != nullptr && *static_cast<GLuint*>(texture) != 0) {
     return apply_mirror_gles(desc, src, static_cast<ultrahdr::uhdr_opengl_ctxt*>(gl_ctxt),
                              static_cast<GLuint*>(texture));
   }
@@ -331,7 +331,7 @@ void apply_crop(uhdr_raw_image_t* src, int left, int top, int wd, int ht,
 #ifdef UHDR_ENABLE_GLES
   if ((src->fmt == UHDR_IMG_FMT_32bppRGBA1010102 || src->fmt == UHDR_IMG_FMT_32bppRGBA8888 ||
        src->fmt == UHDR_IMG_FMT_64bppRGBAHalfFloat || src->fmt == UHDR_IMG_FMT_8bppYCbCr400) &&
-      isBufferDataContiguous(src) && gl_ctxt != nullptr) {
+      gl_ctxt != nullptr && *static_cast<GLuint*>(texture) != 0) {
     return apply_crop_gles(src, left, top, wd, ht,
                            static_cast<ultrahdr::uhdr_opengl_ctxt*>(gl_ctxt),
                            static_cast<GLuint*>(texture));
@@ -380,7 +380,7 @@ std::unique_ptr<uhdr_raw_image_ext_t> apply_resize(ultrahdr::uhdr_resize_effect_
 #ifdef UHDR_ENABLE_GLES
   if ((src->fmt == UHDR_IMG_FMT_32bppRGBA1010102 || src->fmt == UHDR_IMG_FMT_32bppRGBA8888 ||
        src->fmt == UHDR_IMG_FMT_64bppRGBAHalfFloat || src->fmt == UHDR_IMG_FMT_8bppYCbCr400) &&
-      isBufferDataContiguous(src) && gl_ctxt != nullptr) {
+      gl_ctxt != nullptr && *static_cast<GLuint*>(texture) != 0) {
     return apply_resize_gles(src, dst_w, dst_h, static_cast<ultrahdr::uhdr_opengl_ctxt*>(gl_ctxt),
                              static_cast<GLuint*>(texture));
   }

--- a/lib/src/gpu/uhdr_gl_utils.cpp
+++ b/lib/src/gpu/uhdr_gl_utils.cpp
@@ -27,6 +27,8 @@ uhdr_opengl_ctxt::uhdr_opengl_ctxt() {
   mQuadVBO = 0;
   mQuadEBO = 0;
   mErrorStatus = g_no_error;
+  mDecodedImgTexture = 0;
+  mGainmapImgTexture = 0;
   for (int i = 0; i < UHDR_RESIZE + 1; i++) {
     mShaderProgram[i] = 0;
   }
@@ -385,6 +387,14 @@ void uhdr_opengl_ctxt::delete_opengl_ctxt() {
   if (mEGLDisplay != EGL_NO_DISPLAY) {
     eglTerminate(mEGLDisplay);
     mEGLDisplay = EGL_NO_DISPLAY;
+  }
+  if (mDecodedImgTexture) {
+    glDeleteTextures(1, &mDecodedImgTexture);
+    mDecodedImgTexture = 0;
+  }
+  if (mGainmapImgTexture) {
+    glDeleteTextures(1, &mGainmapImgTexture);
+    mGainmapImgTexture = 0;
   }
   for (int i = 0; i < UHDR_RESIZE + 1; i++) {
     if (mShaderProgram[i]) {


### PR DESCRIPTION
After applyGainMap, the frame buffers are copied to CPU. If image editing effects are to be applied, these are again copied to GPU. This consumes time and can be avoided. The current change defers GPU to CPU transfer to the end after all GL processing is done.

Test: ./ultrahdr_app -m 1 -j input_uhdr.jpg -o 1 -O 5
Test: ./ultrahdr_unit_test

Change-Id: I9b3e401027ab9d44e2c6aeb664fb10aee2496b52