### PR TITLE
ci: Remove legacy macOS Intel (HEIF ON) job from daily regression matrix

### DIFF
--- a/.github/workflows/daily-regression.yml
+++ b/.github/workflows/daily-regression.yml
@@ -49,13 +49,6 @@ jobs:
             cmake-opts: "-DUHDR_BUILD_TESTS=1 -DUHDR_BUILD_DEPS=1 -DUHDR_ENABLE_HEIF=1 -DUHDR_ENABLE_WERROR=1"
             enable_heif: "ON"
 
-          - name: "macOS Intel (HEIF ON)"
-            os: macos-13
-            cc: clang
-            cxx: clang++
-            cmake-opts: "-DUHDR_BUILD_TESTS=1 -DUHDR_BUILD_DEPS=1 -DUHDR_ENABLE_HEIF=1 -DUHDR_ENABLE_WERROR=1"
-            enable_heif: "ON"
-
           # --- Windows Configurations ---
           - name: "Windows MSVC 2022 (HEIF OFF)"
             os: windows-latest


### PR DESCRIPTION
## Summary
- Removes the legacy `macOS Intel (HEIF ON)` (`macos-13`) job from the daily regression workflow (`.github/workflows/daily-regression.yml`).
- macOS HEIF support remains fully verified via the modern Apple Silicon runner (`macos-14`), eliminating queuing bottlenecks and deprecated Intel runner execution.