### PR TITLE
fix hang if gainmap image is larger than base image

### DIFF
--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -1406,7 +1406,7 @@ uhdr_error_info_t JpegR::applyGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_ima
   }
 
   float map_scale_factor = (float)sdr_intent->w / gainmap_img->w;
-  int map_scale_factor_rnd = std::roundf(map_scale_factor);
+  int map_scale_factor_rnd = (std::max)(1, (int)std::roundf(map_scale_factor));
 
   dest->cg = sdr_intent->cg;
   // Table will only be used when map scale factor is integer.


### PR DESCRIPTION
commit aad4ffc fixes the hang issue only partially. It only works if the gainmap image is only slightly larger than base image. If the gainmap image is much larger than base image, then map scale factor can round to zero causing enqueueJob to hang. For instance base image is 64x64 and gainmap image is 256x256. The map scale factor evaluates to 0.25 and this rounds to zero.

fixes oss-fuzz-42537374

Test: ./ultrahdr_dec_fuzzer