### PR TITLE
Check JPEG_FOUND before finding the JPEG package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,7 +423,7 @@ if(UHDR_ENABLE_GLES)
 endif()
 
 # libjpeg-turbo
-if(NOT UHDR_BUILD_DEPS)
+if(NOT UHDR_BUILD_DEPS AND NOT JPEG_FOUND)
   find_package(JPEG QUIET)
   if(NOT JPEG_FOUND)
     message(FATAL_ERROR "Could NOT find JPEG (missing: JPEG_LIBRARIES JPEG_INCLUDE_DIRS),\


### PR DESCRIPTION
Check for JPEG_FOUND before calling find_package(JPEG). This allows a project which depends libjpeg-turbo already via add_subdirectory() to share that implementation with libultrahdr.