### PR TITLE
fix primaries used for display p3 gamut

### DIFF
--- a/lib/src/icc.cpp
+++ b/lib/src/icc.cpp
@@ -601,7 +601,7 @@ std::shared_ptr<DataStruct> IccHelper::writeIccProfile(uhdr_color_transfer_t tf,
 
 bool IccHelper::tagsEqualToMatrix(const Matrix3x3& matrix, const uint8_t* red_tag,
                                   const uint8_t* green_tag, const uint8_t* blue_tag) {
-  const float tolerance = 0.001;
+  const float tolerance = 0.001f;
   Fixed r_x_fixed = Endian_SwapBE32(reinterpret_cast<int32_t*>(const_cast<uint8_t*>(red_tag))[2]);
   Fixed r_y_fixed = Endian_SwapBE32(reinterpret_cast<int32_t*>(const_cast<uint8_t*>(red_tag))[3]);
   Fixed r_z_fixed = Endian_SwapBE32(reinterpret_cast<int32_t*>(const_cast<uint8_t*>(red_tag))[4]);

--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -920,7 +920,7 @@ uhdr_error_info_t JpegR::generateGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_
       min_content_boost_log2 = (std::max)(min_content_boost_log2, suggestion);
     }
     if (fabs(max_content_boost_log2 - min_content_boost_log2) < FLT_EPSILON) {
-      max_content_boost_log2 += 0.1;  // to avoid div by zero during affine transform
+      max_content_boost_log2 += 0.1f;  // to avoid div by zero during affine transform
     }
 
     std::function<void()> encodeMap = [this, gainmap_data, map_width, dest, min_content_boost_log2,
@@ -1422,7 +1422,7 @@ uhdr_error_info_t JpegR::applyGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_ima
     float gainmap_aspect_ratio = (float)gainmap_img->w / gainmap_img->h;
     float delta_aspect_ratio = fabs(primary_aspect_ratio - gainmap_aspect_ratio);
     // Allow 1% delta
-    const float delta_tolerance = 0.01;
+    const float delta_tolerance = 0.01f;
     if (delta_aspect_ratio / primary_aspect_ratio > delta_tolerance) {
       resized_gainmap = resize_image(gainmap_img, sdr_intent->w, sdr_intent->h);
       if (resized_gainmap == nullptr) {
@@ -1697,8 +1697,8 @@ uhdr_error_info_t JpegR::parseJpegInfo(uhdr_compressed_image_t* jpeg_image, j_in
 }
 
 static float ReinhardMap(float y_hdr, float headroom) {
-  float out = 1.0 + y_hdr / (headroom * headroom);
-  out /= 1.0 + y_hdr;
+  float out = 1.0f + y_hdr / (headroom * headroom);
+  out /= 1.0f + y_hdr;
   return out * y_hdr;
 }
 

--- a/tests/gainmapmath_test.cpp
+++ b/tests/gainmapmath_test.cpp
@@ -540,9 +540,9 @@ TEST_F(GainMapMathTest, ColorDivideFloat) {
 TEST_F(GainMapMathTest, SrgbLuminance) {
   EXPECT_FLOAT_EQ(srgbLuminance(RgbBlack()), 0.0f);
   EXPECT_FLOAT_EQ(srgbLuminance(RgbWhite()), 1.0f);
-  EXPECT_FLOAT_EQ(srgbLuminance(RgbRed()), 0.2126f);
-  EXPECT_FLOAT_EQ(srgbLuminance(RgbGreen()), 0.7152f);
-  EXPECT_FLOAT_EQ(srgbLuminance(RgbBlue()), 0.0722f);
+  EXPECT_FLOAT_EQ(srgbLuminance(RgbRed()), 0.212639f);
+  EXPECT_FLOAT_EQ(srgbLuminance(RgbGreen()), 0.715169f);
+  EXPECT_FLOAT_EQ(srgbLuminance(RgbBlue()), 0.072192f);
 }
 
 TEST_F(GainMapMathTest, SrgbYuvToRgb) {
@@ -607,9 +607,9 @@ TEST_F(GainMapMathTest, SrgbTransferFunction) {
 TEST_F(GainMapMathTest, P3Luminance) {
   EXPECT_FLOAT_EQ(p3Luminance(RgbBlack()), 0.0f);
   EXPECT_FLOAT_EQ(p3Luminance(RgbWhite()), 1.0f);
-  EXPECT_FLOAT_EQ(p3Luminance(RgbRed()), 0.20949f);
-  EXPECT_FLOAT_EQ(p3Luminance(RgbGreen()), 0.72160f);
-  EXPECT_FLOAT_EQ(p3Luminance(RgbBlue()), 0.06891f);
+  EXPECT_FLOAT_EQ(p3Luminance(RgbRed()), 0.2289746f);
+  EXPECT_FLOAT_EQ(p3Luminance(RgbGreen()), 0.6917385f);
+  EXPECT_FLOAT_EQ(p3Luminance(RgbBlue()), 0.0792869f);
 }
 
 TEST_F(GainMapMathTest, P3YuvToRgb) {
@@ -666,8 +666,8 @@ TEST_F(GainMapMathTest, Bt2100Luminance) {
   EXPECT_FLOAT_EQ(bt2100Luminance(RgbBlack()), 0.0f);
   EXPECT_FLOAT_EQ(bt2100Luminance(RgbWhite()), 1.0f);
   EXPECT_FLOAT_EQ(bt2100Luminance(RgbRed()), 0.2627f);
-  EXPECT_FLOAT_EQ(bt2100Luminance(RgbGreen()), 0.6780f);
-  EXPECT_FLOAT_EQ(bt2100Luminance(RgbBlue()), 0.0593f);
+  EXPECT_FLOAT_EQ(bt2100Luminance(RgbGreen()), 0.677998f);
+  EXPECT_FLOAT_EQ(bt2100Luminance(RgbBlue()), 0.059302f);
 }
 
 TEST_F(GainMapMathTest, Bt2100YuvToRgb) {


### PR DESCRIPTION
- luminance function for p3 gamut is using weights of dci p3 instead of display p3. this is corrected. accordingly the gamut conversions involving display p3 are updated.
- increased precision of some constants used in csc

Test: ./ultrahdr_unit_test