### PR TITLE
add rgba8888 to yuv444 conversion using arm neon

### DIFF
--- a/lib/include/ultrahdr/gainmapmath.h
+++ b/lib/include/ultrahdr/gainmapmath.h
@@ -578,6 +578,10 @@ uhdr_error_info_t copy_raw_image(uhdr_raw_image_t* src, uhdr_raw_image_t* dst);
 std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr(
     uhdr_raw_image_t* src, bool chroma_sampling_enabled = false);
 
+#if (defined(UHDR_ENABLE_INTRINSICS) && (defined(__ARM_NEON__) || defined(__ARM_NEON)))
+std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr_neon(uhdr_raw_image_t* src);
+#endif
+
 bool floatToSignedFraction(float v, int32_t* numerator, uint32_t* denominator);
 bool floatToUnsignedFraction(float v, uint32_t* numerator, uint32_t* denominator);
 

--- a/lib/src/dsp/arm/gainmapmath_neon.cpp
+++ b/lib/src/dsp/arm/gainmapmath_neon.cpp
@@ -317,4 +317,163 @@ uhdr_error_info_t convertYuv_neon(uhdr_raw_image_t* image, uhdr_color_gamut_t sr
   return status;
 }
 
+// Scale all coefficients by 2^14 to avoid needing floating-point arithmetic. This can cause an off
+// by one error compared to the scalar floating-point implementation.
+
+// In the 3x3 conversion matrix, 0.5 is duplicated. But represented as only one entry in lut leaving
+// with an array size of 8 elements.
+
+// RGB Bt709 -> Yuv Bt709
+// Y = 0.212639 * R + 0.715169 * G + 0.072192 * B
+// U = -0.114592135 * R + -0.385407865 * G + 0.5 * B
+// V = 0.5 * R + -0.454155718 * G + -0.045844282 * B
+ALIGNED(16)
+const uint16_t kRgb709ToYuv_coeffs_neon[8] = {3484, 11717, 1183, 1877, 6315, 8192, 7441, 751};
+
+// RGB Display P3 -> Yuv Display P3
+// Y = 0.2289746 * R + 0.6917385 * G + 0.0792869 * B
+// U = -0.124346335 * R + -0.375653665 * G + 0.5 * B
+// V = 0.5 * R + -0.448583471 * G + -0.051416529 * B
+ALIGNED(16)
+const uint16_t kRgbDispP3ToYuv_coeffs_neon[8] = {3752, 11333, 1299, 2037, 6155, 8192, 7350, 842};
+
+// RGB Bt2100 -> Yuv Bt2100
+// Y = 0.2627 * R + 0.677998 * G + 0.059302 * B
+// U = -0.13963036 * R + -0.36036964 * G + 0.5 * B
+// V = 0.5 * R + -0.459784348 * G + -0.040215652 * B
+ALIGNED(16)
+const uint16_t kRgb2100ToYuv_coeffs_neon[8] = {4304, 11108, 972, 2288, 5904, 8192, 7533, 659};
+
+// The core logic is taken from jsimd_rgb_ycc_convert_neon implementation in jccolext-neon.c of
+// libjpeg-turbo
+static void ConvertRgba8888ToYuv444_neon(uhdr_raw_image_t* src, uhdr_raw_image_t* dst,
+                                         const uint16_t* coeffs_ptr) {
+  // Implementation processes 16 pixel per iteration.
+  assert(src->stride[UHDR_PLANE_PACKED] % 16 == 0);
+  uint8_t* rgba_base_ptr = static_cast<uint8_t*>(src->planes[UHDR_PLANE_PACKED]);
+
+  uint8_t* y_base_ptr = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_Y]);
+  uint8_t* u_base_ptr = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_U]);
+  uint8_t* v_base_ptr = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_V]);
+
+  const uint16x8_t coeffs = vld1q_u16(coeffs_ptr);
+  const uint32x4_t bias = vdupq_n_u32((128 << 14) + 8191);
+
+  unsigned int h = 0;
+  do {
+    unsigned int w = 0;
+    uint8_t* rgba_ptr = rgba_base_ptr + (size_t)src->stride[UHDR_PLANE_PACKED] * 4 * h;
+    uint8_t* y_ptr = y_base_ptr + (size_t)dst->stride[UHDR_PLANE_Y] * h;
+    uint8_t* u_ptr = u_base_ptr + (size_t)dst->stride[UHDR_PLANE_U] * h;
+    uint8_t* v_ptr = v_base_ptr + (size_t)dst->stride[UHDR_PLANE_V] * h;
+    do {
+      uint8x16x4_t rgb_pixels = vld4q_u8(rgba_ptr);
+
+      uint16x8_t r_l = vmovl_u8(vget_low_u8(rgb_pixels.val[0]));
+      uint16x8_t g_l = vmovl_u8(vget_low_u8(rgb_pixels.val[1]));
+      uint16x8_t b_l = vmovl_u8(vget_low_u8(rgb_pixels.val[2]));
+      uint16x8_t r_h = vmovl_u8(vget_high_u8(rgb_pixels.val[0]));
+      uint16x8_t g_h = vmovl_u8(vget_high_u8(rgb_pixels.val[1]));
+      uint16x8_t b_h = vmovl_u8(vget_high_u8(rgb_pixels.val[2]));
+
+      /* Compute Y */
+      uint32x4_t y_ll = vmull_lane_u16(vget_low_u16(r_l), vget_low_u16(coeffs), 0);
+      y_ll = vmlal_lane_u16(y_ll, vget_low_u16(g_l), vget_low_u16(coeffs), 1);
+      y_ll = vmlal_lane_u16(y_ll, vget_low_u16(b_l), vget_low_u16(coeffs), 2);
+      uint32x4_t y_lh = vmull_lane_u16(vget_high_u16(r_l), vget_low_u16(coeffs), 0);
+      y_lh = vmlal_lane_u16(y_lh, vget_high_u16(g_l), vget_low_u16(coeffs), 1);
+      y_lh = vmlal_lane_u16(y_lh, vget_high_u16(b_l), vget_low_u16(coeffs), 2);
+      uint32x4_t y_hl = vmull_lane_u16(vget_low_u16(r_h), vget_low_u16(coeffs), 0);
+      y_hl = vmlal_lane_u16(y_hl, vget_low_u16(g_h), vget_low_u16(coeffs), 1);
+      y_hl = vmlal_lane_u16(y_hl, vget_low_u16(b_h), vget_low_u16(coeffs), 2);
+      uint32x4_t y_hh = vmull_lane_u16(vget_high_u16(r_h), vget_low_u16(coeffs), 0);
+      y_hh = vmlal_lane_u16(y_hh, vget_high_u16(g_h), vget_low_u16(coeffs), 1);
+      y_hh = vmlal_lane_u16(y_hh, vget_high_u16(b_h), vget_low_u16(coeffs), 2);
+
+      /* Compute Cb */
+      uint32x4_t cb_ll = bias;
+      cb_ll = vmlsl_lane_u16(cb_ll, vget_low_u16(r_l), vget_low_u16(coeffs), 3);
+      cb_ll = vmlsl_lane_u16(cb_ll, vget_low_u16(g_l), vget_high_u16(coeffs), 0);
+      cb_ll = vmlal_lane_u16(cb_ll, vget_low_u16(b_l), vget_high_u16(coeffs), 1);
+      uint32x4_t cb_lh = bias;
+      cb_lh = vmlsl_lane_u16(cb_lh, vget_high_u16(r_l), vget_low_u16(coeffs), 3);
+      cb_lh = vmlsl_lane_u16(cb_lh, vget_high_u16(g_l), vget_high_u16(coeffs), 0);
+      cb_lh = vmlal_lane_u16(cb_lh, vget_high_u16(b_l), vget_high_u16(coeffs), 1);
+      uint32x4_t cb_hl = bias;
+      cb_hl = vmlsl_lane_u16(cb_hl, vget_low_u16(r_h), vget_low_u16(coeffs), 3);
+      cb_hl = vmlsl_lane_u16(cb_hl, vget_low_u16(g_h), vget_high_u16(coeffs), 0);
+      cb_hl = vmlal_lane_u16(cb_hl, vget_low_u16(b_h), vget_high_u16(coeffs), 1);
+      uint32x4_t cb_hh = bias;
+      cb_hh = vmlsl_lane_u16(cb_hh, vget_high_u16(r_h), vget_low_u16(coeffs), 3);
+      cb_hh = vmlsl_lane_u16(cb_hh, vget_high_u16(g_h), vget_high_u16(coeffs), 0);
+      cb_hh = vmlal_lane_u16(cb_hh, vget_high_u16(b_h), vget_high_u16(coeffs), 1);
+
+      /* Compute Cr */
+      uint32x4_t cr_ll = bias;
+      cr_ll = vmlal_lane_u16(cr_ll, vget_low_u16(r_l), vget_high_u16(coeffs), 1);
+      cr_ll = vmlsl_lane_u16(cr_ll, vget_low_u16(g_l), vget_high_u16(coeffs), 2);
+      cr_ll = vmlsl_lane_u16(cr_ll, vget_low_u16(b_l), vget_high_u16(coeffs), 3);
+      uint32x4_t cr_lh = bias;
+      cr_lh = vmlal_lane_u16(cr_lh, vget_high_u16(r_l), vget_high_u16(coeffs), 1);
+      cr_lh = vmlsl_lane_u16(cr_lh, vget_high_u16(g_l), vget_high_u16(coeffs), 2);
+      cr_lh = vmlsl_lane_u16(cr_lh, vget_high_u16(b_l), vget_high_u16(coeffs), 3);
+      uint32x4_t cr_hl = bias;
+      cr_hl = vmlal_lane_u16(cr_hl, vget_low_u16(r_h), vget_high_u16(coeffs), 1);
+      cr_hl = vmlsl_lane_u16(cr_hl, vget_low_u16(g_h), vget_high_u16(coeffs), 2);
+      cr_hl = vmlsl_lane_u16(cr_hl, vget_low_u16(b_h), vget_high_u16(coeffs), 3);
+      uint32x4_t cr_hh = bias;
+      cr_hh = vmlal_lane_u16(cr_hh, vget_high_u16(r_h), vget_high_u16(coeffs), 1);
+      cr_hh = vmlsl_lane_u16(cr_hh, vget_high_u16(g_h), vget_high_u16(coeffs), 2);
+      cr_hh = vmlsl_lane_u16(cr_hh, vget_high_u16(b_h), vget_high_u16(coeffs), 3);
+
+      /* Descale Y values (rounding right shift) and narrow to 16-bit. */
+      uint16x8_t y_l = vcombine_u16(vrshrn_n_u32(y_ll, 14), vrshrn_n_u32(y_lh, 14));
+      uint16x8_t y_h = vcombine_u16(vrshrn_n_u32(y_hl, 14), vrshrn_n_u32(y_hh, 14));
+      /* Descale Cb values (right shift) and narrow to 16-bit. */
+      uint16x8_t cb_l = vcombine_u16(vshrn_n_u32(cb_ll, 14), vshrn_n_u32(cb_lh, 14));
+      uint16x8_t cb_h = vcombine_u16(vshrn_n_u32(cb_hl, 14), vshrn_n_u32(cb_hh, 14));
+      /* Descale Cr values (right shift) and narrow to 16-bit. */
+      uint16x8_t cr_l = vcombine_u16(vshrn_n_u32(cr_ll, 14), vshrn_n_u32(cr_lh, 14));
+      uint16x8_t cr_h = vcombine_u16(vshrn_n_u32(cr_hl, 14), vshrn_n_u32(cr_hh, 14));
+
+      /* Narrow Y, Cb, and Cr values to 8-bit and store to memory.  Buffer
+       * overwrite is permitted up to the next multiple of ALIGN_SIZE bytes.
+       */
+      vst1q_u8(y_ptr, vcombine_u8(vmovn_u16(y_l), vmovn_u16(y_h)));
+      vst1q_u8(u_ptr, vcombine_u8(vmovn_u16(cb_l), vmovn_u16(cb_h)));
+      vst1q_u8(v_ptr, vcombine_u8(vmovn_u16(cr_l), vmovn_u16(cr_h)));
+
+      /* Increment pointers. */
+      rgba_ptr += (16 * 4);
+      y_ptr += 16;
+      u_ptr += 16;
+      v_ptr += 16;
+
+      w += 16;
+    } while (w < src->w);
+  } while (++h < src->h);
+}
+
+std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr_neon(uhdr_raw_image_t* src) {
+  if (src->fmt == UHDR_IMG_FMT_32bppRGBA8888) {
+    std::unique_ptr<uhdr_raw_image_ext_t> dst = nullptr;
+    const uint16_t* coeffs_ptr = nullptr;
+
+    if (src->cg == UHDR_CG_BT_709) {
+      coeffs_ptr = kRgb709ToYuv_coeffs_neon;
+    } else if (src->cg == UHDR_CG_BT_2100) {
+      coeffs_ptr = kRgbDispP3ToYuv_coeffs_neon;
+    } else if (src->cg == UHDR_CG_DISPLAY_P3) {
+      coeffs_ptr = kRgb2100ToYuv_coeffs_neon;
+    } else {
+      return dst;
+    }
+    dst = std::make_unique<uhdr_raw_image_ext_t>(UHDR_IMG_FMT_24bppYCbCr444, src->cg, src->ct,
+                                                 UHDR_CR_FULL_RANGE, src->w, src->h, 64);
+    ConvertRgba8888ToYuv444_neon(src, dst.get(), coeffs_ptr);
+    return dst;
+  }
+  return nullptr;
+}
+
 }  // namespace ultrahdr

--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -214,7 +214,11 @@ uhdr_error_info_t JpegR::encodeJPEGR(uhdr_raw_image_t* hdr_intent, uhdr_compress
   std::unique_ptr<uhdr_raw_image_ext_t> sdr_intent_yuv_ext;
   uhdr_raw_image_t* sdr_intent_yuv = sdr_intent.get();
   if (isPixelFormatRgb(sdr_intent->fmt)) {
+#if (defined(UHDR_ENABLE_INTRINSICS) && (defined(__ARM_NEON__) || defined(__ARM_NEON)))
+    sdr_intent_yuv_ext = convert_raw_input_to_ycbcr_neon(sdr_intent.get());
+#else
     sdr_intent_yuv_ext = convert_raw_input_to_ycbcr(sdr_intent.get());
+#endif
     sdr_intent_yuv = sdr_intent_yuv_ext.get();
   }
 
@@ -249,7 +253,11 @@ uhdr_error_info_t JpegR::encodeJPEGR(uhdr_raw_image_t* hdr_intent, uhdr_raw_imag
   std::unique_ptr<uhdr_raw_image_ext_t> sdr_intent_yuv_ext;
   uhdr_raw_image_t* sdr_intent_yuv = sdr_intent;
   if (isPixelFormatRgb(sdr_intent->fmt)) {
+#if (defined(UHDR_ENABLE_INTRINSICS) && (defined(__ARM_NEON__) || defined(__ARM_NEON)))
+    sdr_intent_yuv_ext = convert_raw_input_to_ycbcr_neon(sdr_intent);
+#else
     sdr_intent_yuv_ext = convert_raw_input_to_ycbcr(sdr_intent);
+#endif
     sdr_intent_yuv = sdr_intent_yuv_ext.get();
   }
 


### PR DESCRIPTION
This change implements a neon equivalent of
convert_raw_input_to_ycbcr(). However not all combinations are handled. Only rgba888 to yuv444 conversion is supported as it happens to be the most common use case.

Test: ./ultrahdr_app <options>