### PR TITLE
enable support for xmp, iso to be build time configurable

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -40,7 +40,8 @@ cc_library {
         "lib/include",
     ],
     local_include_dirs: ["lib/include"],
-    cflags: ["-DUHDR_ENABLE_INTRINSICS"],
+    cflags: ["-DUHDR_ENABLE_INTRINSICS",
+        "-DUHDR_WRITE_XMP",],
     srcs: [
         "lib/src/icc.cpp",
         "lib/src/jpegr.cpp",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,12 @@ option_if_not_defined(UHDR_ENABLE_INTRINSICS "Build with SIMD acceleration " TRU
 option_if_not_defined(UHDR_ENABLE_GLES "Build with GPU acceleration " FALSE)
 option_if_not_defined(UHDR_ENABLE_WERROR "Build with -Werror" FALSE)
 
+# These options effect only encoding process.
+# Decoding continues to support both iso and xmp irrespective of this configuration.
+# Also, if both packets are present iso is prioritized over xmp.
+option_if_not_defined(UHDR_WRITE_XMP "Write gainmap metadata in XMP packet" FALSE)
+option_if_not_defined(UHDR_WRITE_ISO "Write gainmap metadata in ISO 21496_1 packet" TRUE)
+
 # pre-requisites
 if(UHDR_BUILD_TESTS AND EMSCRIPTEN)
   message(FATAL_ERROR "Building tests not supported for wasm targets")
@@ -198,6 +204,12 @@ if(UHDR_ENABLE_LOGS)
 endif()
 if(UHDR_ENABLE_INTRINSICS)
   add_compile_options(-DUHDR_ENABLE_INTRINSICS)
+endif()
+if(UHDR_WRITE_XMP)
+  add_compile_options(-DUHDR_WRITE_XMP)
+endif()
+if(UHDR_WRITE_ISO)
+  add_compile_options(-DUHDR_WRITE_ISO)
 endif()
 
 include(CheckCXXCompilerFlag)

--- a/docs/building.md
+++ b/docs/building.md
@@ -64,6 +64,8 @@ Following is a list of available options:
 | `UHDR_ENABLE_GLES` | OFF | Build with GPU acceleration. |
 | `UHDR_ENABLE_WERROR` | OFF | Enable -Werror when building. |
 | `UHDR_MAX_DIMENSION` | 8192 | Maximum dimension supported by the library. The library defaults to handling images upto resolution 8192x8192. For different resolution needs use this option. For example, `-DUHDR_MAX_DIMENSION=4096`. |
+| `UHDR_WRITE_XMP` | OFF | Enable writing gainmap metadata in XMP packet. <ul><li> Current implementation of XMP format supports writing only single channel gainmap metadata. To support encoding multi channel gainmap metadata, XMP format encoding is disabled by default. If enabled, metadata of all channels of gainmap image is merged into one and signalled. </li></ul> |
+| `UHDR_WRITE_ISO` | ON | Enable writing gainmap metadata in ISO 21496-1 format. |
 | `UHDR_SANITIZE_OPTIONS` | OFF | Build library with sanitize options. Values set to this parameter are passed to directly to compilation option `-fsanitize`. For example, `-DUHDR_SANITIZE_OPTIONS=address,undefined` adds `-fsanitize=address,undefined` to the list of compilation options. CMake configuration errors are raised if the compiler does not support these flags. This is useful during fuzz testing. <ul><li> As `-fsanitize` is an instrumentation option, dependencies are also built from source instead of using pre-builts. This is done by forcing `UHDR_BUILD_DEPS` to **ON** internally. </li></ul> |
 | `UHDR_BUILD_PACKAGING` | OFF | Build distribution packages using CPack. |
 | | | |

--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -54,8 +54,16 @@ uhdr_error_info_t applyGainMapGLES(uhdr_raw_image_t* sdr_intent, uhdr_raw_image_
 #endif
 
 // Gain map metadata
+#ifdef UHDR_WRITE_XMP
 static const bool kWriteXmpMetadata = true;
+#else
+static const bool kWriteXmpMetadata = false;
+#endif
+#ifdef UHDR_WRITE_ISO
+static const bool kWriteIso21496_1Metadata = true;
+#else
 static const bool kWriteIso21496_1Metadata = false;
+#endif
 
 static const string kXmpNameSpace = "http://ns.adobe.com/xap/1.0/";
 static const string kIsoNameSpace = "urn:iso:std:iso:ts:21496:-1";
@@ -551,16 +559,6 @@ uhdr_error_info_t JpegR::generateGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_
              hdr_intent->fmt);
     return status;
   }
-
-  /*if (mUseMultiChannelGainMap) {
-    if (!kWriteIso21496_1Metadata || kWriteXmpMetadata) {
-      status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
-      status.has_detail = 1;
-      snprintf(status.detail, sizeof status.detail,
-               "Multi-channel gain map is only supported for ISO 21496-1 metadata");
-      return status;
-    }
-  }*/
 
   ColorTransformFn hdrInvOetf = getInverseOetfFn(hdr_intent->ct);
   if (hdrInvOetf == nullptr) {

--- a/tests/gainmapmath_test.cpp
+++ b/tests/gainmapmath_test.cpp
@@ -1127,13 +1127,16 @@ TEST_F(GainMapMathTest, srgbInvOetfLUT) {
 
 TEST_F(GainMapMathTest, applyGainLUT) {
   for (float boost = 1.5; boost <= 12; boost++) {
-    uhdr_gainmap_metadata_ext_t metadata;
+    uhdr_gainmap_metadata_ext_t metadata(kJpegrVersion);
 
-    metadata.min_content_boost[0] = 1.0f / boost;
-    metadata.max_content_boost[0] = boost;
-    metadata.gamma[0] = 1.0f;
+    std::fill_n(metadata.min_content_boost, 3, 1.0f / boost);
+    std::fill_n(metadata.max_content_boost, 3, boost);
+    std::fill_n(metadata.gamma, 3, 1.0f);
+    std::fill_n(metadata.offset_sdr, 3, 0.0f);
+    std::fill_n(metadata.offset_hdr, 3, 0.0f);
     metadata.hdr_capacity_max = metadata.max_content_boost[0];
     metadata.hdr_capacity_min = metadata.min_content_boost[0];
+    metadata.use_base_cg = true;
     GainLUT gainLUT(&metadata);
     float weight = (log2(boost) - log2(metadata.hdr_capacity_min)) /
                    (log2(metadata.hdr_capacity_max) - log2(metadata.hdr_capacity_min));
@@ -1165,13 +1168,16 @@ TEST_F(GainMapMathTest, applyGainLUT) {
   }
 
   for (float boost = 1.5; boost <= 12; boost++) {
-    uhdr_gainmap_metadata_ext_t metadata;
+    uhdr_gainmap_metadata_ext_t metadata(kJpegrVersion);
 
-    metadata.min_content_boost[0] = 1.0f;
-    metadata.max_content_boost[0] = boost;
-    metadata.gamma[0] = 1.0f;
+    std::fill_n(metadata.min_content_boost, 3, 1.0f / boost);
+    std::fill_n(metadata.max_content_boost, 3, boost);
+    std::fill_n(metadata.gamma, 3, 1.0f);
+    std::fill_n(metadata.offset_sdr, 3, 0.0f);
+    std::fill_n(metadata.offset_hdr, 3, 0.0f);
     metadata.hdr_capacity_max = metadata.max_content_boost[0];
     metadata.hdr_capacity_min = metadata.min_content_boost[0];
+    metadata.use_base_cg = true;
     GainLUT gainLUT(&metadata);
     float weight = (log2(boost) - log2(metadata.hdr_capacity_min)) /
                    (log2(metadata.hdr_capacity_max) - log2(metadata.hdr_capacity_min));
@@ -1203,13 +1209,16 @@ TEST_F(GainMapMathTest, applyGainLUT) {
   }
 
   for (float boost = 1.5; boost <= 12; boost++) {
-    uhdr_gainmap_metadata_ext_t metadata;
+    uhdr_gainmap_metadata_ext_t metadata(kJpegrVersion);
 
-    metadata.min_content_boost[0] = 1.0f / powf(boost, 1.0f / 3.0f);
-    metadata.max_content_boost[0] = boost;
-    metadata.gamma[0] = 1.0f;
+    std::fill_n(metadata.min_content_boost, 3, 1.0f / powf(boost, 1.0f / 3.0f));
+    std::fill_n(metadata.max_content_boost, 3, boost);
+    std::fill_n(metadata.gamma, 3, 1.0f);
+    std::fill_n(metadata.offset_sdr, 3, 0.0f);
+    std::fill_n(metadata.offset_hdr, 3, 0.0f);
     metadata.hdr_capacity_max = metadata.max_content_boost[0];
     metadata.hdr_capacity_min = metadata.min_content_boost[0];
+    metadata.use_base_cg = true;
     GainLUT gainLUT(&metadata);
     float weight = (log2(boost) - log2(metadata.hdr_capacity_min)) /
                    (log2(metadata.hdr_capacity_max) - log2(metadata.hdr_capacity_min));
@@ -1328,15 +1337,16 @@ TEST_F(GainMapMathTest, EncodeGain) {
 }
 
 TEST_F(GainMapMathTest, ApplyGain) {
-  uhdr_gainmap_metadata_ext_t metadata;
+  uhdr_gainmap_metadata_ext_t metadata(kJpegrVersion);
 
-  metadata.min_content_boost[0] = 1.0f / 4.0f;
-  metadata.max_content_boost[0] = 4.0f;
-  metadata.offset_sdr[0] = 0.0f;
-  metadata.offset_hdr[0] = 0.0f;
-  metadata.gamma[0] = 1.0f;
+  std::fill_n(metadata.min_content_boost, 3, 1.0f / 4.0f);
+  std::fill_n(metadata.max_content_boost, 3, 4.0f);
+  std::fill_n(metadata.offset_sdr, 3, 0.0f);
+  std::fill_n(metadata.offset_hdr, 3, 0.0f);
+  std::fill_n(metadata.gamma, 3, 1.0f);
   metadata.hdr_capacity_max = metadata.max_content_boost[0];
   metadata.hdr_capacity_min = metadata.min_content_boost[0];
+  metadata.use_base_cg = true;
 
   EXPECT_RGB_NEAR(applyGain(RgbBlack(), 0.0f, &metadata), RgbBlack());
   EXPECT_RGB_NEAR(applyGain(RgbBlack(), 0.5f, &metadata), RgbBlack());
@@ -1348,8 +1358,8 @@ TEST_F(GainMapMathTest, ApplyGain) {
   EXPECT_RGB_NEAR(applyGain(RgbWhite(), 0.75f, &metadata), RgbWhite() * 2.0f);
   EXPECT_RGB_NEAR(applyGain(RgbWhite(), 1.0f, &metadata), RgbWhite() * 4.0f);
 
-  metadata.max_content_boost[0] = 2.0f;
-  metadata.min_content_boost[0] = 1.0f / 2.0f;
+  std::fill_n(metadata.max_content_boost, 3, 2.0f);
+  std::fill_n(metadata.min_content_boost, 3, 1.0f / 2.0f);
   metadata.hdr_capacity_max = metadata.max_content_boost[0];
   metadata.hdr_capacity_min = metadata.min_content_boost[0];
 
@@ -1359,8 +1369,8 @@ TEST_F(GainMapMathTest, ApplyGain) {
   EXPECT_RGB_NEAR(applyGain(RgbWhite(), 0.75f, &metadata), RgbWhite() * 1.41421f);
   EXPECT_RGB_NEAR(applyGain(RgbWhite(), 1.0f, &metadata), RgbWhite() * 2.0f);
 
-  metadata.max_content_boost[0] = 8.0f;
-  metadata.min_content_boost[0] = 1.0f / 8.0f;
+  std::fill_n(metadata.max_content_boost, 3, 8.0f);
+  std::fill_n(metadata.min_content_boost, 3, 1.0f / 8.0f);
   metadata.hdr_capacity_max = metadata.max_content_boost[0];
   metadata.hdr_capacity_min = metadata.min_content_boost[0];
 
@@ -1370,8 +1380,8 @@ TEST_F(GainMapMathTest, ApplyGain) {
   EXPECT_RGB_NEAR(applyGain(RgbWhite(), 0.75f, &metadata), RgbWhite() * 2.82843f);
   EXPECT_RGB_NEAR(applyGain(RgbWhite(), 1.0f, &metadata), RgbWhite() * 8.0f);
 
-  metadata.max_content_boost[0] = 8.0f;
-  metadata.min_content_boost[0] = 1.0f;
+  std::fill_n(metadata.max_content_boost, 3, 8.0f);
+  std::fill_n(metadata.min_content_boost, 3, 1.0f);
   metadata.hdr_capacity_max = metadata.max_content_boost[0];
   metadata.hdr_capacity_min = metadata.min_content_boost[0];
 
@@ -1380,8 +1390,8 @@ TEST_F(GainMapMathTest, ApplyGain) {
   EXPECT_RGB_NEAR(applyGain(RgbWhite(), 2.0f / 3.0f, &metadata), RgbWhite() * 4.0f);
   EXPECT_RGB_NEAR(applyGain(RgbWhite(), 1.0f, &metadata), RgbWhite() * 8.0f);
 
-  metadata.max_content_boost[0] = 8.0f;
-  metadata.min_content_boost[0] = 0.5f;
+  std::fill_n(metadata.max_content_boost, 3, 8.0f);
+  std::fill_n(metadata.min_content_boost, 3, 0.5f);
   metadata.hdr_capacity_max = metadata.max_content_boost[0];
   metadata.hdr_capacity_min = metadata.min_content_boost[0];
 
@@ -1392,8 +1402,8 @@ TEST_F(GainMapMathTest, ApplyGain) {
   EXPECT_RGB_NEAR(applyGain(RgbWhite(), 1.0f, &metadata), RgbWhite() * 8.0f);
 
   Color e = {{{0.0f, 0.5f, 1.0f}}};
-  metadata.max_content_boost[0] = 4.0f;
-  metadata.min_content_boost[0] = 1.0f / 4.0f;
+  std::fill_n(metadata.max_content_boost, 3, 4.0f);
+  std::fill_n(metadata.min_content_boost, 3, 1.0f / 4.0f);
   metadata.hdr_capacity_max = metadata.max_content_boost[0];
   metadata.hdr_capacity_min = metadata.min_content_boost[0];
 
@@ -1623,13 +1633,13 @@ TEST_F(GainMapMathTest, GenerateMapLuminancePq) {
 }
 
 TEST_F(GainMapMathTest, ApplyMap) {
-  uhdr_gainmap_metadata_ext_t metadata;
+  uhdr_gainmap_metadata_ext_t metadata(kJpegrVersion);
 
-  metadata.min_content_boost[0] = 1.0f / 8.0f;
-  metadata.max_content_boost[0] = 8.0f;
-  metadata.offset_sdr[0] = 0.0f;
-  metadata.offset_hdr[0] = 0.0f;
-  metadata.gamma[0] = 1.0f;
+  std::fill_n(metadata.min_content_boost, 3, 1.0f / 8.0f);
+  std::fill_n(metadata.max_content_boost, 3, 8.0f);
+  std::fill_n(metadata.offset_sdr, 3, 0.0f);
+  std::fill_n(metadata.offset_hdr, 3, 0.0f);
+  std::fill_n(metadata.gamma, 3, 1.0f);
 
   EXPECT_RGB_EQ(Recover(YuvWhite(), 1.0f, &metadata), RgbWhite() * 8.0f);
   EXPECT_RGB_EQ(Recover(YuvBlack(), 1.0f, &metadata), RgbBlack());


### PR DESCRIPTION
as per https://developer.android.com/media/platform/hdr-image-format implementations are expected to write both xmp and iso metadata by default.

Test: ./ultrahdr_app