### PR TITLE
gainmapmath: write green channel in RGB888 output

### DIFF
--- a/lib/src/gainmapmath.cpp
+++ b/lib/src/gainmapmath.cpp
@@ -561,7 +561,7 @@ void putRgb888Pixel(uhdr_raw_image_t* image, size_t x, size_t y, Color& pixel) {
   pixel.g = CLIP3(pixel.g, 0.0f, 255.0f);
   pixel.b = CLIP3(pixel.b, 0.0f, 255.0f);
   rgbData[offset] = uint8_t(pixel.r);
-  rgbData[offset + 1] = uint8_t(pixel.r);
+  rgbData[offset + 1] = uint8_t(pixel.g);
   rgbData[offset + 2] = uint8_t(pixel.b);
 }
 

--- a/tests/gainmapmath_test.cpp
+++ b/tests/gainmapmath_test.cpp
@@ -534,6 +534,23 @@ TEST_F(GainMapMathTest, ColorDivideFloat) {
   EXPECT_FLOAT_EQ(e2.b, e1.b / 4.0f);
 }
 
+TEST_F(GainMapMathTest, PutRgb888PixelWritesGreenChannel) {
+  uint8_t data[3] = {};
+  uhdr_raw_image_t image{};
+  image.fmt = UHDR_IMG_FMT_24bppRGB888;
+  image.w = 1;
+  image.h = 1;
+  image.planes[UHDR_PLANE_PACKED] = data;
+  image.stride[UHDR_PLANE_PACKED] = 1;
+
+  Color pixel = {{{0.1f, 0.5f, 0.9f}}};
+  putRgb888Pixel(&image, 0, 0, pixel);
+
+  EXPECT_EQ(26, data[0]);
+  EXPECT_EQ(128, data[1]);
+  EXPECT_EQ(230, data[2]);
+}
+
 TEST_F(GainMapMathTest, SrgbLuminance) {
   EXPECT_FLOAT_EQ(srgbLuminance(RgbBlack()), 0.0f);
   EXPECT_FLOAT_EQ(srgbLuminance(RgbWhite()), 1.0f);


### PR DESCRIPTION
## What changed

- Write `pixel.g` to the green byte in `putRgb888Pixel()`.
- Add a regression test using distinct red, green, and blue values.

## Why

`putRgb888Pixel()` currently writes `pixel.r` to both the red and green bytes. Any
RGB888 output where red and green differ is therefore color-corrupted. Writing the
actual green component preserves the requested RGB pixel values.

## Testing

- Added `GainMapMathTest.PutRgb888PixelWritesGreenChannel`; it fails on current main
  and passes with this change.
- Full non-HEIF unit suite: 1,291 tests run; 1,067 passed and 224 existing parameter
  combinations skipped.