### PR TITLE
ci: Add system libheif test jobs to CI and Daily Regression

### DIFF
--- a/.github/workflows/cmake_linux.yml
+++ b/.github/workflows/cmake_linux.yml
@@ -3,6 +3,9 @@ name: Build and Test CI - Linux
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/cmake_linux.yml
+++ b/.github/workflows/cmake_linux.yml
@@ -88,16 +88,15 @@ jobs:
     - name: Checkout the repository
       uses: actions/checkout@v4
 
-    - name: Setup ninja
-      uses: seanmiddleditch/gha-setup-ninja@master
-
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@v2
 
     - name: Install dependencies on Ubuntu
+      env:
+        EXTRA_PKGS: ${{ matrix.config.extra_pkgs }}
       run: |
         sudo apt update
-        sudo apt install -y libjpeg-dev ${{ matrix.config.extra_pkgs }}
+        sudo apt install -y ninja-build libjpeg-dev ${EXTRA_PKGS}
 
     - name: Configure CMake
       shell: bash

--- a/.github/workflows/cmake_linux.yml
+++ b/.github/workflows/cmake_linux.yml
@@ -86,10 +86,10 @@ jobs:
 
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v2
+      uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
 
     - name: Install dependencies on Ubuntu
       env:

--- a/.github/workflows/cmake_linux.yml
+++ b/.github/workflows/cmake_linux.yml
@@ -75,6 +75,15 @@ jobs:
             cxx: clang++
             cmake-opts: '-DUHDR_BUILD_TESTS=1 -DUHDR_ENABLE_LOGS=1 -DUHDR_ENABLE_INSTALL=1 -DBUILD_SHARED_LIBS=0 -DUHDR_ENABLE_WERROR=1'
 
+          # <Ubuntu-latest Platform, Release Build, GCC toolchain, Ninja generator, System libheif-dev>
+          - name: "ubuntu latest gcc rel ninja with system libheif"
+            os: ubuntu-latest
+            build_type: Release
+            cc: gcc
+            cxx: g++
+            extra_pkgs: "libheif-dev"
+            cmake-opts: '-DUHDR_BUILD_TESTS=1 -DUHDR_ENABLE_LOGS=1 -DUHDR_ENABLE_INSTALL=1 -DUHDR_ENABLE_HEIF=1 -DUHDR_BUILD_DEPS=0 -DUHDR_ENABLE_WERROR=1'
+
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v4
@@ -86,7 +95,9 @@ jobs:
       uses: jwlawson/actions-setup-cmake@v2
 
     - name: Install dependencies on Ubuntu
-      run: sudo apt install -y libjpeg-dev
+      run: |
+        sudo apt update
+        sudo apt install -y libjpeg-dev ${{ matrix.config.extra_pkgs }}
 
     - name: Configure CMake
       shell: bash

--- a/.github/workflows/daily-regression.yml
+++ b/.github/workflows/daily-regression.yml
@@ -80,9 +80,11 @@ jobs:
 
       - name: Install dependencies (Ubuntu)
         if: runner.os == 'Linux'
+        env:
+          EXTRA_PKGS: ${{ matrix.config.extra_pkgs }}
         run: |
           sudo apt update
-          sudo apt install -y libjpeg-dev pkg-config yasm ${{ matrix.config.extra-pkgs }}
+          sudo apt install -y libjpeg-dev pkg-config yasm ${EXTRA_PKGS}
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/daily-regression.yml
+++ b/.github/workflows/daily-regression.yml
@@ -41,6 +41,15 @@ jobs:
             cmake-opts: "-DUHDR_BUILD_TESTS=1 -DUHDR_BUILD_DEPS=1 -DUHDR_ENABLE_HEIF=0 -DUHDR_ENABLE_WERROR=1"
             enable_heif: "OFF"
 
+          # --- System libheif Configuration ---
+          - name: "Linux GCC (System libheif-dev)"
+            os: ubuntu-latest
+            cc: gcc
+            cxx: g++
+            extra_pkgs: "libheif-dev"
+            cmake-opts: "-DUHDR_BUILD_TESTS=1 -DUHDR_BUILD_DEPS=0 -DUHDR_ENABLE_HEIF=1 -DUHDR_ENABLE_WERROR=1"
+            enable_heif: "AUTO"
+
           # --- macOS Configurations ---
           - name: "macOS Apple Silicon (HEIF ON)"
             os: macos-14
@@ -73,7 +82,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt update
-          sudo apt install -y libjpeg-dev pkg-config yasm
+          sudo apt install -y libjpeg-dev pkg-config yasm ${{ matrix.config.extra-pkgs }}
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'


### PR DESCRIPTION
### Summary

This PR adds CI and Daily Regression test matrix coverage for builds using a system-installed `libheif-dev` with `-DUHDR_BUILD_DEPS=0`.

### Context & Motivation

Previously, both the Linux PR CI checks (`cmake_linux.yml`) and Daily Regression matrix (`daily-regression.yml`) only tested two cases:
1. Bundled dependencies (`-DUHDR_BUILD_DEPS=1`).
2. Clean Ubuntu runner without `libheif` installed (where `find_package(libheif)` quietly returned `NOT_FOUND`).

Neither CI nor daily regression ever exercised the system `libheif` discovery and symbol check path in `cmake/Findlibheif.cmake`.

### Changes

- **`.github/workflows/cmake_linux.yml`**: Added `ubuntu latest gcc rel ninja with system libheif` matrix job testing with `libheif-dev` installed and `-DUHDR_BUILD_DEPS=0`.
- **`.github/workflows/daily-regression.yml`**: Added `Linux GCC (System libheif-dev)` matrix job.