### PR TITLE
Add missing header for GCC 15

### DIFF
--- a/lib/include/ultrahdr/ultrahdrcommon.h
+++ b/lib/include/ultrahdr/ultrahdrcommon.h
@@ -24,6 +24,7 @@
 #include <GLES3/gl3.h>
 #endif
 
+#include <cstdint>
 #include <deque>
 #include <map>
 #include <memory>


### PR DESCRIPTION
The C++ header [`<cstdint>`](https://en.cppreference.com/w/cpp/header/cstdint.html) is explicitly required to be included with GCC 15 and beyond when using [fixed width integer types](https://en.cppreference.com/w/cpp/types/integer.html).

For more details, see the guide about [porting to GCC 15](https://gcc.gnu.org/gcc-15/porting_to.html#cxx).
