### PR TITLE
Catch potential memory corruption in applyGainmap() call

### DIFF
--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -1444,8 +1444,16 @@ uhdr_error_info_t JpegR::decodeJPEGR(uhdr_compressed_image_t* uhdr_compressed_im
     return g_no_error;
   }
 
-  UHDR_ERR_CHECK(applyGainMap(&sdr_intent, &gainmap, &uhdr_metadata, output_ct, output_format,
-                              max_display_boost, dest));
+  try {
+    UHDR_ERR_CHECK(applyGainMap(&sdr_intent, &gainmap, &uhdr_metadata, output_ct, output_format,
+                                max_display_boost, dest));
+  } catch (const std::out_of_range& e) {
+    uhdr_error_info_t status;
+    status.error_code = UHDR_CODEC_MEM_ERROR;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail, "The output buffer size is too small.");
+    return status;
+  }
 
   return g_no_error;
 }


### PR DESCRIPTION
applyGainMap() call is vulnerable to memory corruption when the buffer size of `dest` from user configuration is not big enough, which will cause crash. This change added a try-catch flow to avoid the crash.