### PR TITLE
use resize filter during applyGainMap process

### DIFF
--- a/lib/include/ultrahdr/editorhelper.h
+++ b/lib/include/ultrahdr/editorhelper.h
@@ -113,6 +113,8 @@ template <typename T>
 extern void resize_buffer(T* src_buffer, T* dst_buffer, int src_w, int src_h, int dst_w, int dst_h,
                           int src_stride, int dst_stride);
 
+std::unique_ptr<uhdr_raw_image_ext_t> resize_image(uhdr_raw_image_t* src, int dst_w, int dst_h);
+
 #if (defined(UHDR_ENABLE_INTRINSICS) && (defined(__ARM_NEON__) || defined(__ARM_NEON)))
 template <typename T>
 extern void mirror_buffer_neon(T* src_buffer, T* dst_buffer, int src_w, int src_h, int src_stride,

--- a/lib/include/ultrahdr/gainmapmath.h
+++ b/lib/include/ultrahdr/gainmapmath.h
@@ -369,8 +369,10 @@ class LookUpTable {
 Color getYuv444Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
 Color getYuv422Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
 Color getYuv420Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
+Color getYuv400Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
 Color getP010Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
 Color getYuv444Pixel10bit(uhdr_raw_image_t* image, size_t x, size_t y);
+Color getRgb888Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
 Color getRgba8888Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
 Color getRgba1010102Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
 Color getRgbaF16Pixel(uhdr_raw_image_t* image, size_t x, size_t y);
@@ -388,6 +390,8 @@ Color sampleRgbaF16(uhdr_raw_image_t* image, size_t map_scale_factor, size_t x, 
 
 // Put pixel in the image at the provided location.
 void putRgba8888Pixel(uhdr_raw_image_t* image, size_t x, size_t y, Color& pixel);
+void putRgb888Pixel(uhdr_raw_image_t* image, size_t x, size_t y, Color& pixel);
+void putYuv400Pixel(uhdr_raw_image_t* image, size_t x, size_t y, Color& pixel);
 void putYuv444Pixel(uhdr_raw_image_t* image, size_t x, size_t y, Color& pixel);
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
If the aspect ratio of the gainmap image differs from the primary image, the library throws an error. Try resizing the gainmap image to primary image dimensions before returning with error.

Test: ./ultrahdr_unit_test