### PR TITLE
Fix OOB write in applyGainMap by validating destination image pointers, stride, output_ct, and pixel format

### DIFF
--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -1528,6 +1528,44 @@ uhdr_error_info_t JpegR::applyGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_ima
                                       uhdr_color_transfer_t output_ct,
                                       [[maybe_unused]] uhdr_img_fmt_t output_format,
                                       float max_display_boost, uhdr_raw_image_t* dest) {
+  if (dest == nullptr || dest->planes[UHDR_PLANE_PACKED] == nullptr) {
+    uhdr_error_info_t status;
+    status.error_code = UHDR_CODEC_INVALID_PARAM;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail,
+             "apply gainmap method received nullptr for destination image or plane pointer");
+    return status;
+  }
+  if (dest->stride[UHDR_PLANE_PACKED] < dest->w) {
+    uhdr_error_info_t status;
+    status.error_code = UHDR_CODEC_INVALID_PARAM;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail,
+             "destination stride (%u) cannot be less than image width (%u)",
+             dest->stride[UHDR_PLANE_PACKED], dest->w);
+    return status;
+  }
+  if (output_ct != UHDR_CT_LINEAR && output_ct != UHDR_CT_HLG && output_ct != UHDR_CT_PQ) {
+    uhdr_error_info_t status;
+    status.error_code = UHDR_CODEC_INVALID_PARAM;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail,
+             "apply gainmap method expects output color transfer to be one of "
+             "{UHDR_CT_LINEAR, UHDR_CT_HLG, UHDR_CT_PQ}. Received %d",
+             output_ct);
+    return status;
+  }
+  if ((output_ct == UHDR_CT_LINEAR && dest->fmt != UHDR_IMG_FMT_64bppRGBAHalfFloat) ||
+      ((output_ct == UHDR_CT_HLG || output_ct == UHDR_CT_PQ) &&
+       dest->fmt != UHDR_IMG_FMT_32bppRGBA1010102)) {
+    uhdr_error_info_t status;
+    status.error_code = UHDR_CODEC_INVALID_PARAM;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail,
+             "unsupported destination pixel format %d for output color transfer %d",
+             dest->fmt, output_ct);
+    return status;
+  }
   if (gainmap_metadata->version.compare(kJpegrVersion)) {
     uhdr_error_info_t status;
     status.error_code = UHDR_CODEC_UNSUPPORTED_FEATURE;

--- a/tests/jpegr_test.cpp
+++ b/tests/jpegr_test.cpp
@@ -1399,8 +1399,13 @@ TEST(JpegRTest, DecodeAPIWithInvalidArgs) {
       << "fail, API allows invalid output format";
 }
 
+class TestJpegR : public JpegR {
+ public:
+  using JpegR::applyGainMap;
+};
+
 TEST(JpegRTest, ApplyGainMapInvalidArgs) {
-  JpegR uHdrLib;
+  TestJpegR uHdrLib;
   uhdr_raw_image_t sdr_intent{};
   sdr_intent.fmt = UHDR_IMG_FMT_32bppRGBA8888;
   sdr_intent.w = 16;

--- a/tests/jpegr_test.cpp
+++ b/tests/jpegr_test.cpp
@@ -1399,6 +1399,61 @@ TEST(JpegRTest, DecodeAPIWithInvalidArgs) {
       << "fail, API allows invalid output format";
 }
 
+TEST(JpegRTest, ApplyGainMapInvalidArgs) {
+  JpegR uHdrLib;
+  uhdr_raw_image_t sdr_intent{};
+  sdr_intent.fmt = UHDR_IMG_FMT_32bppRGBA8888;
+  sdr_intent.w = 16;
+  sdr_intent.h = 16;
+  sdr_intent.stride[0] = 16;
+  std::vector<uint8_t> sdr_buf(16 * 16 * 4, 128);
+  sdr_intent.planes[0] = sdr_buf.data();
+
+  uhdr_raw_image_t gainmap_img{};
+  gainmap_img.fmt = UHDR_IMG_FMT_8bppYCbCr400;
+  gainmap_img.w = 16;
+  gainmap_img.h = 16;
+  gainmap_img.stride[0] = 16;
+  std::vector<uint8_t> gm_buf(16 * 16, 128);
+  gainmap_img.planes[0] = gm_buf.data();
+
+  uhdr_gainmap_metadata_ext_t metadata("1.0");
+  std::fill_n(metadata.max_content_boost, 3, 2.0f);
+  std::fill_n(metadata.min_content_boost, 3, 1.0f);
+  std::fill_n(metadata.gamma, 3, 1.0f);
+  std::fill_n(metadata.offset_sdr, 3, 0.0f);
+  std::fill_n(metadata.offset_hdr, 3, 0.0f);
+  metadata.hdr_capacity_min = 1.0f;
+  metadata.hdr_capacity_max = 2.0f;
+
+  uhdr_raw_image_t dest{};
+  dest.fmt = UHDR_IMG_FMT_64bppRGBAHalfFloat;
+  dest.w = 16;
+  dest.h = 16;
+  dest.stride[0] = 16;
+  std::vector<uint8_t> dest_buf(16 * 16 * 8);
+  dest.planes[0] = dest_buf.data();
+
+  // Test nullptr dest or plane pointer
+  EXPECT_NE(uHdrLib.applyGainMap(&sdr_intent, &gainmap_img, &metadata, UHDR_CT_LINEAR, dest.fmt, 2.0f, nullptr).error_code, UHDR_CODEC_OK);
+  dest.planes[0] = nullptr;
+  EXPECT_EQ(uHdrLib.applyGainMap(&sdr_intent, &gainmap_img, &metadata, UHDR_CT_LINEAR, dest.fmt, 2.0f, &dest).error_code, UHDR_CODEC_INVALID_PARAM);
+
+  dest.planes[0] = dest_buf.data();
+
+  // Test stride < width
+  dest.stride[0] = 8;
+  EXPECT_EQ(uHdrLib.applyGainMap(&sdr_intent, &gainmap_img, &metadata, UHDR_CT_LINEAR, dest.fmt, 2.0f, &dest).error_code, UHDR_CODEC_INVALID_PARAM);
+  dest.stride[0] = 16;
+
+  // Test invalid output_ct
+  EXPECT_EQ(uHdrLib.applyGainMap(&sdr_intent, &gainmap_img, &metadata, UHDR_CT_UNSPECIFIED, dest.fmt, 2.0f, &dest).error_code, UHDR_CODEC_INVALID_PARAM);
+
+  // Test format mismatch (LINEAR ct with non-64bpp format)
+  dest.fmt = UHDR_IMG_FMT_32bppRGBA1010102;
+  EXPECT_EQ(uHdrLib.applyGainMap(&sdr_intent, &gainmap_img, &metadata, UHDR_CT_LINEAR, dest.fmt, 2.0f, &dest).error_code, UHDR_CODEC_INVALID_PARAM);
+}
+
 TEST(JpegRTest, writeXmpThenRead) {
   uhdr_gainmap_metadata_ext_t metadata_expected("1.0");
   std::fill_n(metadata_expected.max_content_boost, 3, 1.25f);


### PR DESCRIPTION
Validate raw image parameters in UltraHdr/JpegR applyGainMap to prevent heap buffer overflow (b/439639756) on bad strides, null destination pointers, or mismatched color transfer and pixel formats.

Includes unit test `JpegRTest.ApplyGainMapInvalidArgs` in `tests/jpegr_test.cpp`.