### PR TITLE
Fix doc of windows platform build with MSYS2

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -158,12 +158,12 @@ Uninstallation:
 sudo ninja uninstall
 ```
 
-### Windows Platform - MSYS Env
+### Windows Platform - MSYS2 Env
 
 Install the prerequisite packages before building:
 
 ```sh
-pacman -S mingw-w64-x86_64-libjpeg-turbo mingw-w64-x86_64-ninja
+pacman -S mingw-w64-ucrt-x86_64-libjpeg-turbo mingw-w64-ucrt-x86_64-ninja
 ```
 
 Compile and Test:


### PR DESCRIPTION
There might be some corrections in `dosc/build.md`.

* MSYS2 and MSys are [not the same project](https://www.msys2.org/wiki/MSYS2-introduction/), and calling it "MSYS" might be misleading for some Windows users who are not familiar with these softwares.
  > It is an **independent rewrite of MSys**, based on modern Cygwin (POSIX compatibility layer) and MinGW-w64 with the aim of better interoperability with native Windows software.
* MSYS2 now [defaults to `ucrt64`](https://www.msys2.org/news/#2022-10-29-changing-the-default-environment-from-mingw64-to-ucrt64) which has better support with modern C, see also [MSYS2's environments](https://www.msys2.org/docs/environments/#msvcrt-vs-ucrt). So we may follow them to recommend to build in `ucrt64` environment.