### PR TITLE
Fix integer overflow in ICC tag offset and parser bounds checks (OSS-Fuzz 501676165)

### DIFF
--- a/lib/src/gainmapmetadata.cpp
+++ b/lib/src/gainmapmetadata.cpp
@@ -52,7 +52,7 @@ uhdr_error_info_t streamReadU8(const std::vector<uint8_t> &data, uint8_t &value,
 }
 
 uhdr_error_info_t streamReadU16(const std::vector<uint8_t> &data, uint16_t &value, size_t &pos) {
-  if (pos + 1 >= data.size()) {
+  if (pos > data.size() || data.size() - pos < 2) {
     uhdr_error_info_t status;
     status.error_code = UHDR_CODEC_MEM_ERROR;
     status.has_detail = 1;
@@ -67,7 +67,7 @@ uhdr_error_info_t streamReadU16(const std::vector<uint8_t> &data, uint16_t &valu
 }
 
 uhdr_error_info_t streamReadU32(const std::vector<uint8_t> &data, uint32_t &value, size_t &pos) {
-  if (pos + 3 >= data.size()) {
+  if (pos > data.size() || data.size() - pos < 4) {
     uhdr_error_info_t status;
     status.error_code = UHDR_CODEC_MEM_ERROR;
     status.has_detail = 1;
@@ -82,7 +82,7 @@ uhdr_error_info_t streamReadU32(const std::vector<uint8_t> &data, uint32_t &valu
 }
 
 uhdr_error_info_t streamReadS32(const std::vector<uint8_t> &data, int32_t &value, size_t &pos) {
-  if (pos + 3 >= data.size()) {
+  if (pos > data.size() || data.size() - pos < 4) {
     uhdr_error_info_t status;
     status.error_code = UHDR_CODEC_MEM_ERROR;
     status.has_detail = 1;

--- a/lib/src/icc.cpp
+++ b/lib/src/icc.cpp
@@ -664,20 +664,22 @@ uhdr_color_gamut_t IccHelper::readIccColorGamut(void* icc_data, size_t icc_size)
   }
   ICCHeader* header = reinterpret_cast<ICCHeader*>(icc_bytes);
 
+  const size_t profile_size = icc_size - kICCIdentifierSize;
+  const size_t max_tags = (profile_size - sizeof(ICCHeader)) / kTagTableEntrySize;
+  size_t tag_count = Endian_SwapBE32(header->tag_count);
+  if (tag_count > max_tags) {
+    ALOGE("Tag table size exceeds buffer size during icc parsing. tag count %zu, max tags %zu",
+          tag_count, max_tags);
+    if (aligned_block) ::operator delete[](aligned_block, std::align_val_t(alignment_needs));
+    return UHDR_CG_UNSPECIFIED;
+  }
+
   // Use 0 to indicate not found, since offsets are always relative to start
   // of ICC data and therefore a tag offset of zero would never be valid.
   size_t red_primary_offset = 0, green_primary_offset = 0, blue_primary_offset = 0;
   size_t red_primary_size = 0, green_primary_size = 0, blue_primary_size = 0;
   size_t cicp_size = 0, cicp_offset = 0;
-  for (size_t tag_idx = 0; tag_idx < Endian_SwapBE32(header->tag_count); ++tag_idx) {
-    if (icc_size < kICCIdentifierSize + sizeof(ICCHeader) + ((tag_idx + 1) * kTagTableEntrySize)) {
-      ALOGE(
-          "Insufficient buffer size during icc parsing. tag index %zu, header %zu, tag size %zu, "
-          "icc size %zu",
-          tag_idx, kICCIdentifierSize + sizeof(ICCHeader), kTagTableEntrySize, icc_size);
-      if (aligned_block) ::operator delete[](aligned_block, std::align_val_t(alignment_needs));
-      return UHDR_CG_UNSPECIFIED;
-    }
+  for (size_t tag_idx = 0; tag_idx < tag_count; ++tag_idx) {
     uint32_t* tag_entry_start =
         reinterpret_cast<uint32_t*>(icc_bytes + sizeof(ICCHeader) + tag_idx * kTagTableEntrySize);
     // first 4 bytes are the tag signature, next 4 bytes are the tag offset,
@@ -698,7 +700,7 @@ uhdr_color_gamut_t IccHelper::readIccColorGamut(void* icc_data, size_t icc_size)
   }
 
   if (cicp_offset != 0 && cicp_size == kCicpTagSize &&
-      kICCIdentifierSize + cicp_offset + cicp_size <= icc_size) {
+      cicp_offset <= profile_size && cicp_size <= profile_size - cicp_offset) {
     uint8_t* cicp = icc_bytes + cicp_offset;
     uint8_t primaries = cicp[8];
     uhdr_color_gamut_t gamut = UHDR_CG_UNSPECIFIED;
@@ -716,11 +718,11 @@ uhdr_color_gamut_t IccHelper::readIccColorGamut(void* icc_data, size_t icc_size)
   }
 
   if (red_primary_offset == 0 || red_primary_size != kColorantTagSize ||
-      kICCIdentifierSize + red_primary_offset + red_primary_size > icc_size ||
+      red_primary_offset > profile_size || red_primary_size > profile_size - red_primary_offset ||
       green_primary_offset == 0 || green_primary_size != kColorantTagSize ||
-      kICCIdentifierSize + green_primary_offset + green_primary_size > icc_size ||
+      green_primary_offset > profile_size || green_primary_size > profile_size - green_primary_offset ||
       blue_primary_offset == 0 || blue_primary_size != kColorantTagSize ||
-      kICCIdentifierSize + blue_primary_offset + blue_primary_size > icc_size) {
+      blue_primary_offset > profile_size || blue_primary_size > profile_size - blue_primary_offset) {
     if (aligned_block) ::operator delete[](aligned_block, std::align_val_t(alignment_needs));
     return UHDR_CG_UNSPECIFIED;
   }

--- a/lib/src/jpegrutils.cpp
+++ b/lib/src/jpegrutils.cpp
@@ -477,7 +477,7 @@ const string XMPXmlHandler::kAppleMapHeadroom = "HDRGainMapHeadroom";
 
 static bool readU16(const uint8_t* data, size_t size, uint16_t* value, size_t* offset,
                     bool isBigEndian) {
-  if (*offset + 2 > size) return false;
+  if (*offset > size || size - *offset < 2) return false;
   if (isBigEndian) {
     *value = (data[*offset] << 8) | data[*offset + 1];
   } else {
@@ -489,7 +489,7 @@ static bool readU16(const uint8_t* data, size_t size, uint16_t* value, size_t* o
 
 static bool readU32(const uint8_t* data, size_t size, uint32_t* value, size_t* offset,
                     bool isBigEndian) {
-  if (*offset + 4 > size) return false;
+  if (*offset > size || size - *offset < 4) return false;
   if (isBigEndian) {
     *value = (data[*offset] << 24) | (data[*offset + 1] << 16) | (data[*offset + 2] << 8) |
              data[*offset + 3];

--- a/tests/icchelper_test.cpp
+++ b/tests/icchelper_test.cpp
@@ -63,4 +63,47 @@ TEST_F(IccHelperTest, iccEndianness) {
   EXPECT_EQ(static_cast<size_t>(encoded_size), profile_size);
 }
 
+TEST_F(IccHelperTest, iccIntegerOverflowOffset) {
+  std::shared_ptr<DataStruct> icc = IccHelper::writeIccProfile(UHDR_CT_SRGB, UHDR_CG_BT_709);
+  ASSERT_NE(icc->getLength(), 0);
+  ASSERT_NE(icc->getData(), nullptr);
+
+  // 1. Mutate cicp tag offset to cause integer overflow when added to identifier size.
+  std::vector<uint8_t> buffer_cicp(reinterpret_cast<uint8_t*>(icc->getData()),
+                                   reinterpret_cast<uint8_t*>(icc->getData()) + icc->getLength());
+  uint8_t* icc_bytes = buffer_cicp.data() + kICCIdentifierSize;
+  uint32_t tag_count_be;
+  memcpy(&tag_count_be, icc_bytes + offsetof(ICCHeader, tag_count), sizeof(tag_count_be));
+  size_t tag_count = Endian_SwapBE32(tag_count_be);
+  for (size_t tag_idx = 0; tag_idx < tag_count; ++tag_idx) {
+    size_t entry_offset = sizeof(ICCHeader) + tag_idx * 12;
+    uint32_t sig_be;
+    memcpy(&sig_be, icc_bytes + entry_offset, sizeof(sig_be));
+    if (sig_be == Endian_SwapBE32(kTAG_cicp)) {
+      uint32_t bad_offset_be = Endian_SwapBE32(0xfffffff1U);
+      memcpy(icc_bytes + entry_offset + 4, &bad_offset_be, sizeof(bad_offset_be));
+      break;
+    }
+  }
+  // With overflow-safe bounds checks, cicp is ignored and fallback matrix tags return BT_709 cleanly without crash.
+  EXPECT_EQ(IccHelper::readIccColorGamut(buffer_cicp.data(), buffer_cicp.size()), UHDR_CG_BT_709);
+
+  // 2. Mutate red colorant tag offset to cause integer overflow.
+  std::vector<uint8_t> buffer_rxyz(reinterpret_cast<uint8_t*>(icc->getData()),
+                                   reinterpret_cast<uint8_t*>(icc->getData()) + icc->getLength());
+  icc_bytes = buffer_rxyz.data() + kICCIdentifierSize;
+  for (size_t tag_idx = 0; tag_idx < tag_count; ++tag_idx) {
+    size_t entry_offset = sizeof(ICCHeader) + tag_idx * 12;
+    uint32_t sig_be;
+    memcpy(&sig_be, icc_bytes + entry_offset, sizeof(sig_be));
+    if (sig_be == Endian_SwapBE32(kTAG_rXYZ)) {
+      uint32_t bad_offset_be = Endian_SwapBE32(0xfffffff1U);
+      memcpy(icc_bytes + entry_offset + 4, &bad_offset_be, sizeof(bad_offset_be));
+      break;
+    }
+  }
+  // With overflow-safe bounds checks, invalid colorant offset returns UHDR_CG_UNSPECIFIED without crash.
+  EXPECT_EQ(IccHelper::readIccColorGamut(buffer_rxyz.data(), buffer_rxyz.size()), UHDR_CG_UNSPECIFIED);
+}
+
 }  // namespace ultrahdr


### PR DESCRIPTION
## Problem
On 32-bit platforms (e.g. `libfuzzer_asan_i386`), `size_t` is 32-bit (`uint32_t`). When parsing ICC profiles in `IccHelper::readIccColorGamut`, tag offsets and sizes read from malformed profiles can cause additive integer wrap-around (e.g., `kICCIdentifierSize + cicp_offset + cicp_size <= icc_size` wrapping around to `11 <= icc_size`). This bypasses bounds checks and causes out-of-bounds heap memory reads (`Heap-buffer-overflow READ 1`), reported in OSS-Fuzz issue 501676165.

## Fix
- Replaced additive bounds checks with subtraction-based checks across `icc.cpp`, `jpegrutils.cpp`, and `gainmapmetadata.cpp` (`offset <= profile_size && size <= profile_size - offset`).
- Added tag count bound checks (`tag_count > max_tags`) to prevent tag table indexing wrap-around.
- Added regression test `iccIntegerOverflowOffset` in `tests/icchelper_test.cpp` verifying safe handling of wrapping tag offsets.

Fixes OSS-Fuzz 501676165.
Original Piper CL: cl/949044592.
