### PR TITLE
gainmapmath: fix OOB reads in encoder pixel processing on odd-dimension images

### DIFF
--- a/lib/src/gainmapmath.cpp
+++ b/lib/src/gainmapmath.cpp
@@ -429,7 +429,11 @@ Color getP010Pixel(uhdr_raw_image_t* image, size_t x, size_t y) {
   size_t chroma_stride = image->stride[UHDR_PLANE_UV];
 
   size_t pixel_y_idx = y * luma_stride + x;
-  size_t pixel_u_idx = (y >> 1) * chroma_stride + (x & ~0x1);
+  size_t chroma_x = x & ~(size_t)0x1;
+  // Clamp chroma_x so that the interleaved V sample (at chroma_x + 1) stays within the
+  // chroma row.  Without this, odd image widths cause a 1-element OOB read.
+  if (chroma_x + 1 >= image->w) chroma_x = image->w >= 2 ? image->w - 2 : 0;
+  size_t pixel_u_idx = (y >> 1) * chroma_stride + chroma_x;
   size_t pixel_v_idx = pixel_u_idx + 1;
 
   uint16_t y_uint = luma_data[pixel_y_idx] >> 6;
@@ -1316,8 +1320,8 @@ std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr(uhdr_raw_image_
     uint16_t* uData = static_cast<uint16_t*>(dst->planes[UHDR_PLANE_UV]);
     uint16_t* vData = uData + 1;
 
-    for (size_t i = 0; i < dst->h; i += 2) {
-      for (size_t j = 0; j < dst->w; j += 2) {
+    for (size_t i = 0; i + 1 < dst->h; i += 2) {
+      for (size_t j = 0; j + 1 < dst->w; j += 2) {
         Color pixel[4];
 
         pixel[0].r = float(rgbData[srcStride * i + j] & 0x3ff);
@@ -1410,8 +1414,8 @@ std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr(uhdr_raw_image_
     uint8_t* yData = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_Y]);
     uint8_t* uData = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_U]);
     uint8_t* vData = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_V]);
-    for (size_t i = 0; i < dst->h; i += 2) {
-      for (size_t j = 0; j < dst->w; j += 2) {
+    for (size_t i = 0; i + 1 < dst->h; i += 2) {
+      for (size_t j = 0; j + 1 < dst->w; j += 2) {
         Color pixel[4];
 
         pixel[0].r = float(rgbData[srcStride * i + j] & 0xff);


### PR DESCRIPTION
## Summary

- **Bug 1 — `getP010Pixel` UV overflow on odd width**: The interleaved chroma index `(x & ~0x1) + 1` reads 1 element past the chroma plane when image width is odd and `x` is the last pixel in a row. Fix: clamp `chroma_x` so the V sample stays in bounds.
- **Bug 2 — `convert_raw_input_to_ycbcr` row/column overflow on odd height/width**: The 2×2 block loops access `row[i+1]` and `col[j+1]` unconditionally, overflowing when height or width is odd. Fix: change loop bounds from `i < h` to `i + 1 < h` (and `j + 1 < w`) so incomplete trailing blocks are skipped. Applied to both the RGBA1010102 and RGBA8888 paths.

The public encoder API (`uhdr_enc_set_raw_image`) already rejects odd dimensions for P010/YCbCr420, so these are defense-in-depth fixes for internal callers that bypass that validation.

Found by AFL++ fuzzing with a custom pixel-format harness.

## Test plan

- [ ] Verify existing unit tests pass (no behavior change for even-dimension images)
- [ ] Confirm ASan-instrumented build no longer triggers OOB on odd-dimension inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)