### PR TITLE
fix oob access while encoding image edited with crop effect

### DIFF
--- a/lib/include/ultrahdr/editorhelper.h
+++ b/lib/include/ultrahdr/editorhelper.h
@@ -65,8 +65,7 @@ typedef struct uhdr_rotate_effect : uhdr_effect_desc {
 
 /*!\brief crop effect descriptor */
 typedef struct uhdr_crop_effect : uhdr_effect_desc {
-  uhdr_crop_effect(int left, int right, int top, int bottom)
-      : m_left{left}, m_right{right}, m_top{top}, m_bottom{bottom} {}
+  uhdr_crop_effect(int left, int right, int top, int bottom);
 
   std::string to_string() {
     return "effect : crop, metadata : left, right, top, bottom - " + std::to_string(m_left) + " ," +
@@ -77,6 +76,11 @@ typedef struct uhdr_crop_effect : uhdr_effect_desc {
   int m_right;
   int m_top;
   int m_bottom;
+
+  void (*m_crop_uint8_t)(uint8_t*, uint8_t*, int, int, int, int, int, int);
+  void (*m_crop_uint16_t)(uint16_t*, uint16_t*, int, int, int, int, int, int);
+  void (*m_crop_uint32_t)(uint32_t*, uint32_t*, int, int, int, int, int, int);
+  void (*m_crop_uint64_t)(uint64_t*, uint64_t*, int, int, int, int, int, int);
 } uhdr_crop_effect_t; /**< alias for struct uhdr_crop_effect */
 
 /*!\brief resize effect descriptor */
@@ -135,8 +139,9 @@ std::unique_ptr<uhdr_raw_image_ext_t> apply_rotate_gles(ultrahdr::uhdr_rotate_ef
                                                         uhdr_opengl_ctxt* gl_ctxt,
                                                         GLuint* srcTexture);
 
-void apply_crop_gles(uhdr_raw_image_t* src, int left, int top, int wd, int ht,
-                     uhdr_opengl_ctxt* gl_ctxt, GLuint* srcTexture);
+std::unique_ptr<uhdr_raw_image_ext_t> apply_crop_gles(uhdr_raw_image_t* src, int left, int top,
+                                                      int wd, int ht, uhdr_opengl_ctxt* gl_ctxt,
+                                                      GLuint* srcTexture);
 #endif
 
 std::unique_ptr<uhdr_raw_image_ext_t> apply_rotate(ultrahdr::uhdr_rotate_effect_t* desc,
@@ -152,8 +157,10 @@ std::unique_ptr<uhdr_raw_image_ext_t> apply_resize(ultrahdr::uhdr_resize_effect_
                                                    void* gl_ctxt = nullptr,
                                                    void* texture = nullptr);
 
-void apply_crop(uhdr_raw_image_t* src, int left, int top, int wd, int ht, void* gl_ctxt = nullptr,
-                void* texture = nullptr);
+std::unique_ptr<uhdr_raw_image_ext_t> apply_crop(ultrahdr::uhdr_crop_effect_t* desc,
+                                                 uhdr_raw_image_t* src, int left, int top, int wd,
+                                                 int ht, void* gl_ctxt = nullptr,
+                                                 void* texture = nullptr);
 
 }  // namespace ultrahdr
 

--- a/lib/src/editorhelper.cpp
+++ b/lib/src/editorhelper.cpp
@@ -69,6 +69,15 @@ void mirror_buffer(T* src_buffer, T* dst_buffer, int src_w, int src_h, int src_s
   }
 }
 
+template <typename T>
+void crop_buffer(T* src_buffer, T* dst_buffer, int src_stride, int dst_stride, int left, int top,
+                 int wd, int ht) {
+  for (int row = 0; row < ht; row++) {
+    memcpy(&dst_buffer[row * dst_stride], &src_buffer[(top + row) * src_stride + left],
+           wd * sizeof(T));
+  }
+}
+
 // TODO (dichenzhang): legacy method, need to be removed
 template <typename T>
 void resize_buffer(T* src_buffer, T* dst_buffer, int src_w, int src_h, int dst_w, int dst_h,
@@ -176,6 +185,14 @@ uhdr_rotate_effect::uhdr_rotate_effect(int degree) : m_degree{degree} {
   m_rotate_uint32_t = rotate_buffer_clockwise<uint32_t>;
   m_rotate_uint64_t = rotate_buffer_clockwise<uint64_t>;
 #endif
+}
+
+uhdr_crop_effect::uhdr_crop_effect(int left, int right, int top, int bottom)
+    : m_left(left), m_right(right), m_top(top), m_bottom(bottom) {
+  m_crop_uint8_t = crop_buffer<uint8_t>;
+  m_crop_uint16_t = crop_buffer<uint16_t>;
+  m_crop_uint32_t = crop_buffer<uint32_t>;
+  m_crop_uint64_t = crop_buffer<uint64_t>;
 }
 
 uhdr_resize_effect::uhdr_resize_effect(int width, int height) : m_width{width}, m_height{height} {
@@ -326,8 +343,10 @@ std::unique_ptr<uhdr_raw_image_ext_t> apply_mirror(ultrahdr::uhdr_mirror_effect_
   return dst;
 }
 
-void apply_crop(uhdr_raw_image_t* src, int left, int top, int wd, int ht,
-                [[maybe_unused]] void* gl_ctxt, [[maybe_unused]] void* texture) {
+std::unique_ptr<uhdr_raw_image_ext_t> apply_crop(ultrahdr::uhdr_crop_effect_t* desc,
+                                                 uhdr_raw_image_t* src, int left, int top, int wd,
+                                                 int ht, [[maybe_unused]] void* gl_ctxt,
+                                                 [[maybe_unused]] void* texture) {
 #ifdef UHDR_ENABLE_GLES
   if ((src->fmt == UHDR_IMG_FMT_32bppRGBA1010102 || src->fmt == UHDR_IMG_FMT_32bppRGBA8888 ||
        src->fmt == UHDR_IMG_FMT_64bppRGBAHalfFloat || src->fmt == UHDR_IMG_FMT_8bppYCbCr400) &&
@@ -337,40 +356,57 @@ void apply_crop(uhdr_raw_image_t* src, int left, int top, int wd, int ht,
                            static_cast<GLuint*>(texture));
   }
 #endif
+  std::unique_ptr<uhdr_raw_image_ext_t> dst =
+      std::make_unique<uhdr_raw_image_ext_t>(src->fmt, src->cg, src->ct, src->range, wd, ht, 64);
+
   if (src->fmt == UHDR_IMG_FMT_24bppYCbCrP010) {
     uint16_t* src_buffer = static_cast<uint16_t*>(src->planes[UHDR_PLANE_Y]);
-    src->planes[UHDR_PLANE_Y] = &src_buffer[top * src->stride[UHDR_PLANE_Y] + left];
+    uint16_t* dst_buffer = static_cast<uint16_t*>(dst->planes[UHDR_PLANE_Y]);
+    desc->m_crop_uint16_t(src_buffer, dst_buffer, src->stride[UHDR_PLANE_Y],
+                          dst->stride[UHDR_PLANE_Y], left, top, wd, ht);
     uint32_t* src_uv_buffer = static_cast<uint32_t*>(src->planes[UHDR_PLANE_UV]);
-    src->planes[UHDR_PLANE_UV] =
-        &src_uv_buffer[(top / 2) * (src->stride[UHDR_PLANE_UV] / 2) + (left / 2)];
+    uint32_t* dst_uv_buffer = static_cast<uint32_t*>(dst->planes[UHDR_PLANE_UV]);
+    desc->m_crop_uint32_t(src_uv_buffer, dst_uv_buffer, src->stride[UHDR_PLANE_UV] / 2,
+                          dst->stride[UHDR_PLANE_UV] / 2, left / 2, top / 2, wd / 2, ht / 2);
   } else if (src->fmt == UHDR_IMG_FMT_12bppYCbCr420 || src->fmt == UHDR_IMG_FMT_8bppYCbCr400) {
     uint8_t* src_buffer = static_cast<uint8_t*>(src->planes[UHDR_PLANE_Y]);
-    src->planes[UHDR_PLANE_Y] = &src_buffer[top * src->stride[UHDR_PLANE_Y] + left];
+    uint8_t* dst_buffer = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_Y]);
+    desc->m_crop_uint8_t(src_buffer, dst_buffer, src->stride[UHDR_PLANE_Y],
+                         dst->stride[UHDR_PLANE_Y], left, top, wd, ht);
     if (src->fmt == UHDR_IMG_FMT_12bppYCbCr420) {
       for (int i = 1; i < 3; i++) {
         src_buffer = static_cast<uint8_t*>(src->planes[i]);
-        src->planes[i] = &src_buffer[(top / 2) * src->stride[i] + (left / 2)];
+        dst_buffer = static_cast<uint8_t*>(dst->planes[i]);
+        desc->m_crop_uint8_t(src_buffer, dst_buffer, src->stride[i], dst->stride[i], left / 2,
+                             top / 2, wd / 2, ht / 2);
       }
     }
   } else if (src->fmt == UHDR_IMG_FMT_32bppRGBA1010102 || src->fmt == UHDR_IMG_FMT_32bppRGBA8888) {
     uint32_t* src_buffer = static_cast<uint32_t*>(src->planes[UHDR_PLANE_PACKED]);
-    src->planes[UHDR_PLANE_PACKED] = &src_buffer[top * src->stride[UHDR_PLANE_PACKED] + left];
+    uint32_t* dst_buffer = static_cast<uint32_t*>(dst->planes[UHDR_PLANE_PACKED]);
+    desc->m_crop_uint32_t(src_buffer, dst_buffer, src->stride[UHDR_PLANE_PACKED],
+                          dst->stride[UHDR_PLANE_PACKED], left, top, wd, ht);
   } else if (src->fmt == UHDR_IMG_FMT_64bppRGBAHalfFloat) {
     uint64_t* src_buffer = static_cast<uint64_t*>(src->planes[UHDR_PLANE_PACKED]);
-    src->planes[UHDR_PLANE_PACKED] = &src_buffer[top * src->stride[UHDR_PLANE_PACKED] + left];
+    uint64_t* dst_buffer = static_cast<uint64_t*>(dst->planes[UHDR_PLANE_PACKED]);
+    desc->m_crop_uint64_t(src_buffer, dst_buffer, src->stride[UHDR_PLANE_PACKED],
+                          dst->stride[UHDR_PLANE_PACKED], left, top, wd, ht);
   } else if (src->fmt == UHDR_IMG_FMT_24bppYCbCr444) {
     for (int i = 0; i < 3; i++) {
       uint8_t* src_buffer = static_cast<uint8_t*>(src->planes[i]);
-      src->planes[i] = &src_buffer[top * src->stride[i] + left];
+      uint8_t* dst_buffer = static_cast<uint8_t*>(dst->planes[i]);
+      desc->m_crop_uint8_t(src_buffer, dst_buffer, src->stride[i], dst->stride[i], left, top, wd,
+                           ht);
     }
   } else if (src->fmt == UHDR_IMG_FMT_30bppYCbCr444) {
     for (int i = 0; i < 3; i++) {
       uint16_t* src_buffer = static_cast<uint16_t*>(src->planes[i]);
-      src->planes[i] = &src_buffer[top * src->stride[i] + left];
+      uint16_t* dst_buffer = static_cast<uint16_t*>(dst->planes[i]);
+      desc->m_crop_uint16_t(src_buffer, dst_buffer, src->stride[UHDR_PLANE_PACKED],
+                            dst->stride[UHDR_PLANE_PACKED], left, top, wd, ht);
     }
   }
-  src->w = wd;
-  src->h = ht;
+  return dst;
 }
 
 std::unique_ptr<uhdr_raw_image_ext_t> apply_resize(ultrahdr::uhdr_resize_effect_t* desc,

--- a/lib/src/ultrahdr_api.cpp
+++ b/lib/src/ultrahdr_api.cpp
@@ -187,7 +187,8 @@ uhdr_error_info_t apply_effects(uhdr_encoder_private* enc) {
                  crop_height);
         return status;
       }
-      apply_crop(hdr_raw_entry.get(), left, top, crop_width, crop_height);
+      hdr_img = apply_crop(dynamic_cast<ultrahdr::uhdr_crop_effect_t*>(it), hdr_raw_entry.get(),
+                           left, top, crop_width, crop_height);
       if (enc->m_raw_images.find(UHDR_SDR_IMG) != enc->m_raw_images.end()) {
         auto& sdr_raw_entry = enc->m_raw_images.find(UHDR_SDR_IMG)->second;
         if (crop_width % 2 != 0 && sdr_raw_entry->fmt == UHDR_IMG_FMT_12bppYCbCr420) {
@@ -210,9 +211,9 @@ uhdr_error_info_t apply_effects(uhdr_encoder_private* enc) {
                    crop_height);
           return status;
         }
-        apply_crop(sdr_raw_entry.get(), left, top, crop_width, crop_height);
+        sdr_img = apply_crop(dynamic_cast<ultrahdr::uhdr_crop_effect_t*>(it), sdr_raw_entry.get(),
+                             left, top, crop_width, crop_height);
       }
-      continue;
     } else if (nullptr != dynamic_cast<uhdr_resize_effect_t*>(it)) {
       auto resize_effect = dynamic_cast<uhdr_resize_effect_t*>(it);
       int dst_w = resize_effect->m_width;
@@ -372,10 +373,10 @@ uhdr_error_info_t apply_effects(uhdr_decoder_private* dec) {
         return status;
       }
 
-      apply_crop(disp, left, top, right - left, bottom - top, gl_ctxt, disp_texture_ptr);
-      apply_crop(gm, gm_left, gm_top, (gm_right - gm_left), (gm_bottom - gm_top), gl_ctxt,
-                 gm_texture_ptr);
-      continue;
+      disp_img = apply_crop(dynamic_cast<ultrahdr::uhdr_crop_effect_t*>(it), disp, left, top,
+                            right - left, bottom - top, gl_ctxt, disp_texture_ptr);
+      gm_img = apply_crop(dynamic_cast<ultrahdr::uhdr_crop_effect_t*>(it), gm, gm_left, gm_top,
+                          (gm_right - gm_left), (gm_bottom - gm_top), gl_ctxt, gm_texture_ptr);
     } else if (nullptr != dynamic_cast<uhdr_resize_effect_t*>(it)) {
       auto resize_effect = dynamic_cast<uhdr_resize_effect_t*>(it);
       int dst_w = resize_effect->m_width;

--- a/tests/editorhelper_test.cpp
+++ b/tests/editorhelper_test.cpp
@@ -333,28 +333,28 @@ TEST_P(EditorHelperTest, Crop) {
                     std::to_string(height) + " format: " + std::to_string(fmt);
   initImageHandle(&img_a, width, height, fmt);
   ASSERT_TRUE(loadFile(filename.c_str(), &img_a)) << "unable to load file " << filename;
-  uhdr_raw_image_t img_copy = img_a;
+  ultrahdr::uhdr_crop_effect_t crop(left, left + crop_wd, top, top + crop_ht);
 #ifdef UHDR_ENABLE_GLES
   if (gl_ctxt != nullptr) {
     Texture = opengl_ctxt->create_texture(img_a.fmt, img_a.w, img_a.h, img_a.planes[0]);
     texture = static_cast<void*>(&Texture);
   }
 #endif
-  apply_crop(&img_copy, left, top, crop_wd, crop_ht, gl_ctxt, texture);
+  auto dst = apply_crop(&crop, &img_a, left, top, crop_wd, crop_ht, gl_ctxt, texture);
 #ifdef UHDR_ENABLE_GLES
   if (gl_ctxt != nullptr) {
-    opengl_ctxt->read_texture(static_cast<GLuint*>(texture), img_copy.fmt, img_copy.w, img_copy.h,
-                              img_copy.planes[0]);
+    opengl_ctxt->read_texture(static_cast<GLuint*>(texture), dst->fmt, dst->w, dst->h,
+                              dst->planes[0]);
   }
 #endif
-  ASSERT_EQ(img_a.fmt, img_copy.fmt) << msg;
-  ASSERT_EQ(img_a.cg, img_copy.cg) << msg;
-  ASSERT_EQ(img_a.ct, img_copy.ct) << msg;
-  ASSERT_EQ(img_a.range, img_copy.range) << msg;
-  ASSERT_EQ(img_copy.w, crop_wd) << msg;
-  ASSERT_EQ(img_copy.h, crop_ht) << msg;
+  ASSERT_EQ(img_a.fmt, dst->fmt) << msg;
+  ASSERT_EQ(img_a.cg, dst->cg) << msg;
+  ASSERT_EQ(img_a.ct, dst->ct) << msg;
+  ASSERT_EQ(img_a.range, dst->range) << msg;
+  ASSERT_EQ(dst->w, crop_wd) << msg;
+  ASSERT_EQ(dst->h, crop_ht) << msg;
 #ifdef DUMP_OUTPUT
-  if (!writeFile("cropped", &img_copy)) {
+  if (!writeFile("cropped", dst.get())) {
     std::cerr << "unable to write output file" << std::endl;
   }
 #endif
@@ -470,20 +470,20 @@ TEST_P(EditorHelperTest, MultipleEffects) {
                         std::to_string(dst->w) + " x " + std::to_string(dst->h) +
                         " format: " + std::to_string(fmt);
   }
-  uhdr_raw_image_ext_t* img_copy = dst.get();
-  apply_crop(img_copy, left, top, crop_wd, crop_ht, gl_ctxt, texture);
+  ultrahdr::uhdr_crop_effect_t crop(left, left + crop_wd, top, top + crop_ht);
+  dst = apply_crop(&crop, dst.get(), left, top, crop_wd, crop_ht, gl_ctxt, texture);
 #ifdef UHDR_ENABLE_GLES
   if (gl_ctxt != nullptr) {
-    opengl_ctxt->read_texture(static_cast<GLuint*>(texture), img_copy->fmt, img_copy->w,
-                              img_copy->h, img_copy->planes[0]);
+    opengl_ctxt->read_texture(static_cast<GLuint*>(texture), dst->fmt, dst->w, dst->h,
+                              dst->planes[0]);
   }
 #endif
-  ASSERT_EQ(dst->fmt, img_copy->fmt) << msg;
-  ASSERT_EQ(dst->cg, img_copy->cg) << msg;
-  ASSERT_EQ(dst->ct, img_copy->ct) << msg;
-  ASSERT_EQ(dst->range, img_copy->range) << msg;
-  ASSERT_EQ(crop_wd, img_copy->w) << msg;
-  ASSERT_EQ(crop_ht, img_copy->h) << msg;
+  ASSERT_EQ(img_a.fmt, dst->fmt) << msg;
+  ASSERT_EQ(img_a.cg, dst->cg) << msg;
+  ASSERT_EQ(img_a.ct, dst->ct) << msg;
+  ASSERT_EQ(img_a.range, dst->range) << msg;
+  ASSERT_EQ(crop_wd, dst->w) << msg;
+  ASSERT_EQ(crop_ht, dst->h) << msg;
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
previous crop implementation involved pointer manipulation. That is base address of plane buffers are offseted by `top * stride + left`. While encoding these buffers, due to alignment requirements of jpeg_write_raw_data, during last MCU row oob access is seen. This change modifies the crop implementation from in-place to new alloc + copy and resolves the oob access issue.

fixes oss-fuzz-371659888

Test: ./ultrahdr_enc_fuzzer <clusterfuzz-vector>

Change-Id: Icf3e5c614c20925c3570d44cda43bc6a3ac02ef3