### PR TITLE
Return after rejecting invalid encoder inputs

### DIFF
--- a/lib/src/ultrahdr_api.cpp
+++ b/lib/src/ultrahdr_api.cpp
@@ -808,6 +808,7 @@ uhdr_error_info_t uhdr_enc_set_target_display_peak_brightness(uhdr_codec_private
         status.detail, sizeof status.detail,
         "unexpected target display peak brightness nits %f, expects to be with in range [%f, %f]",
         nits, ultrahdr::kSdrWhiteNits, ultrahdr::kPqMaxNits);
+    return status;
   }
 
   uhdr_encoder_private* handle = dynamic_cast<uhdr_encoder_private*>(enc);
@@ -1055,6 +1056,7 @@ uhdr_error_info_t uhdr_enc_set_compressed_image(uhdr_codec_private_t* enc,
     snprintf(status.detail, sizeof status.detail,
              "invalid intent %d, expects one of {UHDR_HDR_IMG, UHDR_SDR_IMG, UHDR_BASE_IMG}",
              intent);
+    return status;
   }
 
   return uhdr_enc_validate_and_set_compressed_img(enc, img, intent);

--- a/tests/ultrahdr_api_test.cpp
+++ b/tests/ultrahdr_api_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 #endif
 #include <fstream>
+#include <limits>
 #include <vector>
 #include <memory>
 
@@ -97,6 +98,37 @@ class UltraHdrApiTest : public ::testing::Test {
   uhdr_raw_image_t mSdrRaw{};
   uhdr_compressed_image_t mSdrCompressed{};
 };
+
+TEST_F(UltraHdrApiTest, InvalidCompressedImageIntentDoesNotMutateEncoder) {
+  uhdr_codec_private_t* enc = uhdr_create_encoder();
+  ASSERT_NE(enc, nullptr);
+  auto* handle = dynamic_cast<uhdr_encoder_private*>(enc);
+  ASSERT_NE(handle, nullptr);
+
+  uhdr_error_info_t status = uhdr_enc_set_compressed_image(
+      enc, &mSdrCompressed, static_cast<uhdr_img_label_t>(999));
+
+  EXPECT_EQ(UHDR_CODEC_INVALID_PARAM, status.error_code) << status.detail;
+  EXPECT_TRUE(handle->m_compressed_images.empty());
+  uhdr_release_encoder(enc);
+}
+
+TEST_F(UltraHdrApiTest, InvalidTargetBrightnessDoesNotMutateEncoder) {
+  uhdr_codec_private_t* enc = uhdr_create_encoder();
+  ASSERT_NE(enc, nullptr);
+  auto* handle = dynamic_cast<uhdr_encoder_private*>(enc);
+  ASSERT_NE(handle, nullptr);
+
+  ASSERT_EQ(UHDR_CODEC_OK, uhdr_enc_set_target_display_peak_brightness(enc, 1000.0f).error_code);
+  ASSERT_FLOAT_EQ(1000.0f, handle->m_target_disp_max_brightness);
+
+  uhdr_error_info_t status = uhdr_enc_set_target_display_peak_brightness(
+      enc, std::numeric_limits<float>::quiet_NaN());
+
+  EXPECT_EQ(UHDR_CODEC_INVALID_PARAM, status.error_code) << status.detail;
+  EXPECT_FLOAT_EQ(1000.0f, handle->m_target_disp_max_brightness);
+  uhdr_release_encoder(enc);
+}
 
 // ============================================================================
 // JPEG Tests (API-0 through API-4)


### PR DESCRIPTION
## What changed

- Return immediately after rejecting an invalid target display brightness.
- Return immediately after rejecting an invalid compressed-image intent.
- Add regression coverage confirming that rejected values do not mutate encoder state.

## Why

Both setters currently construct an error but continue executing. An invalid brightness
is stored in the encoder, and an otherwise valid JPEG with an invalid intent is accepted
under that intent while the API reports success. Returning the validation error keeps
rejected input out of encoder state and makes the public API result trustworthy.

## Testing

- Added tests for an invalid compressed-image intent and a non-finite target brightness;
  both fail on current main and pass with this change.
- Full non-HEIF unit suite: 1,292 tests run; 1,068 passed and 224 existing parameter
  combinations skipped.