### PR TITLE
ci: Set fail-fast: false for Linux and macOS test matrices

### DIFF
--- a/.github/workflows/cmake_linux.yml
+++ b/.github/workflows/cmake_linux.yml
@@ -8,7 +8,7 @@ jobs:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         config:
           # <Ubuntu-latest Platform, Release Build, GCC toolchain, Ninja generator>

--- a/.github/workflows/cmake_mac.yml
+++ b/.github/workflows/cmake_mac.yml
@@ -8,7 +8,7 @@ jobs:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         config:
           # <macOS-latest ARM64 Platform, Release Build, Clang toolchain, Ninja generator>


### PR DESCRIPTION
### Summary

Set `fail-fast: false` in `.github/workflows/cmake_linux.yml` and `.github/workflows/cmake_mac.yml`.

### Motivation

Currently, when a single matrix job encounters a transient runner or network issue (such as downloading toolchain archives), GitHub Actions automatically cancels all other matrix jobs due to `fail-fast: true`. 

Setting `fail-fast: false` allows all matrix configurations to run to completion, ensuring full visibility into platform build and test results.