### PR TITLE
Add FreeBSD to recognized platforms in main CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ project(libuhdr
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Android")
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
 elseif(WIN32)
 elseif(APPLE)
 else()


### PR DESCRIPTION
This allows libultrahdr to build on FreeBSD.

It appears to work fine (I was able to generate a gain mapped jpeg image that looked correct when I viewed it in Chrome), so I don't think there's anything else that needs to change for this to work.

I don't know if it's worth adding an entry for it to docs/building.md since I doubt there will be official support for it.