### PR TITLE
enable support for odd dimensions for rgb inputs

### DIFF
--- a/fuzzer/ultrahdr_enc_fuzzer.cpp
+++ b/fuzzer/ultrahdr_enc_fuzzer.cpp
@@ -105,10 +105,14 @@ void UltraHdrEncFuzzer::process() {
     auto multi_channel_gainmap = mFdp.ConsumeBool();
 
     int width = mFdp.ConsumeIntegralInRange<int>(kMinWidth, kMaxWidth);
-    width = (width >> 1) << 1;
+    if (hdr_img_fmt == UHDR_IMG_FMT_24bppYCbCrP010 || sdr_img_fmt == UHDR_IMG_FMT_12bppYCbCr420) {
+      width = (width >> 1) << 1;
+    }
 
     int height = mFdp.ConsumeIntegralInRange<int>(kMinHeight, kMaxHeight);
-    height = (height >> 1) << 1;
+    if (hdr_img_fmt == UHDR_IMG_FMT_24bppYCbCrP010 || sdr_img_fmt == UHDR_IMG_FMT_12bppYCbCr420) {
+      height = (height >> 1) << 1;
+    }
 
     // gainmap scale factor
     auto gm_scale_factor = mFdp.ConsumeIntegralInRange<int>(1, 128);

--- a/lib/src/jpegencoderhelper.cpp
+++ b/lib/src/jpegencoderhelper.cpp
@@ -176,10 +176,19 @@ uhdr_error_info_t JpegEncoderHelper::encode(const uint8_t* planes[3], const size
       if (format == UHDR_IMG_FMT_8bppYCbCr400) {
         cinfo.input_components = 1;
         cinfo.in_color_space = JCS_GRAYSCALE;
-      } else {
+      } else if (format == UHDR_IMG_FMT_12bppYCbCr420 || format == UHDR_IMG_FMT_24bppYCbCr444 ||
+                 format == UHDR_IMG_FMT_16bppYCbCr422 || format == UHDR_IMG_FMT_16bppYCbCr440 ||
+                 format == UHDR_IMG_FMT_12bppYCbCr411 || format == UHDR_IMG_FMT_10bppYCbCr410) {
         cinfo.input_components = 3;
         cinfo.in_color_space = JCS_YCbCr;
         isGainMapImg = false;
+      } else {
+        status.error_code = UHDR_CODEC_ERROR;
+        status.has_detail = 1;
+        snprintf(status.detail, sizeof status.detail,
+                 "unrecognized input color format for encoding, color format %d", format);
+        jpeg_destroy_compress(&cinfo);
+        return status;
       }
     }
     jpeg_set_defaults(&cinfo);


### PR DESCRIPTION
The library supports input color formats UHDR_IMG_FMT_24bppYCbCrP010, UHDR_IMG_FMT_12bppYCbCr420. Both these formats have chroma planes subsampled by 2, horizontally and vertically. Each chroma pixel corresponds to 4 luma pixels. Library holds this attribute too tightly and evaluates chroma plane dimensions as half of luma plane dimensions (round_down(w / 2) and round_down(h/2)). It is possible to have 420 subsampled images with odd dimensions where the edge chroma pixels correspond to 1 or 2 luma pixels but this was not handled. For rgb inputs, this restriction need not be enforced. The current change lifts this gating.

Test: ./ultrahdr_unit_test