### PR TITLE
Support Unicode file paths in the Windows CLI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -787,6 +787,14 @@ if(UHDR_BUILD_EXAMPLES)
     target_link_options(${UHDR_SAMPLE_APP} PRIVATE -static)
   endif()
   target_link_libraries(${UHDR_SAMPLE_APP} PRIVATE ${UHDR_CORE_LIB_NAME})
+  if(WIN32)
+    if(MSVC)
+      target_sources(${UHDR_SAMPLE_APP} PRIVATE "${EXAMPLES_DIR}/utf8.manifest")
+    elseif(MINGW)
+      # MinGW does not have a manifest tool (mt.exe), so wrap the manifest in a resource script.
+      target_sources(${UHDR_SAMPLE_APP} PRIVATE "${EXAMPLES_DIR}/utf8.rc")
+    endif()
+  endif()
 endif()
 
 if(UHDR_BUILD_TESTS OR UHDR_BUILD_BENCHMARK)
@@ -828,6 +836,16 @@ if(UHDR_BUILD_TESTS)
     set_target_properties(ultrahdr_unit_test PROPERTIES BUILD_RPATH "${LIBHEIF_LIB_PREFIX}")
   endif()
   add_test(NAME UHDRUnitTests COMMAND ultrahdr_unit_test)
+  if(WIN32 AND UHDR_BUILD_EXAMPLES)
+    add_test(
+      NAME UHDRWindowsUnicodeCliPaths
+      COMMAND ${CMAKE_COMMAND}
+        "-DUHDR_APP=$<TARGET_FILE:${UHDR_SAMPLE_APP}>"
+        "-DTEST_INPUT=${TESTS_DIR}/data/raw_p010_image.p010"
+        "-DTEST_OUTPUT_DIR=${CMAKE_CURRENT_BINARY_DIR}/unicode_cli_test"
+        -P "${TESTS_DIR}/windows_unicode_cli_test.cmake"
+    )
+  endif()
 endif()
 
 if(UHDR_BUILD_BENCHMARK)

--- a/examples/utf8.manifest
+++ b/examples/utf8.manifest
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  Copyright 2026 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+  https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+  <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+  option. This file may not be copied, modified, or distributed
+  except according to those terms.
+-->
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/examples/utf8.rc
+++ b/examples/utf8.rc
@@ -1,0 +1,11 @@
+// Copyright 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#include <winuser.h>
+
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "utf8.manifest"

--- a/tests/windows_unicode_cli_test.cmake
+++ b/tests/windows_unicode_cli_test.cmake
@@ -1,0 +1,40 @@
+# Copyright 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+if(NOT DEFINED UHDR_APP OR NOT DEFINED TEST_INPUT OR NOT DEFINED TEST_OUTPUT_DIR)
+  message(FATAL_ERROR "UHDR_APP, TEST_INPUT, and TEST_OUTPUT_DIR are required")
+endif()
+
+set(test_dir "${TEST_OUTPUT_DIR}/路径-🌈")
+set(input_file "${test_dir}/输入图像.p010")
+set(output_file "${test_dir}/输出图像.jpeg")
+
+file(REMOVE_RECURSE "${TEST_OUTPUT_DIR}")
+file(MAKE_DIRECTORY "${test_dir}")
+configure_file("${TEST_INPUT}" "${input_file}" COPYONLY)
+
+execute_process(
+  COMMAND "${UHDR_APP}" -m 0 -p "${input_file}" -w 1280 -h 720 -a 0 -z "${output_file}"
+  RESULT_VARIABLE encode_result
+  ERROR_VARIABLE encode_error
+)
+if(NOT encode_result EQUAL 0)
+  message(FATAL_ERROR "Unicode-path encode failed: ${encode_error}")
+endif()
+if(NOT EXISTS "${output_file}")
+  message(FATAL_ERROR "Unicode-path encode did not create ${output_file}")
+endif()
+
+execute_process(
+  COMMAND "${UHDR_APP}" -m 1 -j "${output_file}" -P
+  RESULT_VARIABLE probe_result
+  ERROR_VARIABLE probe_error
+)
+if(NOT probe_result EQUAL 0)
+  message(FATAL_ERROR "Unicode-path probe failed: ${probe_error}")
+endif()


### PR DESCRIPTION
## Summary

- Enable UTF-8 paths in `ultrahdr_app` through the Windows active-code-page manifest.
- Add the manifest directly for MSVC and through a resource file for MinGW.
- Add an end-to-end test using CJK and emoji input/output paths.

## Why

The Windows CLI otherwise interprets narrow command-line arguments and file paths using the legacy system code page. Valid Unicode filenames may therefore be changed or rejected.

Using the UTF-8 application manifest fixes this without custom command-line parsing or per-path conversions. This follows the same approach used by libavif.

## Compatibility

This affects only `ultrahdr_app`; the library API/ABI and non-Windows behavior are unchanged.

Full Unicode path support requires Windows 10 version 1903 or newer, including Windows 11. Earlier Windows versions can still run the CLI, but arbitrary Unicode paths remain limited by the legacy system code page.

Long-path policy and Windows-reserved filenames are outside this change.

Addresses #379.

## Validation

Google’s native Windows CI passed:

- `UHDRUnitTests`
- `UHDRWindowsUnicodeCliPaths`