### PR TITLE
ossfuzz.sh: re-enable shift sanitizer

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -4,7 +4,7 @@
 [![Build Status](https://github.com/google/libultrahdr/actions/workflows/cmake_mac.yml/badge.svg?event=push)](https://github.com/google/libultrahdr/actions/workflows/cmake_mac.yml?query=event%3Apush)
 [![Build Status](https://github.com/google/libultrahdr/actions/workflows/cmake_win.yml/badge.svg?event=push)](https://github.com/google/libultrahdr/actions/workflows/cmake_win.yml?query=event%3Apush)
 [![Build Status](https://github.com/google/libultrahdr/actions/workflows/cmake_android.yml/badge.svg?event=push)](https://github.com/google/libultrahdr/actions/workflows/cmake_android.yml?query=event%3Apush)
-[![Fuzz Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/libultrahdr.svg)](https://oss-fuzz-build-logs.storage.googleapis.com/index.html#libultrahdr)
+[![Fuzz Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/libultrahdr.svg)](https://introspector.oss-fuzz.com/project-profile?project=libultrahdr)
 
 ### Requirements
 

--- a/fuzzer/ossfuzz.sh
+++ b/fuzzer/ossfuzz.sh
@@ -17,12 +17,6 @@
 test "${SRC}" != "" || exit 1
 test "${WORK}" != "" || exit 1
 
-#Opt out of shift sanitizer in undefined sanitizer
-if [[ $SANITIZER = *undefined* ]]; then
-  CFLAGS="$CFLAGS -fno-sanitize=shift"
-  CXXFLAGS="$CXXFLAGS -fno-sanitize=shift"
-fi
-
 # Build libultrahdr
 build_dir=$WORK/build
 rm -rf ${build_dir}

--- a/lib/include/ultrahdr/gainmapmath.h
+++ b/lib/include/ultrahdr/gainmapmath.h
@@ -165,6 +165,12 @@ union FloatUIntUnion {
   float fFloat;
 };
 
+// FIXME: The shift operations in this function are causing UBSAN (Undefined-shift) errors
+// Precisely,
+// runtime error: left shift of negative value -112
+// runtime error : shift exponent 125 is too large for 32 - bit type 'uint32_t'(aka 'unsigned int')
+// These need to be addressed. Until then, disable ubsan analysis for this function
+UHDR_NO_SANITIZE_UNDEFINED
 inline uint16_t floatToHalf(float f) {
   FloatUIntUnion floatUnion;
   floatUnion.fFloat = f;

--- a/lib/include/ultrahdr/ultrahdrcommon.h
+++ b/lib/include/ultrahdr/ultrahdrcommon.h
@@ -140,6 +140,23 @@
 #define INLINE inline
 #endif
 
+// '__has_attribute' macro was introduced by clang. later picked up by gcc.
+// If not supported by the current toolchain, define it to zero.
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
+// Disables undefined behavior analysis for a function.
+// GCC 4.9+ uses __attribute__((no_sanitize_undefined))
+// clang uses __attribute__((no_sanitize("undefined")))
+#if defined(__GNUC__) && ((__GNUC__ * 100 + __GNUC_MINOR__) >= 409)
+#define UHDR_NO_SANITIZE_UNDEFINED __attribute__((no_sanitize_undefined))
+#elif __has_attribute(no_sanitize)
+#define UHDR_NO_SANITIZE_UNDEFINED __attribute__((no_sanitize("undefined")))
+#else
+#define UHDR_NO_SANITIZE_UNDEFINED
+#endif
+
 static const uhdr_error_info_t g_no_error = {UHDR_CODEC_OK, 0, ""};
 
 namespace ultrahdr {


### PR DESCRIPTION
commit ea72bc8 opts uhdr library out of shift sanitizer validation. This was because function floatToHalf was raising errors. This change re-enables shift sanitizer by excluding floatToHalf from being sanitized. A more elegant solution to the problem fixed by ea72bc8.

Fixing floatToHalf() to not raise ubsan errors is the correct and permanent fix. Until then, this should help continue fuzzing.

Test: ./ultrahdr_enc_fuzzer