### PR TITLE
choose gainmap application space adaptively basing on input gamuts

### DIFF
--- a/lib/include/ultrahdr/ultrahdrcommon.h
+++ b/lib/include/ultrahdr/ultrahdrcommon.h
@@ -204,9 +204,10 @@ typedef struct uhdr_effect_desc uhdr_effect_desc_t;
 typedef struct uhdr_gainmap_metadata_ext : uhdr_gainmap_metadata {
   uhdr_gainmap_metadata_ext() {}
 
-  uhdr_gainmap_metadata_ext(std::string ver) { version = ver; }
+  uhdr_gainmap_metadata_ext(std::string ver) : version(ver), use_base_cg(true) {}
 
-  uhdr_gainmap_metadata_ext(uhdr_gainmap_metadata& metadata, std::string ver) {
+  uhdr_gainmap_metadata_ext(uhdr_gainmap_metadata& metadata, std::string ver)
+      : uhdr_gainmap_metadata_ext(ver) {
     max_content_boost = metadata.max_content_boost;
     min_content_boost = metadata.min_content_boost;
     gamma = metadata.gamma;
@@ -214,10 +215,10 @@ typedef struct uhdr_gainmap_metadata_ext : uhdr_gainmap_metadata {
     offset_hdr = metadata.offset_hdr;
     hdr_capacity_min = metadata.hdr_capacity_min;
     hdr_capacity_max = metadata.hdr_capacity_max;
-    version = ver;
   }
 
   std::string version;         /**< Ultra HDR format version */
+  bool use_base_cg;            /**< Is gainmap application space base color space */
 } uhdr_gainmap_metadata_ext_t; /**< alias for struct uhdr_gainmap_metadata */
 
 #ifdef UHDR_ENABLE_GLES

--- a/lib/src/gainmapmetadata.cpp
+++ b/lib/src/gainmapmetadata.cpp
@@ -344,16 +344,6 @@ uhdr_error_info_t uhdr_gainmap_metadata_frac::gainmapMetadataFractionToFloat(
     return status;
   }
 
-  // TODO: parse gainmap image icc and use it for color conversion during applygainmap
-  if (!from->useBaseColorSpace) {
-    uhdr_error_info_t status;
-    status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;
-    status.has_detail = 1;
-    snprintf(status.detail, sizeof status.detail,
-             "current implementation requires gainmap application space to match base color space");
-    return status;
-  }
-
   to->version = kJpegrVersion;
   to->max_content_boost = exp2((float)from->gainMapMaxN[0] / from->gainMapMaxD[0]);
   to->min_content_boost = exp2((float)from->gainMapMinN[0] / from->gainMapMinD[0]);
@@ -365,6 +355,7 @@ uhdr_error_info_t uhdr_gainmap_metadata_frac::gainmapMetadataFractionToFloat(
   to->offset_hdr = (float)from->alternateOffsetN[0] / from->alternateOffsetD[0];
   to->hdr_capacity_max = exp2((float)from->alternateHdrHeadroomN / from->alternateHdrHeadroomD);
   to->hdr_capacity_min = exp2((float)from->baseHdrHeadroomN / from->baseHdrHeadroomD);
+  to->use_base_cg = from->useBaseColorSpace;
 
   return g_no_error;
 }
@@ -381,7 +372,7 @@ uhdr_error_info_t uhdr_gainmap_metadata_frac::gainmapMetadataFloatToFraction(
   }
 
   to->backwardDirection = false;
-  to->useBaseColorSpace = true;
+  to->useBaseColorSpace = from->use_base_cg;
 
 #define CONVERT_FLT_TO_UNSIGNED_FRACTION(flt, numerator, denominator)                          \
   if (!floatToUnsignedFraction(flt, numerator, denominator)) {                                 \

--- a/lib/src/jpegrutils.cpp
+++ b/lib/src/jpegrutils.cpp
@@ -623,6 +623,7 @@ uhdr_error_info_t getMetadataFromXMP(uint8_t* xmp_data, size_t xmp_size,
     snprintf(status.detail, sizeof status.detail, "hdr intent as base rendition is not supported");
     return status;
   }
+  metadata->use_base_cg = true;
 
   return g_no_error;
 }

--- a/tests/gainmapmetadata_test.cpp
+++ b/tests/gainmapmetadata_test.cpp
@@ -50,6 +50,7 @@ TEST_F(GainMapMetadataTest, encodeMetadataThenDecode) {
   expected.offset_hdr = 0.0625f;
   expected.hdr_capacity_min = 1.0f;
   expected.hdr_capacity_max = 10000.0f / 203.0f;
+  expected.use_base_cg = false;
 
   uhdr_gainmap_metadata_frac metadata;
   EXPECT_EQ(
@@ -78,12 +79,14 @@ TEST_F(GainMapMetadataTest, encodeMetadataThenDecode) {
   EXPECT_FLOAT_EQ(expected.offset_hdr, decodedUHdrMetadata.offset_hdr);
   EXPECT_FLOAT_EQ(expected.hdr_capacity_min, decodedUHdrMetadata.hdr_capacity_min);
   EXPECT_FLOAT_EQ(expected.hdr_capacity_max, decodedUHdrMetadata.hdr_capacity_max);
+  EXPECT_EQ(expected.use_base_cg, decodedUHdrMetadata.use_base_cg);
 
   data.clear();
   expected.min_content_boost = 0.000578369f;
   expected.offset_sdr = -0.0625f;
   expected.offset_hdr = -0.0625f;
   expected.hdr_capacity_max = 1000.0f / 203.0f;
+  expected.use_base_cg = true;
 
   EXPECT_EQ(
       uhdr_gainmap_metadata_frac::gainmapMetadataFloatToFraction(&expected, &metadata).error_code,
@@ -104,6 +107,7 @@ TEST_F(GainMapMetadataTest, encodeMetadataThenDecode) {
   EXPECT_FLOAT_EQ(expected.offset_hdr, decodedUHdrMetadata.offset_hdr);
   EXPECT_FLOAT_EQ(expected.hdr_capacity_min, decodedUHdrMetadata.hdr_capacity_min);
   EXPECT_FLOAT_EQ(expected.hdr_capacity_max, decodedUHdrMetadata.hdr_capacity_max);
+  EXPECT_EQ(expected.use_base_cg, decodedUHdrMetadata.use_base_cg);
 }
 
 }  // namespace ultrahdr

--- a/tests/jpegr_test.cpp
+++ b/tests/jpegr_test.cpp
@@ -1403,6 +1403,7 @@ TEST(JpegRTest, DecodeAPIWithInvalidArgs) {
 TEST(JpegRTest, writeXmpThenRead) {
   uhdr_gainmap_metadata_ext_t metadata_expected;
   metadata_expected.version = "1.0";
+  metadata_expected.use_base_cg = true;
   metadata_expected.max_content_boost = 1.25f;
   metadata_expected.min_content_boost = 0.75f;
   metadata_expected.gamma = 1.0f;
@@ -1432,6 +1433,7 @@ TEST(JpegRTest, writeXmpThenRead) {
   EXPECT_FLOAT_EQ(metadata_expected.offset_hdr, metadata_read.offset_hdr);
   EXPECT_FLOAT_EQ(metadata_expected.hdr_capacity_min, metadata_read.hdr_capacity_min);
   EXPECT_FLOAT_EQ(metadata_expected.hdr_capacity_max, metadata_read.hdr_capacity_max);
+  EXPECT_TRUE(metadata_read.use_base_cg);
 }
 
 class JpegRAPIEncodeAndDecodeTest


### PR DESCRIPTION
during generateGainMap, the color spaces of hdr intent and sdr intent are unified. if a wider gamut space is converted to narrower-gamut this may result in pixel values less than zero and/or greater than 1. choosing offsets to keep the domain of log during gainmap computation is tricky. This can be mitigated by converting narrower gamut space data to wider gamut space. This yields lesser overrange values. current change implements this.

for this to work as intended writing xmp metadata in the bitstream needs to be disabled.

Test: ./ultrahdr_app options


Change-Id: I0155a1dc043f3c3e0493e04e5a6eabe160659476