### PR TITLE
Add MIT dual licensing (Apache-2.0 OR MIT)

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,16 +1,7 @@
 // Copyright 2022 The Android Open Source Project
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
 
 package {
     // See: http://go/android-license-faq

--- a/Android.bp
+++ b/Android.bp
@@ -1,7 +1,10 @@
 // Copyright 2022 The Android Open Source Project
 //
-// This project is dual-licensed under Apache 2.0 and MIT terms.
-// See LICENSE-APACHE and LICENSE-MIT for details.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
 
 package {
     // See: http://go/android-license-faq

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,11 @@
 #
 # Copyright (C) 2023 The Android Open Source Project
 #
-# This project is dual-licensed under Apache 2.0 and MIT terms.
-# See LICENSE-APACHE and LICENSE-MIT for details.
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
 #
 
 cmake_minimum_required(VERSION 3.15)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,8 @@
 #
 # Copyright (C) 2023 The Android Open Source Project
 #
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not
-# use this file except in compliance with the License. You may obtain a copy of
-# the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations under
-# the License.
+# This project is dual-licensed under Apache 2.0 and MIT terms.
+# See LICENSE-APACHE and LICENSE-MIT for details.
 #
 
 cmake_minimum_required(VERSION 3.15)

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-This project is dual-licensed under Apache 2.0 and MIT terms.
+This software is distributed under the terms of both the MIT license and the
+Apache License (Version 2.0).
 
 ====
 

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,30 +1,3 @@
-This project is dual-licensed under Apache 2.0 and MIT terms.
-
-====
-
-MIT License
-
-Copyright (c) 2022 The Android Open Source Project
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-====
 
                                  Apache License
                            Version 2.0, January 2004

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 The Android Open Source Project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ Configure display device characteristics (display transfer characteristics, max 
 This software is distributed under the terms of both the MIT license and the
 Apache License (Version 2.0).
 
-See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
+See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -54,3 +54,10 @@ Configure display device characteristics (display transfer characteristics, max 
 | ------------- | ------------- |
 | max_display_boost  | (optional, >= 1.0) the maximum available boost supported by a display. |
 | supported color transfer format pairs  | <table><thead><tr><th>color transfer</th><th>Color format </th></tr></thead><tbody><tr><td>SDR</td><td>32bppRGBA8888</td></tr><tr><td>HDR_LINEAR</td><td>64bppRGBAHalfFloat</td></tr><tr><td>HDR_PQ</td><td>32bppRGBA1010102 PQ</td></tr><tr><td>HDR_HLG</td><td>32bppRGBA1010102 HLG</td></tr></tbody></table> |
+
+## License
+
+This software is distributed under the terms of both the MIT license and the
+Apache License (Version 2.0).
+
+See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.

--- a/adobe-hdr-gain-map-license/Android.bp
+++ b/adobe-hdr-gain-map-license/Android.bp
@@ -1,7 +1,10 @@
 // Copyright 2023 The Android Open Source Project
 //
-// This project is dual-licensed under Apache 2.0 and MIT terms.
-// See LICENSE-APACHE and LICENSE-MIT for details.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
 
 license {
     name: "adobe_hdr_gain_map_license",

--- a/adobe-hdr-gain-map-license/Android.bp
+++ b/adobe-hdr-gain-map-license/Android.bp
@@ -1,16 +1,7 @@
 // Copyright 2023 The Android Open Source Project
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
 
 license {
     name: "adobe_hdr_gain_map_license",

--- a/benchmark/Android.bp
+++ b/benchmark/Android.bp
@@ -1,16 +1,7 @@
 // Copyright 2023 The Android Open Source Project
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
 
 package {
     // See: http://go/android-license-faq

--- a/benchmark/Android.bp
+++ b/benchmark/Android.bp
@@ -1,7 +1,10 @@
 // Copyright 2023 The Android Open Source Project
 //
-// This project is dual-licensed under Apache 2.0 and MIT terms.
-// See LICENSE-APACHE and LICENSE-MIT for details.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
 
 package {
     // See: http://go/android-license-faq

--- a/benchmark/AndroidTest.xml
+++ b/benchmark/AndroidTest.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (C) 2023 The Android Open Source Project
 
-     This project is dual-licensed under Apache 2.0 and MIT terms.
-     See LICENSE-APACHE and LICENSE-MIT for details.
+     Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+     https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+     <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+     option. This file may not be copied, modified, or distributed
+     except according to those terms.
 -->
 <configuration description="Test module config for ultrahdr benchmark tests">
     <option name="test-suite-tag" value="ultrahdr_benchmark" />

--- a/benchmark/AndroidTest.xml
+++ b/benchmark/AndroidTest.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (C) 2023 The Android Open Source Project
 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
-
-          http://www.apache.org/licenses/LICENSE-2.0
-
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
+     This project is dual-licensed under Apache 2.0 and MIT terms.
+     See LICENSE-APACHE and LICENSE-MIT for details.
 -->
 <configuration description="Test module config for ultrahdr benchmark tests">
     <option name="test-suite-tag" value="ultrahdr_benchmark" />

--- a/benchmark/DynamicConfig.xml
+++ b/benchmark/DynamicConfig.xml
@@ -1,16 +1,7 @@
 <!-- Copyright (C) 2023 The Android Open Source Project
 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
-
-          http://www.apache.org/licenses/LICENSE-2.0
-
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
+     This project is dual-licensed under Apache 2.0 and MIT terms.
+     See LICENSE-APACHE and LICENSE-MIT for details.
 -->
 
 <dynamicConfig>

--- a/benchmark/DynamicConfig.xml
+++ b/benchmark/DynamicConfig.xml
@@ -1,7 +1,10 @@
 <!-- Copyright (C) 2023 The Android Open Source Project
 
-     This project is dual-licensed under Apache 2.0 and MIT terms.
-     See LICENSE-APACHE and LICENSE-MIT for details.
+     Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+     https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+     <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+     option. This file may not be copied, modified, or distributed
+     except according to those terms.
 -->
 
 <dynamicConfig>

--- a/benchmark/benchmark_test.cpp
+++ b/benchmark/benchmark_test.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2023 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <fstream>

--- a/benchmark/benchmark_test.cpp
+++ b/benchmark/benchmark_test.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2023 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <fstream>

--- a/cmake/FindEGL.cmake
+++ b/cmake/FindEGL.cmake
@@ -1,8 +1,11 @@
 #
 # Copyright (C) 2024 The Android Open Source Project
 #
-# This project is dual-licensed under Apache 2.0 and MIT terms.
-# See LICENSE-APACHE and LICENSE-MIT for details.
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
 #
 
 #

--- a/cmake/FindEGL.cmake
+++ b/cmake/FindEGL.cmake
@@ -1,17 +1,8 @@
 #
 # Copyright (C) 2024 The Android Open Source Project
 #
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not
-# use this file except in compliance with the License. You may obtain a copy of
-# the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations under
-# the License.
+# This project is dual-licensed under Apache 2.0 and MIT terms.
+# See LICENSE-APACHE and LICENSE-MIT for details.
 #
 
 #

--- a/cmake/FindOpenGLES3.cmake
+++ b/cmake/FindOpenGLES3.cmake
@@ -1,8 +1,11 @@
 #
 # Copyright (C) 2024 The Android Open Source Project
 #
-# This project is dual-licensed under Apache 2.0 and MIT terms.
-# See LICENSE-APACHE and LICENSE-MIT for details.
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
 #
 
 #

--- a/cmake/FindOpenGLES3.cmake
+++ b/cmake/FindOpenGLES3.cmake
@@ -1,17 +1,8 @@
 #
 # Copyright (C) 2024 The Android Open Source Project
 #
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not
-# use this file except in compliance with the License. You may obtain a copy of
-# the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations under
-# the License.
+# This project is dual-licensed under Apache 2.0 and MIT terms.
+# See LICENSE-APACHE and LICENSE-MIT for details.
 #
 
 #

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -1,8 +1,11 @@
 #
 # Copyright (C) 2024 The Android Open Source Project
 #
-# This project is dual-licensed under Apache 2.0 and MIT terms.
-# See LICENSE-APACHE and LICENSE-MIT for details.
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
 #
 
 # common package configuration

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -1,17 +1,8 @@
 #
 # Copyright (C) 2024 The Android Open Source Project
 #
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not
-# use this file except in compliance with the License. You may obtain a copy of
-# the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations under
-# the License.
+# This project is dual-licensed under Apache 2.0 and MIT terms.
+# See LICENSE-APACHE and LICENSE-MIT for details.
 #
 
 # common package configuration

--- a/cmake/toolchains/aarch64-linux-gnu.cmake
+++ b/cmake/toolchains/aarch64-linux-gnu.cmake
@@ -1,17 +1,8 @@
 #
 # Copyright (C) 2023 The Android Open Source Project
 #
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not
-# use this file except in compliance with the License. You may obtain a copy of
-# the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations under
-# the License.
+# This project is dual-licensed under Apache 2.0 and MIT terms.
+# See LICENSE-APACHE and LICENSE-MIT for details.
 #
 
 if(UHDR_BUILD_CMAKE_TOOLCHAINS_AARCH64_LINUX_GNU_CMAKE_)

--- a/cmake/toolchains/aarch64-linux-gnu.cmake
+++ b/cmake/toolchains/aarch64-linux-gnu.cmake
@@ -1,8 +1,11 @@
 #
 # Copyright (C) 2023 The Android Open Source Project
 #
-# This project is dual-licensed under Apache 2.0 and MIT terms.
-# See LICENSE-APACHE and LICENSE-MIT for details.
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
 #
 
 if(UHDR_BUILD_CMAKE_TOOLCHAINS_AARCH64_LINUX_GNU_CMAKE_)

--- a/cmake/toolchains/android.cmake
+++ b/cmake/toolchains/android.cmake
@@ -1,17 +1,8 @@
 #
 # Copyright (C) 2023 The Android Open Source Project
 #
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not
-# use this file except in compliance with the License. You may obtain a copy of
-# the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations under
-# the License.
+# This project is dual-licensed under Apache 2.0 and MIT terms.
+# See LICENSE-APACHE and LICENSE-MIT for details.
 #
 
 if(UHDR_BUILD_CMAKE_TOOLCHAINS_ANDROID_CMAKE_)

--- a/cmake/toolchains/android.cmake
+++ b/cmake/toolchains/android.cmake
@@ -1,8 +1,11 @@
 #
 # Copyright (C) 2023 The Android Open Source Project
 #
-# This project is dual-licensed under Apache 2.0 and MIT terms.
-# See LICENSE-APACHE and LICENSE-MIT for details.
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
 #
 
 if(UHDR_BUILD_CMAKE_TOOLCHAINS_ANDROID_CMAKE_)

--- a/cmake/toolchains/arm-linux-gnueabihf.cmake
+++ b/cmake/toolchains/arm-linux-gnueabihf.cmake
@@ -1,8 +1,11 @@
 #
 # Copyright (C) 2023 The Android Open Source Project
 #
-# This project is dual-licensed under Apache 2.0 and MIT terms.
-# See LICENSE-APACHE and LICENSE-MIT for details.
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
 #
 
 if(UHDR_BUILD_CMAKE_TOOLCHAINS_ARM_LINUX_GNUEABIHF_CMAKE_)

--- a/cmake/toolchains/arm-linux-gnueabihf.cmake
+++ b/cmake/toolchains/arm-linux-gnueabihf.cmake
@@ -1,17 +1,8 @@
 #
 # Copyright (C) 2023 The Android Open Source Project
 #
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not
-# use this file except in compliance with the License. You may obtain a copy of
-# the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations under
-# the License.
+# This project is dual-licensed under Apache 2.0 and MIT terms.
+# See LICENSE-APACHE and LICENSE-MIT for details.
 #
 
 if(UHDR_BUILD_CMAKE_TOOLCHAINS_ARM_LINUX_GNUEABIHF_CMAKE_)

--- a/cmake/toolchains/loong64-linux-gnu.cmake
+++ b/cmake/toolchains/loong64-linux-gnu.cmake
@@ -1,17 +1,8 @@
 #
 # Copyright (C) 2023 The Android Open Source Project
 #
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not
-# use this file except in compliance with the License. You may obtain a copy of
-# the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations under
-# the License.
+# This project is dual-licensed under Apache 2.0 and MIT terms.
+# See LICENSE-APACHE and LICENSE-MIT for details.
 #
 
 if(UHDR_BUILD_CMAKE_TOOLCHAINS_LOONG64_LINUX_GNU_CMAKE_)

--- a/cmake/toolchains/loong64-linux-gnu.cmake
+++ b/cmake/toolchains/loong64-linux-gnu.cmake
@@ -1,8 +1,11 @@
 #
 # Copyright (C) 2023 The Android Open Source Project
 #
-# This project is dual-licensed under Apache 2.0 and MIT terms.
-# See LICENSE-APACHE and LICENSE-MIT for details.
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
 #
 
 if(UHDR_BUILD_CMAKE_TOOLCHAINS_LOONG64_LINUX_GNU_CMAKE_)

--- a/cmake/toolchains/riscv32-linux-gnu.cmake
+++ b/cmake/toolchains/riscv32-linux-gnu.cmake
@@ -1,17 +1,8 @@
 #
 # Copyright (C) 2023 The Android Open Source Project
 #
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not
-# use this file except in compliance with the License. You may obtain a copy of
-# the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations under
-# the License.
+# This project is dual-licensed under Apache 2.0 and MIT terms.
+# See LICENSE-APACHE and LICENSE-MIT for details.
 #
 
 if(UHDR_BUILD_CMAKE_TOOLCHAINS_RISCV32_LINUX_GNU_CMAKE_)

--- a/cmake/toolchains/riscv32-linux-gnu.cmake
+++ b/cmake/toolchains/riscv32-linux-gnu.cmake
@@ -1,8 +1,11 @@
 #
 # Copyright (C) 2023 The Android Open Source Project
 #
-# This project is dual-licensed under Apache 2.0 and MIT terms.
-# See LICENSE-APACHE and LICENSE-MIT for details.
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
 #
 
 if(UHDR_BUILD_CMAKE_TOOLCHAINS_RISCV32_LINUX_GNU_CMAKE_)

--- a/cmake/toolchains/riscv64-linux-gnu.cmake
+++ b/cmake/toolchains/riscv64-linux-gnu.cmake
@@ -1,8 +1,11 @@
 #
 # Copyright (C) 2023 The Android Open Source Project
 #
-# This project is dual-licensed under Apache 2.0 and MIT terms.
-# See LICENSE-APACHE and LICENSE-MIT for details.
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
 #
 
 if(UHDR_BUILD_CMAKE_TOOLCHAINS_RISCV64_LINUX_GNU_CMAKE_)

--- a/cmake/toolchains/riscv64-linux-gnu.cmake
+++ b/cmake/toolchains/riscv64-linux-gnu.cmake
@@ -1,17 +1,8 @@
 #
 # Copyright (C) 2023 The Android Open Source Project
 #
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not
-# use this file except in compliance with the License. You may obtain a copy of
-# the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations under
-# the License.
+# This project is dual-licensed under Apache 2.0 and MIT terms.
+# See LICENSE-APACHE and LICENSE-MIT for details.
 #
 
 if(UHDR_BUILD_CMAKE_TOOLCHAINS_RISCV64_LINUX_GNU_CMAKE_)

--- a/examples/Android.bp
+++ b/examples/Android.bp
@@ -1,16 +1,7 @@
 // Copyright 2023 The Android Open Source Project
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
 
 package {
     // See: http://go/android-license-faq

--- a/examples/Android.bp
+++ b/examples/Android.bp
@@ -1,7 +1,10 @@
 // Copyright 2023 The Android Open Source Project
 //
-// This project is dual-licensed under Apache 2.0 and MIT terms.
-// See LICENSE-APACHE and LICENSE-MIT for details.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
 
 package {
     // See: http://go/android-license-faq

--- a/examples/ultrahdr_app.cpp
+++ b/examples/ultrahdr_app.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2023 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #ifdef _WIN32

--- a/examples/ultrahdr_app.cpp
+++ b/examples/ultrahdr_app.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2023 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #ifdef _WIN32

--- a/fuzzer/Android.bp
+++ b/fuzzer/Android.bp
@@ -1,16 +1,7 @@
 // Copyright 2023 The Android Open Source Project
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
 
 package {
     // See: http://go/android-license-faq

--- a/fuzzer/Android.bp
+++ b/fuzzer/Android.bp
@@ -1,7 +1,10 @@
 // Copyright 2023 The Android Open Source Project
 //
-// This project is dual-licensed under Apache 2.0 and MIT terms.
-// See LICENSE-APACHE and LICENSE-MIT for details.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
 
 package {
     // See: http://go/android-license-faq

--- a/fuzzer/ossfuzz.sh
+++ b/fuzzer/ossfuzz.sh
@@ -1,16 +1,7 @@
 #!/bin/bash -eu
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# This project is dual-licensed under Apache 2.0 and MIT terms.
+# See LICENSE-APACHE and LICENSE-MIT for details.
 #
 ################################################################################
 # Ensure SRC and WORK are set

--- a/fuzzer/ossfuzz.sh
+++ b/fuzzer/ossfuzz.sh
@@ -1,7 +1,10 @@
 #!/bin/bash -eu
 #
-# This project is dual-licensed under Apache 2.0 and MIT terms.
-# See LICENSE-APACHE and LICENSE-MIT for details.
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
 #
 ################################################################################
 # Ensure SRC and WORK are set

--- a/fuzzer/ultrahdr_dec_fuzzer.cpp
+++ b/fuzzer/ultrahdr_dec_fuzzer.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2023 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <fuzzer/FuzzedDataProvider.h>

--- a/fuzzer/ultrahdr_dec_fuzzer.cpp
+++ b/fuzzer/ultrahdr_dec_fuzzer.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2023 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <fuzzer/FuzzedDataProvider.h>

--- a/fuzzer/ultrahdr_enc_fuzzer.cpp
+++ b/fuzzer/ultrahdr_enc_fuzzer.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2023 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <fuzzer/FuzzedDataProvider.h>

--- a/fuzzer/ultrahdr_enc_fuzzer.cpp
+++ b/fuzzer/ultrahdr_enc_fuzzer.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2023 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <fuzzer/FuzzedDataProvider.h>

--- a/fuzzer/ultrahdr_legacy_fuzzer.cpp
+++ b/fuzzer/ultrahdr_legacy_fuzzer.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2023 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <fuzzer/FuzzedDataProvider.h>

--- a/fuzzer/ultrahdr_legacy_fuzzer.cpp
+++ b/fuzzer/ultrahdr_legacy_fuzzer.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2023 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <fuzzer/FuzzedDataProvider.h>

--- a/java/UltraHdrApp.java
+++ b/java/UltraHdrApp.java
@@ -1,17 +1,8 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 import static com.google.media.codecs.ultrahdr.UltraHDRCommon.*;

--- a/java/UltraHdrApp.java
+++ b/java/UltraHdrApp.java
@@ -1,8 +1,11 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 import static com.google.media.codecs.ultrahdr.UltraHDRCommon.*;

--- a/java/com/google/media/codecs/ultrahdr/UltraHDRCommon.java
+++ b/java/com/google/media/codecs/ultrahdr/UltraHDRCommon.java
@@ -1,17 +1,8 @@
 /*
  * Copyright (C) 2024 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 package com.google.media.codecs.ultrahdr;

--- a/java/com/google/media/codecs/ultrahdr/UltraHDRCommon.java
+++ b/java/com/google/media/codecs/ultrahdr/UltraHDRCommon.java
@@ -1,8 +1,11 @@
 /*
  * Copyright (C) 2024 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 package com.google.media.codecs.ultrahdr;

--- a/java/com/google/media/codecs/ultrahdr/UltraHDRDecoder.java
+++ b/java/com/google/media/codecs/ultrahdr/UltraHDRDecoder.java
@@ -1,17 +1,8 @@
 /*
  * Copyright (C) 2024 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 package com.google.media.codecs.ultrahdr;

--- a/java/com/google/media/codecs/ultrahdr/UltraHDRDecoder.java
+++ b/java/com/google/media/codecs/ultrahdr/UltraHDRDecoder.java
@@ -1,8 +1,11 @@
 /*
  * Copyright (C) 2024 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 package com.google.media.codecs.ultrahdr;

--- a/java/com/google/media/codecs/ultrahdr/UltraHDREncoder.java
+++ b/java/com/google/media/codecs/ultrahdr/UltraHDREncoder.java
@@ -1,17 +1,8 @@
 /*
  * Copyright (C) 2024 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 package com.google.media.codecs.ultrahdr;

--- a/java/com/google/media/codecs/ultrahdr/UltraHDREncoder.java
+++ b/java/com/google/media/codecs/ultrahdr/UltraHDREncoder.java
@@ -1,8 +1,11 @@
 /*
  * Copyright (C) 2024 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 package com.google.media.codecs.ultrahdr;

--- a/java/jni/ultrahdr-jni.cpp
+++ b/java/jni/ultrahdr-jni.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <cstring>

--- a/java/jni/ultrahdr-jni.cpp
+++ b/java/jni/ultrahdr-jni.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <cstring>

--- a/lib/include/ultrahdr/dsp/arm/mem_neon.h
+++ b/lib/include/ultrahdr/dsp/arm/mem_neon.h
@@ -1,8 +1,11 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #ifndef ULTRAHDR_DSP_ARM_MEM_NEON_H

--- a/lib/include/ultrahdr/dsp/arm/mem_neon.h
+++ b/lib/include/ultrahdr/dsp/arm/mem_neon.h
@@ -1,17 +1,8 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #ifndef ULTRAHDR_DSP_ARM_MEM_NEON_H

--- a/lib/include/ultrahdr/editorhelper.h
+++ b/lib/include/ultrahdr/editorhelper.h
@@ -1,17 +1,8 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #ifndef ULTRAHDR_EDITORHELPER_H

--- a/lib/include/ultrahdr/editorhelper.h
+++ b/lib/include/ultrahdr/editorhelper.h
@@ -1,8 +1,11 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #ifndef ULTRAHDR_EDITORHELPER_H

--- a/lib/include/ultrahdr/gainmapmath.h
+++ b/lib/include/ultrahdr/gainmapmath.h
@@ -1,17 +1,8 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #ifndef ULTRAHDR_GAINMAPMATH_H

--- a/lib/include/ultrahdr/gainmapmath.h
+++ b/lib/include/ultrahdr/gainmapmath.h
@@ -1,8 +1,11 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #ifndef ULTRAHDR_GAINMAPMATH_H

--- a/lib/include/ultrahdr/gainmapmetadata.h
+++ b/lib/include/ultrahdr/gainmapmetadata.h
@@ -1,8 +1,11 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #ifndef ULTRAHDR_GAINMAPMETADATA_H

--- a/lib/include/ultrahdr/gainmapmetadata.h
+++ b/lib/include/ultrahdr/gainmapmetadata.h
@@ -1,17 +1,8 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #ifndef ULTRAHDR_GAINMAPMETADATA_H

--- a/lib/include/ultrahdr/icc.h
+++ b/lib/include/ultrahdr/icc.h
@@ -1,8 +1,11 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #ifndef ULTRAHDR_ICC_H

--- a/lib/include/ultrahdr/icc.h
+++ b/lib/include/ultrahdr/icc.h
@@ -1,17 +1,8 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #ifndef ULTRAHDR_ICC_H

--- a/lib/include/ultrahdr/jpegdecoderhelper.h
+++ b/lib/include/ultrahdr/jpegdecoderhelper.h
@@ -1,17 +1,8 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #ifndef ULTRAHDR_JPEGDECODERHELPER_H

--- a/lib/include/ultrahdr/jpegdecoderhelper.h
+++ b/lib/include/ultrahdr/jpegdecoderhelper.h
@@ -1,8 +1,11 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #ifndef ULTRAHDR_JPEGDECODERHELPER_H

--- a/lib/include/ultrahdr/jpegencoderhelper.h
+++ b/lib/include/ultrahdr/jpegencoderhelper.h
@@ -1,17 +1,8 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #ifndef ULTRAHDR_JPEGENCODERHELPER_H

--- a/lib/include/ultrahdr/jpegencoderhelper.h
+++ b/lib/include/ultrahdr/jpegencoderhelper.h
@@ -1,8 +1,11 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #ifndef ULTRAHDR_JPEGENCODERHELPER_H

--- a/lib/include/ultrahdr/jpegr.h
+++ b/lib/include/ultrahdr/jpegr.h
@@ -1,17 +1,8 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #ifndef ULTRAHDR_JPEGR_H

--- a/lib/include/ultrahdr/jpegr.h
+++ b/lib/include/ultrahdr/jpegr.h
@@ -1,8 +1,11 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #ifndef ULTRAHDR_JPEGR_H

--- a/lib/include/ultrahdr/jpegrutils.h
+++ b/lib/include/ultrahdr/jpegrutils.h
@@ -1,17 +1,8 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #ifndef ULTRAHDR_JPEGRUTILS_H

--- a/lib/include/ultrahdr/jpegrutils.h
+++ b/lib/include/ultrahdr/jpegrutils.h
@@ -1,8 +1,11 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #ifndef ULTRAHDR_JPEGRUTILS_H

--- a/lib/include/ultrahdr/multipictureformat.h
+++ b/lib/include/ultrahdr/multipictureformat.h
@@ -1,17 +1,8 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #ifndef ULTRAHDR_MULTIPICTUREFORMAT_H

--- a/lib/include/ultrahdr/multipictureformat.h
+++ b/lib/include/ultrahdr/multipictureformat.h
@@ -1,8 +1,11 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #ifndef ULTRAHDR_MULTIPICTUREFORMAT_H

--- a/lib/include/ultrahdr/ultrahdr.h
+++ b/lib/include/ultrahdr/ultrahdr.h
@@ -1,8 +1,11 @@
 /*
  * Copyright 2023 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #ifndef ULTRAHDR_ULTRAHDR_H

--- a/lib/include/ultrahdr/ultrahdr.h
+++ b/lib/include/ultrahdr/ultrahdr.h
@@ -1,17 +1,8 @@
 /*
  * Copyright 2023 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #ifndef ULTRAHDR_ULTRAHDR_H

--- a/lib/include/ultrahdr/ultrahdrcommon.h
+++ b/lib/include/ultrahdr/ultrahdrcommon.h
@@ -1,17 +1,8 @@
 /*
  * Copyright 2023 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #ifndef ULTRAHDR_ULTRAHDRCOMMON_H

--- a/lib/include/ultrahdr/ultrahdrcommon.h
+++ b/lib/include/ultrahdr/ultrahdrcommon.h
@@ -1,8 +1,11 @@
 /*
  * Copyright 2023 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #ifndef ULTRAHDR_ULTRAHDRCOMMON_H

--- a/lib/src/dsp/arm/editorhelper_neon.cpp
+++ b/lib/src/dsp/arm/editorhelper_neon.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <arm_neon.h>

--- a/lib/src/dsp/arm/editorhelper_neon.cpp
+++ b/lib/src/dsp/arm/editorhelper_neon.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <arm_neon.h>

--- a/lib/src/dsp/arm/gainmapmath_neon.cpp
+++ b/lib/src/dsp/arm/gainmapmath_neon.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include "ultrahdr/gainmapmath.h"

--- a/lib/src/dsp/arm/gainmapmath_neon.cpp
+++ b/lib/src/dsp/arm/gainmapmath_neon.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include "ultrahdr/gainmapmath.h"

--- a/lib/src/editorhelper.cpp
+++ b/lib/src/editorhelper.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <cstring>

--- a/lib/src/editorhelper.cpp
+++ b/lib/src/editorhelper.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <cstring>

--- a/lib/src/gainmapmath.cpp
+++ b/lib/src/gainmapmath.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <cmath>

--- a/lib/src/gainmapmath.cpp
+++ b/lib/src/gainmapmath.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <cmath>

--- a/lib/src/gainmapmetadata.cpp
+++ b/lib/src/gainmapmetadata.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <algorithm>

--- a/lib/src/gainmapmetadata.cpp
+++ b/lib/src/gainmapmetadata.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <algorithm>

--- a/lib/src/gpu/applygainmap_gl.cpp
+++ b/lib/src/gpu/applygainmap_gl.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include "ultrahdr/ultrahdrcommon.h"

--- a/lib/src/gpu/applygainmap_gl.cpp
+++ b/lib/src/gpu/applygainmap_gl.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include "ultrahdr/ultrahdrcommon.h"

--- a/lib/src/gpu/editorhelper_gl.cpp
+++ b/lib/src/gpu/editorhelper_gl.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <ultrahdr/editorhelper.h>

--- a/lib/src/gpu/editorhelper_gl.cpp
+++ b/lib/src/gpu/editorhelper_gl.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <ultrahdr/editorhelper.h>

--- a/lib/src/gpu/uhdr_gl_utils.cpp
+++ b/lib/src/gpu/uhdr_gl_utils.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include "ultrahdr/ultrahdrcommon.h"

--- a/lib/src/gpu/uhdr_gl_utils.cpp
+++ b/lib/src/gpu/uhdr_gl_utils.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include "ultrahdr/ultrahdrcommon.h"

--- a/lib/src/icc.cpp
+++ b/lib/src/icc.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <cstring>

--- a/lib/src/icc.cpp
+++ b/lib/src/icc.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <cstring>

--- a/lib/src/jpegdecoderhelper.cpp
+++ b/lib/src/jpegdecoderhelper.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <errno.h>

--- a/lib/src/jpegdecoderhelper.cpp
+++ b/lib/src/jpegdecoderhelper.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <errno.h>

--- a/lib/src/jpegencoderhelper.cpp
+++ b/lib/src/jpegencoderhelper.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <errno.h>

--- a/lib/src/jpegencoderhelper.cpp
+++ b/lib/src/jpegencoderhelper.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <errno.h>

--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #ifdef _WIN32

--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #ifdef _WIN32

--- a/lib/src/jpegrutils.cpp
+++ b/lib/src/jpegrutils.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <algorithm>

--- a/lib/src/jpegrutils.cpp
+++ b/lib/src/jpegrutils.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <algorithm>

--- a/lib/src/multipictureformat.cpp
+++ b/lib/src/multipictureformat.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2023 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include "ultrahdr/multipictureformat.h"

--- a/lib/src/multipictureformat.cpp
+++ b/lib/src/multipictureformat.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2023 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include "ultrahdr/multipictureformat.h"

--- a/lib/src/ultrahdr_api.cpp
+++ b/lib/src/ultrahdr_api.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <cstdio>

--- a/lib/src/ultrahdr_api.cpp
+++ b/lib/src/ultrahdr_api.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <cstdio>

--- a/tests/Android.bp
+++ b/tests/Android.bp
@@ -1,16 +1,7 @@
 // Copyright 2022 The Android Open Source Project
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
 
 package {
     // See: http://go/android-license-faq

--- a/tests/Android.bp
+++ b/tests/Android.bp
@@ -1,7 +1,10 @@
 // Copyright 2022 The Android Open Source Project
 //
-// This project is dual-licensed under Apache 2.0 and MIT terms.
-// See LICENSE-APACHE and LICENSE-MIT for details.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
 
 package {
     // See: http://go/android-license-faq

--- a/tests/AndroidTest.xml
+++ b/tests/AndroidTest.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (C) 2023 The Android Open Source Project
 
-     This project is dual-licensed under Apache 2.0 and MIT terms.
-     See LICENSE-APACHE and LICENSE-MIT for details.
+     Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+     https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+     <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+     option. This file may not be copied, modified, or distributed
+     except according to those terms.
 -->
 <configuration description="Unit test configuration for ultrahdr_unit_test">
     <target_preparer class="com.android.tradefed.targetprep.PushFilePreparer">

--- a/tests/AndroidTest.xml
+++ b/tests/AndroidTest.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (C) 2023 The Android Open Source Project
 
-     Licensed under the Apache License, Version 2.0 (the"License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
-
-          http://www.apache.org/licenses/LICENSE-2.0
-
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an"AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
+     This project is dual-licensed under Apache 2.0 and MIT terms.
+     See LICENSE-APACHE and LICENSE-MIT for details.
 -->
 <configuration description="Unit test configuration for ultrahdr_unit_test">
     <target_preparer class="com.android.tradefed.targetprep.PushFilePreparer">

--- a/tests/editorhelper_test.cpp
+++ b/tests/editorhelper_test.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <gtest/gtest.h>

--- a/tests/editorhelper_test.cpp
+++ b/tests/editorhelper_test.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <gtest/gtest.h>

--- a/tests/gainmapmath_test.cpp
+++ b/tests/gainmapmath_test.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <gtest/gtest.h>

--- a/tests/gainmapmath_test.cpp
+++ b/tests/gainmapmath_test.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <gtest/gtest.h>

--- a/tests/gainmapmetadata_test.cpp
+++ b/tests/gainmapmetadata_test.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <gtest/gtest.h>

--- a/tests/gainmapmetadata_test.cpp
+++ b/tests/gainmapmetadata_test.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <gtest/gtest.h>

--- a/tests/icchelper_test.cpp
+++ b/tests/icchelper_test.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <gtest/gtest.h>

--- a/tests/icchelper_test.cpp
+++ b/tests/icchelper_test.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <gtest/gtest.h>

--- a/tests/jpegdecoderhelper_test.cpp
+++ b/tests/jpegdecoderhelper_test.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <gtest/gtest.h>

--- a/tests/jpegdecoderhelper_test.cpp
+++ b/tests/jpegdecoderhelper_test.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <gtest/gtest.h>

--- a/tests/jpegencoderhelper_test.cpp
+++ b/tests/jpegencoderhelper_test.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #include <gtest/gtest.h>

--- a/tests/jpegencoderhelper_test.cpp
+++ b/tests/jpegencoderhelper_test.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #include <gtest/gtest.h>

--- a/tests/jpegr_test.cpp
+++ b/tests/jpegr_test.cpp
@@ -1,8 +1,11 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 #ifdef _WIN32

--- a/tests/jpegr_test.cpp
+++ b/tests/jpegr_test.cpp
@@ -1,17 +1,8 @@
 /*
  * Copyright 2022 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 #ifdef _WIN32

--- a/ultrahdr_api.h
+++ b/ultrahdr_api.h
@@ -1,8 +1,11 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * This project is dual-licensed under Apache 2.0 and MIT terms.
- * See LICENSE-APACHE and LICENSE-MIT for details.
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
  */
 
 /** \file ultrahdr_api.h

--- a/ultrahdr_api.h
+++ b/ultrahdr_api.h
@@ -1,17 +1,8 @@
 /*
  * Copyright 2024 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This project is dual-licensed under Apache 2.0 and MIT terms.
+ * See LICENSE-APACHE and LICENSE-MIT for details.
  */
 
 /** \file ultrahdr_api.h


### PR DESCRIPTION
## Summary

Add MIT as a dual license option alongside Apache 2.0, enabling GPLv2 compatibility. This follows the exact pattern used by other Google dual-licensed projects (e.g. `google/aarch64-paging`).

- Add `LICENSE-MIT` and `LICENSE-APACHE` standalone license files
- Update combined `LICENSE` file with dual-license preamble and both full license texts
- Update source file headers across all project-owned files to reference dual licensing
- Add License section to `README.md`

Third-party code (`third_party/`), test data licenses (`tests/data/LICENSE`), and machine-generated JNI headers are intentionally left unchanged.

Resolves #380