### PR TITLE
Android.bp: enable writing both ISO 21496-1 and XMP metadata in encoding path

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -34,8 +34,11 @@ cc_library {
         "lib/include",
     ],
     local_include_dirs: ["lib/include"],
-    cflags: ["-DUHDR_ENABLE_INTRINSICS",
-        "-DUHDR_WRITE_XMP",],
+    cflags: [
+        "-DUHDR_ENABLE_INTRINSICS",
+        "-DUHDR_WRITE_ISO",
+        "-DUHDR_WRITE_XMP",
+    ],
     srcs: [
         "lib/src/icc.cpp",
         "lib/src/jpegr.cpp",


### PR DESCRIPTION
Adds `-DUHDR_WRITE_ISO` and `-DUHDR_WRITE_XMP` to `cflags` in `Android.bp`.

This ensures that when building `libultrahdr` under Android, the encoder emits both ISO 21496-1 (APP2) and XMP (APP1) gainmap metadata payloads into encoded JPEG files.