### PR TITLE
added support for reading raw RGB 16+16+16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 ## This is an experimental fork ##
 Most likely you are looking for the original: https://github.com/google/libultrahdr
 
-This replaces HDR raw reading of format RGBA 10+10+10+2 by format RGB 16+16+16 which can be written by most other tools.
+This adds raw input image reading of format RGB 16+16+16 which can be written by most other tools.
 
-The upper 6 bits of each 16 bit channel are ignored in this version.
+The lower 6 bits of each 16 bit channel are ignored as internally it converts to 10+10+10+2 RGBA before HDR-JPEG conversion.
+
+RGB16+16+16 format is indicated by new command line parameter -a 13.
 
 Example:
-```magick imgfile.tif -depth 16 RGB:imgfile.raw```
+```
+magick imgfile.tif -depth 16 RGB:imgfile.raw
+ultrahdr_app -m 0 -p imgfile.raw -w RAWWIDTH -h RAWHEIGHT -a 13 -z outfile.jpg
+```
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+## This is an experimental fork ##
+Most likely you are looking for the original: https://github.com/google/libultrahdr
+
+This replaces HDR raw reading of format RGBA 10+10+10+2 by format RGB 16+16+16 which can be written by most other tools.
+
+The upper 6 bits of each 16 bit channel are ignored in this version.
+
+Example:
+```magick imgfile.tif -depth 16 RGB:imgfile.raw```
+
 ## Introduction
 
 libultrahdr is an image compression library that uses gain map technology

--- a/examples/ultrahdr_app.cpp
+++ b/examples/ultrahdr_app.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * modified version supporting reading of raw RGB 16+16+16 with option -a 13, internally converted to 10+10+10+2
  */
 
 #ifdef _WIN32
@@ -141,7 +140,6 @@ class Profiler {
 
 /* reads RGB 16+16+16 bits which can be written by most tools
  * and converts to internal RGBA 10+10+10+2 bits by ignoring the lower 6 bits of each channel
- * example to create input raw file: magick imgin.tif -depth 16 RGB:imgout.raw
  * RGBA 10+10+10+2 format in memory: 32-bit little-endian: Red 9:0, Green 19:10, Blue 29:20, Alpha 31:30
  * 0: R7    ...    R0
  * 1: G5 ... G0 R9 R8
@@ -1398,7 +1396,7 @@ static void usage(const char* name) {
       stderr,
       "    -y    raw sdr intent input resource (8-bit), required for encoding scenarios 1, 2. \n");
   fprintf(stderr,
-          "    -a    raw hdr intent color format, optional. [0:p010, 5:rgba1010102 (default)] \n");
+          "    -a    raw hdr intent color format, optional. [0:p010, 5:rgba1010102 (default), 13:rgb161616 (ignoring lower 6 bits)] \n");
   fprintf(stderr,
           "    -b    raw sdr intent color format, optional. [1:yuv420, 3:rgba8888 (default)] \n");
   fprintf(stderr,

--- a/examples/ultrahdr_app.cpp
+++ b/examples/ultrahdr_app.cpp
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 #ifdef _WIN32

--- a/ultrahdr_api.h
+++ b/ultrahdr_api.h
@@ -113,6 +113,8 @@ typedef enum uhdr_img_fmt {
   UHDR_IMG_FMT_10bppYCbCr410 = 10,     /**< 8-bit-per component 4:1:0 YCbCr planar format */
   UHDR_IMG_FMT_24bppRGB888 = 11,       /**< 8-bit-per component RGB interleaved format */
   UHDR_IMG_FMT_30bppYCbCr444 = 12,     /**< 10-bit-per component 4:4:4 YCbCr planar format */
+  UHDR_IMG_FMT_48bppRGB161616 = 13,    /**< 48 bits per pixel RGB 16-bits/channel without alpha
+                                        internally converted to UHDR_IMG_FMT_32bppRGBA1010102 */
 } uhdr_img_fmt_t;                      /**< alias for enum uhdr_img_fmt */
 
 /*!\brief List of supported color gamuts */


### PR DESCRIPTION
Currently as RGB input format only RGBA 10+10+10+2 bits is supported which can't be written by most open source tools due to the difference in depth for the alpha channel compared to the RGB channels.

This change adds reading support for RGB 16+16+16 bits which is a more frequently used format, for example using ImageMagick:

magick infile.tif -depth 16 RBG:outfile.raw

To enable reading RGB 16+16+16: -a 13
to use existing RGBA 10+10+10+2 code: -a 5

Disadvantage of this quick hack: Internally it still uses the 10+10+10+2 format for storage, which means the lower 6 bits of each channel are ignored.