### PR TITLE
jpegr: initialize legacy gain map output

### DIFF
--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -2837,21 +2837,21 @@ status_t JpegR::decodeJPEGR(jr_compressed_ptr jpegr_image_ptr, jr_uncompressed_p
   output.planes[UHDR_PLANE_V] = nullptr;
   output.stride[UHDR_PLANE_V] = 0;
 
-  uhdr_raw_image_t output_gm;
+  uhdr_raw_image_t output_gm{};
   if (gainmap_image_ptr) {
-    output.fmt =
+    output_gm.fmt =
         gainmap_image.numComponents == 1 ? UHDR_IMG_FMT_8bppYCbCr400 : UHDR_IMG_FMT_24bppRGB888;
-    output.cg = UHDR_CG_UNSPECIFIED;
-    output.ct = UHDR_CT_UNSPECIFIED;
-    output.range = UHDR_CR_UNSPECIFIED;
-    output.w = gainmap_image.width;
-    output.h = gainmap_image.height;
-    output.planes[UHDR_PLANE_PACKED] = gainmap_image_ptr->data;
-    output.stride[UHDR_PLANE_PACKED] = gainmap_image.width;
-    output.planes[UHDR_PLANE_U] = nullptr;
-    output.stride[UHDR_PLANE_U] = 0;
-    output.planes[UHDR_PLANE_V] = nullptr;
-    output.stride[UHDR_PLANE_V] = 0;
+    output_gm.cg = UHDR_CG_UNSPECIFIED;
+    output_gm.ct = UHDR_CT_UNSPECIFIED;
+    output_gm.range = UHDR_CR_UNSPECIFIED;
+    output_gm.w = gainmap_image.width;
+    output_gm.h = gainmap_image.height;
+    output_gm.planes[UHDR_PLANE_PACKED] = gainmap_image_ptr->data;
+    output_gm.stride[UHDR_PLANE_PACKED] = gainmap_image.width;
+    output_gm.planes[UHDR_PLANE_U] = nullptr;
+    output_gm.stride[UHDR_PLANE_U] = 0;
+    output_gm.planes[UHDR_PLANE_V] = nullptr;
+    output_gm.stride[UHDR_PLANE_V] = 0;
   }
 
   uhdr_gainmap_metadata_ext_t meta;

--- a/tests/jpegr_test.cpp
+++ b/tests/jpegr_test.cpp
@@ -1417,6 +1417,43 @@ TEST(JpegRTest, DecodeAPIWithInvalidArgs) {
       << "fail, API allows invalid output format";
 }
 
+TEST(JpegRTest, DecodeLegacyApiWithGainMapOutputKeepsPrimaryDescriptor) {
+  UhdrUnCompressedStructWrapper rawImg(kImageWidth, kImageHeight, YCbCr_p010);
+  ASSERT_TRUE(rawImg.setImageColorGamut(ULTRAHDR_COLORGAMUT_BT2100));
+  ASSERT_TRUE(rawImg.allocateMemory());
+  ASSERT_TRUE(rawImg.loadRawResource(kYCbCrP010FileName));
+
+  UhdrCompressedStructWrapper jpgImg(kImageWidth, kImageHeight);
+  ASSERT_TRUE(jpgImg.allocateMemory());
+
+  JpegR uHdrLib;
+  ASSERT_EQ(JPEGR_NO_ERROR,
+            uHdrLib.encodeJPEGR(rawImg.getImageHandle(), ULTRAHDR_TF_HLG,
+                                jpgImg.getImageHandle(), kQuality, nullptr));
+
+  std::vector<uint8_t> primaryData(kImageWidth * kImageHeight * 8);
+  jpegr_uncompressed_struct primaryImage{};
+  primaryImage.data = primaryData.data();
+
+  std::vector<uint8_t> gainmapData(kImageWidth * kImageHeight * 3);
+  jpegr_uncompressed_struct gainmapImage{};
+  gainmapImage.data = gainmapData.data();
+
+  ultrahdr_metadata_struct metadata{};
+  ASSERT_EQ(JPEGR_NO_ERROR,
+            uHdrLib.decodeJPEGR(jpgImg.getImageHandle(), &primaryImage, FLT_MAX, nullptr,
+                                ULTRAHDR_OUTPUT_HDR_LINEAR, &gainmapImage, &metadata));
+
+  EXPECT_EQ(kImageWidth, primaryImage.width);
+  EXPECT_EQ(kImageHeight, primaryImage.height);
+  EXPECT_EQ(UHDR_IMG_FMT_64bppRGBAHalfFloat, primaryImage.pixelFormat);
+  EXPECT_GT(gainmapImage.width, 0u);
+  EXPECT_GT(gainmapImage.height, 0u);
+  EXPECT_LE(gainmapImage.width, kImageWidth);
+  EXPECT_LE(gainmapImage.height, kImageHeight);
+  EXPECT_GT(metadata.hdrCapacityMax, 1.0f);
+}
+
 class TestJpegR : public JpegR {
  public:
   using JpegR::applyGainMap;


### PR DESCRIPTION
## What changed

- Correctly configure the gain-map output in the legacy `decodeJPEGR()` wrapper.
- Add a test that requests the primary image, gain map, and metadata together.

## Why

When a caller asks for both the decoded image and its gain map, the wrapper puts the
gain-map settings on the wrong output and passes an uninitialized descriptor for the
gain map. This causes the decode to fail. The fix configures the correct output so both
images are returned successfully.

## Testing

- Added `JpegRTest.DecodeLegacyApiWithGainMapOutputKeepsPrimaryDescriptor`; it fails on
  current main and passes with this change.
- Full non-HEIF unit suite: 1,291 tests run; 1,067 passed and 224 existing parameter
  combinations skipped.