### PR TITLE
cmake: fix static libheif feature probe and cleanup target linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -642,7 +642,6 @@ if(UHDR_ENABLE_GLES)
 endif()
 if(UHDR_ENABLE_HEIF)
   if(NOT UHDR_BUILD_DEPS)
-    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
     find_package(libheif QUIET)
     if(LIBHEIF_FOUND AND NOT LIBHEIF_HAS_GAIN_MAP)
       message(WARNING "System libheif found but lacks ISO 21496-1 gain map API (PR 1503). "
@@ -725,6 +724,7 @@ if(UHDR_ENABLE_HEIF)
         IMPORTED_LOCATION "${LIBHEIF_LIBRARIES}"
         INTERFACE_INCLUDE_DIRECTORIES "${LIBHEIF_INCLUDE_DIRS}"
         INTERFACE_COMPILE_DEFINITIONS "LIBHEIF_STATIC_BUILD;WITH_EXPERIMENTAL_GAIN_MAP=1"
+        INTERFACE_LINK_LIBRARIES "${CMAKE_DL_LIBS}"
       )
     endif()
     set(LIBHEIF_FOUND TRUE)
@@ -732,7 +732,7 @@ if(UHDR_ENABLE_HEIF)
   if(LIBHEIF_FOUND)
     message(STATUS "Found libheif: ${LIBHEIF_LIBRARIES}")
     add_compile_options(-DUHDR_ENABLE_HEIF)
-    list(APPEND PRIVATE_LINK_LIBS libheif::heif ${CMAKE_DL_LIBS})
+    list(APPEND PRIVATE_LINK_LIBS libheif::heif)
   else()
     message(WARNING "libheif not found. Building without HEIF/AVIF support.")
     set(UHDR_ENABLE_HEIF FALSE)
@@ -772,7 +772,7 @@ target_include_directories(${UHDR_CORE_LIB_NAME} PUBLIC ${EXPORT_INCLUDE_DIR})
 if(${CMAKE_SYSTEM_NAME} MATCHES "Android")
   target_link_libraries(${UHDR_CORE_LIB_NAME} PUBLIC ${log-lib})
 endif()
-target_link_libraries(${UHDR_CORE_LIB_NAME} PUBLIC ${PRIVATE_LINK_LIBS} ${IMAGEIO_TARGET_NAME})
+target_link_libraries(${UHDR_CORE_LIB_NAME} PRIVATE ${PRIVATE_LINK_LIBS} ${IMAGEIO_TARGET_NAME})
 
 if(UHDR_BUILD_EXAMPLES)
   set(UHDR_SAMPLE_APP ultrahdr_app)

--- a/cmake/Findlibheif.cmake
+++ b/cmake/Findlibheif.cmake
@@ -67,6 +67,7 @@ if(NOT LIBHEIF_TARGET)
       set_target_properties(libheif::heif PROPERTIES
         IMPORTED_LOCATION "${LIBHEIF_LIBRARY}"
         INTERFACE_INCLUDE_DIRECTORIES "${LIBHEIF_INCLUDE_DIR}"
+        INTERFACE_LINK_LIBRARIES "${CMAKE_DL_LIBS}"
       )
     endif()
     set(LIBHEIF_TARGET libheif::heif)
@@ -89,16 +90,24 @@ if(LIBHEIF_TARGET)
   if(LIBHEIF_INCLUDE_DIR)
     list(APPEND CMAKE_REQUIRED_INCLUDES ${LIBHEIF_INCLUDE_DIR})
   endif()
-  set(CMAKE_REQUIRED_LIBRARIES ${LIBHEIF_TARGET})
   if(LIBHEIF_DEFS)
     set(CMAKE_REQUIRED_DEFINITIONS "-D${LIBHEIF_DEFS}")
   endif()
+
+  # Perform a compile-only check to avoid linking transitive dependencies
+  # (e.g. AOM::aom, x265) of static libheif targets in the try_compile sandbox.
+  set(_saved_try_compile_target_type ${CMAKE_TRY_COMPILE_TARGET_TYPE})
+  set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
   check_cxx_symbol_exists(
     heif_image_handle_get_gain_map_image_handle
     "libheif/heif.h"
     LIBHEIF_HAS_GAIN_MAP
   )
+
+  set(CMAKE_TRY_COMPILE_TARGET_TYPE ${_saved_try_compile_target_type})
+  unset(CMAKE_REQUIRED_INCLUDES)
+  unset(CMAKE_REQUIRED_DEFINITIONS)
 endif()
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
- Use compile-only check in Findlibheif.cmake to avoid linking transitive private dependencies (e.g. AOM::aom, x265) of static libheif targets during try_compile feature probing.
- Remove redundant CMAKE_MODULE_PATH append in CMakeLists.txt (line 645).
- Attach CMAKE_DL_LIBS as INTERFACE_LINK_LIBRARIES on libheif::heif target.
- Change core target_link_libraries to PRIVATE to prevent overlinking downstream consumers with internal dependencies.