### PR TITLE
Use TRUE instead of true

### DIFF
--- a/lib/src/jpegencoderhelper.cpp
+++ b/lib/src/jpegencoderhelper.cpp
@@ -72,7 +72,7 @@ static boolean emptyOutputBuffer(j_compress_ptr cinfo) {
   buffer.resize(oldsize + dest->kBlockSize);
   dest->next_output_byte = &buffer[oldsize];
   dest->free_in_buffer = dest->kBlockSize;
-  return true;
+  return TRUE;
 }
 
 /*!\brief  called by jpeg_finish_compress() to flush out all the remaining encoded data. client


### PR DESCRIPTION
Some impls of jpeg, does not recognize booleans 'true' and 'false'. They maintain internal macros 'TRUE' and 'FALSE'. Use them instead for universal portability.

Test: Build