### PR TITLE
Decode requested gain maps for SDR output

### DIFF
--- a/lib/src/avifultrahdr.cpp
+++ b/lib/src/avifultrahdr.cpp
@@ -624,10 +624,10 @@ uhdr_error_info_t AvifUltraHdr::decodeAvifUltraHdr(uhdr_compressed_image_t* uhdr
   HEIF_ERR_CHECK(copy_img_plane(sdr_image, heif_channel_interleaved,
                                 sdr_intent->planes[UHDR_PLANE_PACKED], sdr_width, sdr_height,
                                 sdr_intent->stride[UHDR_PLANE_PACKED] * 4, 4))
-  if (gainmap_metadata != nullptr || output_ct != UHDR_CT_SRGB) {
+  if (gainmap_img != nullptr || gainmap_metadata != nullptr || output_ct != UHDR_CT_SRGB) {
     HEIF_ERR_CHECK(heif_image_handle_get_gain_map_image_handle(base_handle, &gainmap_handle))
     status = heif_get_gainmap_metadata(base_handle, &metadata);
-    if (status.error_code != UHDR_CODEC_OK) return status;
+    if (status.error_code != UHDR_CODEC_OK) goto CleanUp;
     if (gainmap_metadata != nullptr) {
       std::copy(metadata.min_content_boost, metadata.min_content_boost + 3,
                 gainmap_metadata->min_content_boost);

--- a/lib/src/heifultrahdr.cpp
+++ b/lib/src/heifultrahdr.cpp
@@ -624,10 +624,10 @@ uhdr_error_info_t HeifUltraHdr::decodeHeicUltraHdr(uhdr_compressed_image_t* uhdr
   HEIF_ERR_CHECK(copy_img_plane(sdr_image, heif_channel_interleaved,
                                 sdr_intent->planes[UHDR_PLANE_PACKED], sdr_width, sdr_height,
                                 sdr_intent->stride[UHDR_PLANE_PACKED] * 4, 4))
-  if (gainmap_metadata != nullptr || output_ct != UHDR_CT_SRGB) {
+  if (gainmap_img != nullptr || gainmap_metadata != nullptr || output_ct != UHDR_CT_SRGB) {
     HEIF_ERR_CHECK(heif_image_handle_get_gain_map_image_handle(base_handle, &gainmap_handle))
     status = heif_get_gainmap_metadata(base_handle, &metadata);
-    if (status.error_code != UHDR_CODEC_OK) return status;
+    if (status.error_code != UHDR_CODEC_OK) goto CleanUp;
     if (gainmap_metadata != nullptr) {
       std::copy(metadata.min_content_boost, metadata.min_content_boost + 3,
                 gainmap_metadata->min_content_boost);

--- a/tests/ultrahdr_api_test.cpp
+++ b/tests/ultrahdr_api_test.cpp
@@ -8,8 +8,9 @@
 #include <gtest/gtest.h>
 #endif
 #include <fstream>
-#include <vector>
+#include <cstring>
 #include <memory>
+#include <vector>
 
 #include "ultrahdr_api.h"
 #include "ultrahdr/ultrahdrcommon.h"
@@ -46,6 +47,27 @@ static bool loadFile(const char* filename, std::vector<uint8_t>& buffer) {
     }
   }
   return false;
+}
+
+static void expectGainMapsEqual(const uhdr_raw_image_t* expected,
+                                const uhdr_raw_image_t* actual) {
+  ASSERT_NE(expected, nullptr);
+  ASSERT_NE(actual, nullptr);
+  ASSERT_EQ(actual->fmt, expected->fmt);
+  ASSERT_EQ(actual->w, expected->w);
+  ASSERT_EQ(actual->h, expected->h);
+
+  const size_t bytes_per_pixel =
+      expected->fmt == UHDR_IMG_FMT_8bppYCbCr400 ? 1 : 4;
+  const size_t row_bytes = expected->w * bytes_per_pixel;
+  const auto* expected_data = static_cast<const uint8_t*>(expected->planes[UHDR_PLANE_PACKED]);
+  const auto* actual_data = static_cast<const uint8_t*>(actual->planes[UHDR_PLANE_PACKED]);
+  for (unsigned row = 0; row < expected->h; ++row) {
+    ASSERT_EQ(0, memcmp(expected_data + row * expected->stride[UHDR_PLANE_PACKED] * bytes_per_pixel,
+                        actual_data + row * actual->stride[UHDR_PLANE_PACKED] * bytes_per_pixel,
+                        row_bytes))
+        << "gain map differs at row " << row;
+  }
 }
 
 class UltraHdrApiTest : public ::testing::Test {
@@ -235,7 +257,20 @@ TEST_F(UltraHdrApiTest, HeicEncodeApi0AndDecode) {
   ASSERT_NE(decoded, nullptr);
   EXPECT_EQ(decoded->w, kImageWidth);
   EXPECT_EQ(decoded->h, kImageHeight);
+  uhdr_raw_image_t* hdr_gainmap = uhdr_get_decoded_gainmap_image(dec);
+  ASSERT_NE(hdr_gainmap, nullptr);
 
+  uhdr_codec_private_t* sdr_dec = uhdr_create_decoder();
+  ASSERT_NE(sdr_dec, nullptr);
+  EXPECT_EQ(uhdr_dec_set_image(sdr_dec, output).error_code, UHDR_CODEC_OK);
+  EXPECT_EQ(uhdr_dec_set_out_color_transfer(sdr_dec, UHDR_CT_SRGB).error_code, UHDR_CODEC_OK);
+  EXPECT_EQ(uhdr_dec_set_out_img_format(sdr_dec, UHDR_IMG_FMT_32bppRGBA8888).error_code,
+            UHDR_CODEC_OK);
+  EXPECT_EQ(uhdr_dec_probe(sdr_dec).error_code, UHDR_CODEC_OK);
+  ASSERT_EQ(uhdr_decode(sdr_dec).error_code, UHDR_CODEC_OK);
+  expectGainMapsEqual(hdr_gainmap, uhdr_get_decoded_gainmap_image(sdr_dec));
+
+  uhdr_release_decoder(sdr_dec);
   uhdr_release_decoder(dec);
   uhdr_release_encoder(enc);
 }
@@ -337,7 +372,20 @@ TEST_F(UltraHdrApiTest, AvifEncodeApi0AndDecode) {
   ASSERT_NE(decoded, nullptr);
   EXPECT_EQ(decoded->w, kImageWidth);
   EXPECT_EQ(decoded->h, kImageHeight);
+  uhdr_raw_image_t* hdr_gainmap = uhdr_get_decoded_gainmap_image(dec);
+  ASSERT_NE(hdr_gainmap, nullptr);
 
+  uhdr_codec_private_t* sdr_dec = uhdr_create_decoder();
+  ASSERT_NE(sdr_dec, nullptr);
+  EXPECT_EQ(uhdr_dec_set_image(sdr_dec, output).error_code, UHDR_CODEC_OK);
+  EXPECT_EQ(uhdr_dec_set_out_color_transfer(sdr_dec, UHDR_CT_SRGB).error_code, UHDR_CODEC_OK);
+  EXPECT_EQ(uhdr_dec_set_out_img_format(sdr_dec, UHDR_IMG_FMT_32bppRGBA8888).error_code,
+            UHDR_CODEC_OK);
+  EXPECT_EQ(uhdr_dec_probe(sdr_dec).error_code, UHDR_CODEC_OK);
+  ASSERT_EQ(uhdr_decode(sdr_dec).error_code, UHDR_CODEC_OK);
+  expectGainMapsEqual(hdr_gainmap, uhdr_get_decoded_gainmap_image(sdr_dec));
+
+  uhdr_release_decoder(sdr_dec);
   uhdr_release_decoder(dec);
   uhdr_release_encoder(enc);
 }


### PR DESCRIPTION
## What changed

- Decode the gain map when the caller supplies a gain-map destination, including for SDR output.
- Route gain-map metadata failures through the existing HEIF/AVIF cleanup path.
- Add HEIF and AVIF regressions comparing gain maps returned by SDR and HDR decode paths.

## Why

The public decoder supplies a gain-map output buffer and exposes it through `uhdr_get_decoded_gainmap_image()`. For SDR HEIF/AVIF output, decoding previously returned success without populating that requested buffer. Callers now receive the decoded gain map consistently, regardless of the requested primary-image transfer function.

## Testing

- HEIF and AVIF regressions fail before the fix and pass afterward.
- Focused HEIF/AVIF tests: 2 passed.
- Full unit suite: passed.
- `git diff --check`