### PR TITLE
Update resize implementation of editor effects

### DIFF
--- a/lib/include/ultrahdr/editorhelper.h
+++ b/lib/include/ultrahdr/editorhelper.h
@@ -95,10 +95,10 @@ typedef struct uhdr_resize_effect : uhdr_effect_desc {
   int m_width;
   int m_height;
 
-  void (*m_resize_uint8_t)(uint8_t*, uint8_t*, int, int, int, int, int, int);
-  void (*m_resize_uint16_t)(uint16_t*, uint16_t*, int, int, int, int, int, int);
-  void (*m_resize_uint32_t)(uint32_t*, uint32_t*, int, int, int, int, int, int);
-  void (*m_resize_uint64_t)(uint64_t*, uint64_t*, int, int, int, int, int, int);
+  void (*m_resize_uint8_t)(uint8_t*, uint8_t*, int, int, int, int, int, int, int, int, uint8_t,
+                           uint8_t);
+  void (*m_resize_uint16_t)(uint16_t*, uint16_t*, int, int, int, int, int, int, int, int, uint16_t,
+                            uint16_t);
 } uhdr_resize_effect_t; /**< alias for struct uhdr_resize_effect */
 
 template <typename T>
@@ -112,6 +112,11 @@ extern void mirror_buffer(T* src_buffer, T* dst_buffer, int src_w, int src_h, in
 template <typename T>
 extern void resize_buffer(T* src_buffer, T* dst_buffer, int src_w, int src_h, int dst_w, int dst_h,
                           int src_stride, int dst_stride);
+
+template <typename T>
+extern void resize_buffer(T* src_buffer, T* dst_buffer, int src_w, int src_h, int dst_w, int dst_h,
+                          int src_row_stride, int dst_row_stride, int src_pixel_stride,
+                          int dst_pixel_stride, T low_limit, T high_limit);
 
 #if (defined(UHDR_ENABLE_INTRINSICS) && (defined(__ARM_NEON__) || defined(__ARM_NEON)))
 template <typename T>
@@ -153,8 +158,7 @@ std::unique_ptr<uhdr_raw_image_ext_t> apply_mirror(ultrahdr::uhdr_mirror_effect_
                                                    void* texture = nullptr);
 
 std::unique_ptr<uhdr_raw_image_ext_t> apply_resize(ultrahdr::uhdr_resize_effect_t* desc,
-                                                   uhdr_raw_image* src, int dst_w, int dst_h,
-                                                   void* gl_ctxt = nullptr,
+                                                   uhdr_raw_image* src, void* gl_ctxt = nullptr,
                                                    void* texture = nullptr);
 
 std::unique_ptr<uhdr_raw_image_ext_t> apply_crop(ultrahdr::uhdr_crop_effect_t* desc,

--- a/lib/include/ultrahdr/ultrahdrcommon.h
+++ b/lib/include/ultrahdr/ultrahdrcommon.h
@@ -124,6 +124,8 @@
 
 #define ALIGNM(x, m) ((((x) + ((m)-1)) / (m)) * (m))
 
+#define CLIP3(x, min, max) ((x) < (min)) ? (min) : ((x) > (max)) ? (max) : (x)
+
 #define UHDR_ERR_CHECK(x)                     \
   {                                           \
     uhdr_error_info_t status = (x);           \

--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -30,6 +30,7 @@
 #include "ultrahdr/gainmapmetadata.h"
 #include "ultrahdr/ultrahdrcommon.h"
 #include "ultrahdr/jpegr.h"
+#include "ultrahdr/editorhelper.h"
 #include "ultrahdr/icc.h"
 #include "ultrahdr/multipictureformat.h"
 
@@ -1426,6 +1427,7 @@ uhdr_error_info_t JpegR::applyGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_ima
   }
 #endif
 
+  std::unique_ptr<uhdr_raw_image_ext_t> resized_gainmap = nullptr;
   {
     float primary_aspect_ratio = (float)sdr_intent->w / sdr_intent->h;
     float gainmap_aspect_ratio = (float)gainmap_img->w / gainmap_img->h;
@@ -1433,15 +1435,19 @@ uhdr_error_info_t JpegR::applyGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_ima
     // Allow 1% delta
     const float delta_tolerance = 0.01;
     if (delta_aspect_ratio / primary_aspect_ratio > delta_tolerance) {
-      uhdr_error_info_t status;
-      status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
-      status.has_detail = 1;
-      snprintf(
-          status.detail, sizeof status.detail,
-          "gain map dimensions scale factor values for height and width are different, \n primary "
-          "image resolution is %ux%u, received gain map resolution is %ux%u",
-          sdr_intent->w, sdr_intent->h, gainmap_img->w, gainmap_img->h);
-      return status;
+      uhdr_resize_effect_t resize(sdr_intent->w, sdr_intent->h);
+      resized_gainmap = apply_resize(&resize, gainmap_img);
+      if (resized_gainmap == nullptr) {
+        uhdr_error_info_t status;
+        status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
+        status.has_detail = 1;
+        snprintf(status.detail, sizeof status.detail,
+                 "gain map dimensions scale factor values for height and width are different, "
+                 "primary image resolution is %ux%u, received gain map resolution is %ux%u",
+                 sdr_intent->w, sdr_intent->h, gainmap_img->w, gainmap_img->h);
+        return status;
+      }
+      gainmap_img = resized_gainmap.get();
     }
   }
 

--- a/lib/src/ultrahdr_api.cpp
+++ b/lib/src/ultrahdr_api.cpp
@@ -237,8 +237,7 @@ uhdr_error_info_t apply_effects(uhdr_encoder_private* enc) {
                  dst_w, dst_h);
         return status;
       }
-      hdr_img =
-          apply_resize(dynamic_cast<uhdr_resize_effect_t*>(it), hdr_raw_entry.get(), dst_w, dst_h);
+      hdr_img = apply_resize(dynamic_cast<uhdr_resize_effect_t*>(it), hdr_raw_entry.get());
       if (enc->m_raw_images.find(UHDR_SDR_IMG) != enc->m_raw_images.end()) {
         auto& sdr_raw_entry = enc->m_raw_images.find(UHDR_SDR_IMG)->second;
         if ((dst_w % 2 != 0 || dst_h % 2 != 0) &&
@@ -251,8 +250,7 @@ uhdr_error_info_t apply_effects(uhdr_encoder_private* enc) {
                    dst_w, dst_h);
           return status;
         }
-        sdr_img = apply_resize(dynamic_cast<uhdr_resize_effect_t*>(it), sdr_raw_entry.get(), dst_w,
-                               dst_h);
+        sdr_img = apply_resize(dynamic_cast<uhdr_resize_effect_t*>(it), sdr_raw_entry.get());
       }
     }
 
@@ -398,12 +396,11 @@ uhdr_error_info_t apply_effects(uhdr_decoder_private* dec) {
                  ultrahdr::kMaxWidth, ultrahdr::kMaxHeight, dst_w, dst_h, dst_gm_w, dst_gm_h);
         return status;
       }
-      disp_img =
-          apply_resize(dynamic_cast<uhdr_resize_effect_t*>(it), dec->m_decoded_img_buffer.get(),
-                       dst_w, dst_h, gl_ctxt, disp_texture_ptr);
-      gm_img =
-          apply_resize(dynamic_cast<uhdr_resize_effect_t*>(it), dec->m_gainmap_img_buffer.get(),
-                       dst_gm_w, dst_gm_h, gl_ctxt, gm_texture_ptr);
+      disp_img = apply_resize(dynamic_cast<uhdr_resize_effect_t*>(it),
+                              dec->m_decoded_img_buffer.get(), gl_ctxt, disp_texture_ptr);
+      uhdr_resize_effect_t gainmap_resz_effect(dst_gm_w, dst_gm_h);
+      gm_img = apply_resize(&gainmap_resz_effect, dec->m_gainmap_img_buffer.get(), gl_ctxt,
+                            gm_texture_ptr);
     }
 
     if (disp_img == nullptr || gm_img == nullptr) {

--- a/tests/editorhelper_test.cpp
+++ b/tests/editorhelper_test.cpp
@@ -377,7 +377,7 @@ TEST_P(EditorHelperTest, Resize) {
     texture = static_cast<void*>(&Texture);
   }
 #endif
-  auto dst = apply_resize(&resize, &img_a, width / 2, height / 2, gl_ctxt, texture);
+  auto dst = apply_resize(&resize, &img_a, gl_ctxt, texture);
 #ifdef UHDR_ENABLE_GLES
   if (gl_ctxt != nullptr) {
     opengl_ctxt->read_texture(static_cast<GLuint*>(texture), dst->fmt, dst->w, dst->h,
@@ -404,7 +404,8 @@ TEST_P(EditorHelperTest, MultipleEffects) {
   ASSERT_TRUE(loadFile(filename.c_str(), &img_a)) << "unable to load file " << filename;
   ultrahdr::uhdr_rotate_effect_t r90(90), r180(180), r270(270);
   ultrahdr::uhdr_mirror_effect_t mhorz(UHDR_MIRROR_HORIZONTAL), mvert(UHDR_MIRROR_VERTICAL);
-  ultrahdr::uhdr_resize_effect_t resize(width / 2, height / 2);
+  ultrahdr::uhdr_resize_effect_t resize(width * 2, height * 2);
+
 #ifdef UHDR_ENABLE_GLES
   if (gl_ctxt != nullptr) {
     Texture = opengl_ctxt->create_texture(img_a.fmt, img_a.w, img_a.h, img_a.planes[0]);
@@ -447,13 +448,14 @@ TEST_P(EditorHelperTest, MultipleEffects) {
 #endif
   ASSERT_NO_FATAL_FAILURE(compareImg(&img_a, dst.get())) << msg;
 
-  dst = apply_resize(&resize, dst.get(), width * 2, height * 2, gl_ctxt, texture);
+  dst = apply_resize(&resize, dst.get(), gl_ctxt, texture);
 #ifdef UHDR_ENABLE_GLES
   if (gl_ctxt != nullptr) {
     opengl_ctxt->read_texture(static_cast<GLuint*>(texture), dst->fmt, dst->w, dst->h,
                               dst->planes[0]);
   }
 #endif
+
   ASSERT_EQ(img_a.fmt, dst->fmt) << msg;
   ASSERT_EQ(img_a.cg, dst->cg) << msg;
   ASSERT_EQ(img_a.ct, dst->ct) << msg;


### PR DESCRIPTION
This change substitutes legacy resize function with 1D bicubic interpolate function. This impl. is also used to resize gainmap image if required during applyRecoveryMap process.

Test: ./ultrahdr_unit_test