### PR TITLE
Make JpegRTest and EditorHelperTest resource loading path agnostic

### DIFF
--- a/tests/editorhelper_test.cpp
+++ b/tests/editorhelper_test.cpp
@@ -12,6 +12,8 @@
 
 #include <fstream>
 #include <iostream>
+#include <string>
+#include <vector>
 
 #include "ultrahdr/editorhelper.h"
 
@@ -57,9 +59,9 @@ static bool writeFile(std::string prefixName, uhdr_raw_image_t* img) {
       bpp = 8;
     }
 
-    const char* data = static_cast<char*>(img->planes[UHDR_PLANE_Y]);
-    size_t stride = img->stride[UHDR_PLANE_Y] * bpp;
-    size_t length = img->w * bpp;
+    char* data = static_cast<char*>(img->planes[UHDR_PLANE_Y]);
+    int stride = img->stride[UHDR_PLANE_Y] * bpp;
+    int length = img->w * bpp;
     for (unsigned i = 0; i < img->h; i++, data += stride) {
       ofd.write(data, length);
     }
@@ -95,7 +97,23 @@ static bool writeFile(std::string prefixName, uhdr_raw_image_t* img) {
 namespace ultrahdr {
 
 static bool loadFile(const char* filename, uhdr_raw_image_t* handle) {
-  std::ifstream ifd(filename, std::ios::binary);
+  std::string base_name = filename;
+  size_t last_slash = base_name.find_last_of("/\\");
+  std::string raw_name = (last_slash != std::string::npos) ? base_name.substr(last_slash + 1) : base_name;
+  std::vector<std::string> candidates = {
+      filename,
+      std::string("tests/data/") + raw_name,
+      std::string("third_party/libultrahdr/tests/data/") + raw_name,
+      std::string("./data/") + raw_name,
+      std::string("../tests/data/") + raw_name,
+      std::string("build/data/") + raw_name,
+  };
+  std::ifstream ifd;
+  for (const auto& path : candidates) {
+    ifd.open(path, std::ios::binary);
+    if (ifd.good()) break;
+    ifd.clear();
+  }
   if (ifd.good()) {
     if (handle->fmt == UHDR_IMG_FMT_24bppYCbCrP010) {
       const int bpp = 2;

--- a/tests/jpegdecoderhelper_test.cpp
+++ b/tests/jpegdecoderhelper_test.cpp
@@ -12,6 +12,8 @@
 
 #include <fstream>
 #include <iostream>
+#include <string>
+#include <vector>
 
 #include "ultrahdr/ultrahdrcommon.h"
 #include "ultrahdr/jpegdecoderhelper.h"
@@ -60,14 +62,27 @@ JpegDecoderHelperTest::JpegDecoderHelperTest() {}
 JpegDecoderHelperTest::~JpegDecoderHelperTest() {}
 
 static bool loadFile(const char filename[], JpegDecoderHelperTest::Image* result) {
-  std::ifstream ifd(filename, std::ios::binary | std::ios::ate);
-  if (ifd.good()) {
-    int size = ifd.tellg();
-    ifd.seekg(0, std::ios::beg);
-    result->buffer.reset(new uint8_t[size]);
-    ifd.read(reinterpret_cast<char*>(result->buffer.get()), size);
-    ifd.close();
-    return true;
+  std::string base_name = filename;
+  size_t last_slash = base_name.find_last_of("/\\");
+  std::string raw_name = (last_slash != std::string::npos) ? base_name.substr(last_slash + 1) : base_name;
+  std::vector<std::string> candidates = {
+      filename,
+      std::string("tests/data/") + raw_name,
+      std::string("third_party/libultrahdr/tests/data/") + raw_name,
+      std::string("./data/") + raw_name,
+      std::string("../tests/data/") + raw_name,
+      std::string("build/data/") + raw_name,
+  };
+  for (const auto& path : candidates) {
+    std::ifstream ifd(path, std::ios::binary | std::ios::ate);
+    if (ifd.good()) {
+      int size = ifd.tellg();
+      ifd.seekg(0, std::ios::beg);
+      result->buffer.reset(new uint8_t[size]);
+      ifd.read(reinterpret_cast<char*>(result->buffer.get()), size);
+      ifd.close();
+      return true;
+    }
   }
   return false;
 }

--- a/tests/jpegencoderhelper_test.cpp
+++ b/tests/jpegencoderhelper_test.cpp
@@ -12,6 +12,8 @@
 
 #include <fstream>
 #include <iostream>
+#include <string>
+#include <vector>
 
 #include "ultrahdr/ultrahdrcommon.h"
 #include "ultrahdr/jpegencoderhelper.h"
@@ -59,14 +61,27 @@ JpegEncoderHelperTest::JpegEncoderHelperTest() {}
 JpegEncoderHelperTest::~JpegEncoderHelperTest() {}
 
 static bool loadFile(const char filename[], JpegEncoderHelperTest::Image* result) {
-  std::ifstream ifd(filename, std::ios::binary | std::ios::ate);
-  if (ifd.good()) {
-    int size = ifd.tellg();
-    ifd.seekg(0, std::ios::beg);
-    result->buffer.reset(new uint8_t[size]);
-    ifd.read(reinterpret_cast<char*>(result->buffer.get()), size);
-    ifd.close();
-    return true;
+  std::string base_name = filename;
+  size_t last_slash = base_name.find_last_of("/\\");
+  std::string raw_name = (last_slash != std::string::npos) ? base_name.substr(last_slash + 1) : base_name;
+  std::vector<std::string> candidates = {
+      filename,
+      std::string("tests/data/") + raw_name,
+      std::string("third_party/libultrahdr/tests/data/") + raw_name,
+      std::string("./data/") + raw_name,
+      std::string("../tests/data/") + raw_name,
+      std::string("build/data/") + raw_name,
+  };
+  for (const auto& path : candidates) {
+    std::ifstream ifd(path, std::ios::binary | std::ios::ate);
+    if (ifd.good()) {
+      int size = ifd.tellg();
+      ifd.seekg(0, std::ios::beg);
+      result->buffer.reset(new uint8_t[size]);
+      ifd.read(reinterpret_cast<char*>(result->buffer.get()), size);
+      ifd.close();
+      return true;
+    }
   }
   return false;
 }

--- a/tests/jpegr_test.cpp
+++ b/tests/jpegr_test.cpp
@@ -18,6 +18,8 @@
 #include <cmath>
 #include <fstream>
 #include <iostream>
+#include <string>
+#include <vector>
 
 #include "ultrahdr_api.h"
 
@@ -203,7 +205,23 @@ bool UhdrUnCompressedStructWrapper::loadRawResource(const char* fileName) {
     std::cerr << "memory is not allocated, read not possible" << std::endl;
     return false;
   }
-  std::ifstream ifd(fileName, std::ios::binary | std::ios::ate);
+  std::string base_name = fileName;
+  size_t last_slash = base_name.find_last_of("/\\");
+  std::string raw_name = (last_slash != std::string::npos) ? base_name.substr(last_slash + 1) : base_name;
+  std::vector<std::string> candidates = {
+      fileName,
+      std::string("tests/data/") + raw_name,
+      std::string("third_party/libultrahdr/tests/data/") + raw_name,
+      std::string("./data/") + raw_name,
+      std::string("../tests/data/") + raw_name,
+      std::string("build/data/") + raw_name,
+  };
+  std::ifstream ifd;
+  for (const auto& path : candidates) {
+    ifd.open(path, std::ios::binary | std::ios::ate);
+    if (ifd.good()) break;
+    ifd.clear();
+  }
   if (ifd.good()) {
     int bpp = mFormat == YCbCr_p010 ? 2 : 1;
     int size = ifd.tellg();
@@ -289,7 +307,23 @@ static bool writeFile(const char* filename, void*& result, int length) {
 #endif
 
 static bool readFile(const char* fileName, void*& result, size_t maxLength, size_t& length) {
-  std::ifstream ifd(fileName, std::ios::binary | std::ios::ate);
+  std::string base_name = fileName;
+  size_t last_slash = base_name.find_last_of("/\\");
+  std::string raw_name = (last_slash != std::string::npos) ? base_name.substr(last_slash + 1) : base_name;
+  std::vector<std::string> candidates = {
+      fileName,
+      std::string("tests/data/") + raw_name,
+      std::string("third_party/libultrahdr/tests/data/") + raw_name,
+      std::string("./data/") + raw_name,
+      std::string("../tests/data/") + raw_name,
+      std::string("build/data/") + raw_name,
+  };
+  std::ifstream ifd;
+  for (const auto& path : candidates) {
+    ifd.open(path, std::ios::binary | std::ios::ate);
+    if (ifd.good()) break;
+    ifd.clear();
+  }
   if (ifd.good()) {
     length = ifd.tellg();
     if (length > maxLength) {
@@ -1500,8 +1534,24 @@ TEST(JpegRTest, writeXmpThenRead) {
 TEST(JpegRTest, decodeApple) {
   JpegR decoder;
   uhdr_compressed_image_t uhdrCompressedImg;
-  for (const auto& fileName : {kOldAppleFileName, kNewAppleFileName}) {
-    std::ifstream ifs(fileName, std::ios::binary);
+  for (const auto& rawFileName : {kOldAppleFileName, kNewAppleFileName}) {
+    std::string base_name = rawFileName;
+    size_t last_slash = base_name.find_last_of("/\\");
+    std::string raw_name = (last_slash != std::string::npos) ? base_name.substr(last_slash + 1) : base_name;
+    std::vector<std::string> candidates = {
+        rawFileName,
+        std::string("tests/data/") + raw_name,
+        std::string("third_party/libultrahdr/tests/data/") + raw_name,
+        std::string("./data/") + raw_name,
+        std::string("../tests/data/") + raw_name,
+        std::string("build/data/") + raw_name,
+    };
+    std::ifstream ifs;
+    for (const auto& path : candidates) {
+      ifs.open(path, std::ios::binary);
+      if (ifs.is_open()) break;
+      ifs.clear();
+    }
     std::string content((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
     ASSERT_EQ(is_uhdr_image(content.data(), content.size()), 1);
 
@@ -1525,7 +1575,7 @@ TEST(JpegRTest, decodeApple) {
     const uhdr_gainmap_metadata_t* gainmapMetadata = uhdr_dec_get_gainmap_metadata(dec);
     ASSERT_NE(gainmapMetadata, nullptr);
 
-    const double headroom = fileName == kOldAppleFileName ? 8.0 : 23.1474762;
+    const double headroom = rawFileName == kOldAppleFileName ? 8.0 : 23.1474762;
     for (int c = 0; c < 3; ++c) {
       EXPECT_EQ(gainmapMetadata->gamma[c], 1.0f);
       EXPECT_EQ(gainmapMetadata->offset_sdr[c], 0.0f);


### PR DESCRIPTION
### Summary

Adopt the multi-candidate test asset search strategy across `tests/jpegr_test.cpp` and `tests/editorhelper_test.cpp` (`tests/data/`, `third_party/libultrahdr/tests/data/`, `./data/`, `../tests/data/`, `build/data/`), consistent with `ultrahdr_api_test.cpp`, `jpegdecoderhelper_test.cpp`, and `jpegencoderhelper_test.cpp`.

### Key Changes
- Update `UhdrUnCompressedStructWrapper::loadRawResource` and `readFile` in `tests/jpegr_test.cpp` to search candidate directories before failing.
- Update `decodeApple` in `tests/jpegr_test.cpp` to search candidate directories for Apple gainmap sample files.
- Update `loadFile` in `tests/editorhelper_test.cpp` to search candidate directories.

### Verification
- Ran full test suite (all 1,288 unit tests) directly from repository root via `./build/ultrahdr_unit_test`.
- All tests in `JpegRTest` (including 36 `JpegRAPIEncodeAndDecodeTest` tests and `decodeApple`) and all 1,170 tests in `EditorHelperTest` pass with 100% success.