### PR TITLE
improve gainmap computation logic for dark pixels

### DIFF
--- a/lib/include/ultrahdr/gainmapmath.h
+++ b/lib/include/ultrahdr/gainmapmath.h
@@ -536,6 +536,14 @@ PutPixelFn putPixelFn(uhdr_img_fmt_t format);
 
 ////////////////////////////////////////////////////////////////////////////////
 // common utils
+static const float kHdrOffset = 1e-7f;
+static const float kSdrOffset = 1e-7f;
+
+static inline float clipNegatives(float value) { return (value < 0.0f) ? 0.0f : value; }
+
+static inline Color clipNegatives(Color e) {
+  return {{{clipNegatives(e.r), clipNegatives(e.g), clipNegatives(e.b)}}};
+}
 
 // maximum limit of normalized pixel value in float representation
 static const float kMaxPixelFloat = 1.0f;

--- a/tests/gainmapmath_test.cpp
+++ b/tests/gainmapmath_test.cpp
@@ -1276,7 +1276,7 @@ TEST_F(GainMapMathTest, EncodeGain) {
   float max_boost = log2(4.0f);
   float gamma = 1.0f;
 
-  EXPECT_EQ(affineMapGain(computeGain(0.0f, 1.0f), min_boost, max_boost, 1.0f), 128);
+  EXPECT_EQ(affineMapGain(computeGain(0.0f, 1.0f), min_boost, max_boost, 1.0f), 255);
   EXPECT_EQ(affineMapGain(computeGain(1.0f, 0.0f), min_boost, max_boost, 1.0f), 0);
   EXPECT_EQ(affineMapGain(computeGain(0.5f, 0.0f), min_boost, max_boost, 1.0f), 0);
   EXPECT_EQ(affineMapGain(computeGain(1.0f, 1.0), min_boost, max_boost, 1.0f), 128);
@@ -1322,7 +1322,7 @@ TEST_F(GainMapMathTest, EncodeGain) {
   EXPECT_EQ(affineMapGain(computeGain(1.0f, 1.0f), min_boost, max_boost, 1.0f), 64);
   EXPECT_EQ(affineMapGain(computeGain(1.0f, 8.0f), min_boost, max_boost, 1.0f), 255);
   EXPECT_EQ(affineMapGain(computeGain(1.0f, 4.0f), min_boost, max_boost, 1.0f), 191);
-  EXPECT_EQ(affineMapGain(computeGain(1.0f, 2.0f), min_boost, max_boost, 1.0f), 128);
+  EXPECT_EQ(affineMapGain(computeGain(1.0f, 2.0f), min_boost, max_boost, 1.0f), 127);
   EXPECT_EQ(affineMapGain(computeGain(1.0f, 0.7071f), min_boost, max_boost, 1.0f), 32);
   EXPECT_EQ(affineMapGain(computeGain(1.0f, 0.5f), min_boost, max_boost, 1.0f), 0);
 }


### PR DESCRIPTION
while computing gain for near blacks or pixels with channel values zero, sdr_offset is used. This value is extremely small and can result large gainmap coefficient. During encode-decode process, if this sdr pixel flips to zero, after applying gainmap the hdr pixel will blow out. It is best if the gainmap computation logic is desensitized for dark pixels.

also, conversion from wider to narrower gamut space can cause overrange values. clip only negative excursions so that domain of computeGain remains positive.

Test: ./ultrahdr_app