### PR TITLE
jpegrutils: fix size_t underflow in getExifAppleHeadroom

### DIFF
--- a/lib/src/jpegrutils.cpp
+++ b/lib/src/jpegrutils.cpp
@@ -586,8 +586,19 @@ static bool getExifAppleHeadroom(const uint8_t* exif, size_t size, float* altHea
           break;
         }
       } else if (inAppleMakerNotes && (tagId == 33 || tagId == 48) && dataFormat == 10) {
+        // Guard against size_t underflow before the subtraction. If
+        // (tiffHeaderOffset + offsetToIfd) is smaller than the Apple Maker
+        // Notes header size, the unsigned arithmetic would wrap around to a
+        // value close to SIZE_MAX, and the subsequent readU32/readS32 bounds
+        // check (*offset + 4 > size) would also overflow and silently pass,
+        // resulting in an out-of-bounds read.
+        if (tiffHeaderOffset + offsetToIfd < appleMakerNotesHeaderSize) return false;
         size_t tmpOffset =
-            tiffHeaderOffset + offsetToIfd - appleMakerNotesHeaderSize + (size_t)tagData;
+            tiffHeaderOffset + offsetToIfd - appleMakerNotesHeaderSize;
+        // Guard against size_t overflow when adding the attacker-controlled
+        // tagData to the computed base offset.
+        if (tmpOffset > SIZE_MAX - (size_t)tagData) return false;
+        tmpOffset += (size_t)tagData;
         int32_t numerator;
         uint32_t denominator;
         if (!readS32(exif, size, &numerator, &tmpOffset, isBigEndian)) return false;


### PR DESCRIPTION
In getExifAppleHeadroom(), the computation:

    size_t tmpOffset =
        tiffHeaderOffset + offsetToIfd - appleMakerNotesHeaderSize + (size_t)tagData;

can underflow when (tiffHeaderOffset + offsetToIfd) is smaller than appleMakerNotesHeaderSize (14). All operands are attacker-controlled via the EXIF block of a crafted UltraHDR JPEG:

  - tiffHeaderOffset is 6 (the "Exif\0\0" prefix length)
  - offsetToIfd is set from tag 0x8769 tagData in a prior IFD
  - appleMakerNotesHeaderSize is the constant 14
  - tagData is read from the tag entry

With tiffHeaderOffset=6, offsetToIfd=7, tagData=0, the unsigned arithmetic wraps to SIZE_MAX. The subsequent readU32/readS32 bounds check (*offset + 4 > size) then also overflows (SIZE_MAX + 4 == 3 on 64-bit), silently passing the guard and resulting in a 1-byte heap out-of-bounds read at data[SIZE_MAX].

This patch adds two guards:

  1. Before the subtraction, ensure tiffHeaderOffset + offsetToIfd is not smaller than appleMakerNotesHeaderSize.
  2. Before adding tagData, ensure the addition will not overflow.

Both conditions return false (the function's existing error-handling pattern) when the EXIF data is malformed.

Confirmed via AddressSanitizer with a crafted UltraHDR JPEG decoded through the public uhdr_decode() API:

  heap-buffer-overflow READ of size 1 in ultrahdr::readU32
  at jpegrutils.cpp:494
  called from ultrahdr::getExifAppleHeadroom at jpegrutils.cpp:593

After the patch, the same input is rejected cleanly and the OOB read no longer occurs.