### PR TITLE
use cicp tag info if present while parsing for gamut space

### DIFF
--- a/.github/workflows/cmake_mac.yml
+++ b/.github/workflows/cmake_mac.yml
@@ -62,7 +62,13 @@ jobs:
       uses: jwlawson/actions-setup-cmake@v2
 
     - name: Install dependencies on macOS
-      run: brew install pkg-config jpeg-turbo
+      run: |
+        if ! command -v pkg-config &> /dev/null; then
+          brew install pkg-config
+        fi
+        if ! brew list jpeg-turbo &> /dev/null; then
+          brew install jpeg-turbo
+        fi
 
     - name: Configure CMake
       shell: bash

--- a/lib/include/ultrahdr/icc.h
+++ b/lib/include/ultrahdr/icc.h
@@ -103,6 +103,10 @@ static constexpr size_t kICCTagTableEntrySize = 12;
 // bytes for a single XYZ number type (4 bytes per coordinate).
 static constexpr size_t kColorantTagSize = 20;
 
+// size should be 12; 4 bytes for type descriptor, 4 bytes reserved, one
+// byte each for primaries, transfer, matrix, range.
+static constexpr size_t kCicpTagSize = 12;
+
 static constexpr uint32_t kDisplay_Profile = SetFourByteTag('m', 'n', 't', 'r');
 static constexpr uint32_t kRGB_ColorSpace = SetFourByteTag('R', 'G', 'B', ' ');
 static constexpr uint32_t kXYZ_PCSSpace = SetFourByteTag('X', 'Y', 'Z', ' ');


### PR DESCRIPTION
color space of the image can be signalled via cicp tag in icc. While parsing for gamut space of the image, use the information present in this tag as well (if available).

Test: ./ultrahdr_app <options>