### PR TITLE
Preserve alpha in raw AVIF and HEIF encoding

### DIFF
--- a/lib/include/ultrahdr/avifultrahdr.h
+++ b/lib/include/ultrahdr/avifultrahdr.h
@@ -59,6 +59,7 @@ class AvifUltraHdr : public UltraHdr {
    * sdr intent. sdr intent and gain map coefficient are compressed using heif/avif encoding.
    * compressed sdr intent is signalled as primary item and compressed gainmap is signalled as a
    * tone map derived item
+   * NOTE: Alpha is preserved as straight 8-bit alpha when hdr intent uses an RGBA pixel format.
    *
    * \param[in]       hdr_intent        hdr intent raw input image descriptor
    * \param[in, out]  dest              output image descriptor to store compressed ultrahdr image
@@ -79,6 +80,7 @@ class AvifUltraHdr : public UltraHdr {
    * coefficient are compressed using heif/avif encoding. compressed sdr intent is signalled as
    * primary item and compressed gainmap is signalled as a tone map derived item
    * NOTE: Color transfer of sdr intent is expected to be sRGB.
+   * NOTE: Alpha is preserved as straight 8-bit alpha when sdr intent uses an RGBA pixel format.
    *
    * \param[in]       hdr_intent        hdr intent raw input image descriptor
    * \param[in]       sdr_intent        sdr intent raw input image descriptor
@@ -147,6 +149,8 @@ class AvifUltraHdr : public UltraHdr {
    * primary item and compressed gainmap is signalled as a tone map derived item
    *
    * \param[in]       sdr_intent        sdr intent raw input image descriptor
+   * \param[in]       base_alpha_source optional raw RGBA image whose alpha is encoded as straight
+   *                                    8-bit alpha in the base image
    * \param[in]       gainmap_img       gainmap raw image descriptor
    * \param[in]       metadata          gainmap metadata descriptor
    * \param[in, out]  dest              output image descriptor to store compressed ultrahdr image
@@ -158,10 +162,13 @@ class AvifUltraHdr : public UltraHdr {
    *
    * \return uhdr_error_info_t #UHDR_CODEC_OK if operation succeeds, uhdr_codec_err_t otherwise.
    */
-  uhdr_error_info_t encodeAvifUltraHdr(uhdr_raw_image_t* sdr_intent, uhdr_raw_image_t* gainmap_img,
-                                uhdr_gainmap_metadata_ext_t* metadata,
-                                uhdr_compressed_image_t* dest, int quality, uhdr_mem_block_t* exif,
-                                DataStruct* baseIcc, DataStruct* alternateIcc);
+  uhdr_error_info_t encodeAvifUltraHdr(uhdr_raw_image_t* sdr_intent,
+                                       uhdr_raw_image_t* base_alpha_source,
+                                       uhdr_raw_image_t* gainmap_img,
+                                       uhdr_gainmap_metadata_ext_t* metadata,
+                                       uhdr_compressed_image_t* dest, int quality,
+                                       uhdr_mem_block_t* exif, DataStruct* baseIcc,
+                                       DataStruct* alternateIcc);
 
   uhdr_codec_t mCodec;
 };

--- a/lib/include/ultrahdr/heifultrahdr.h
+++ b/lib/include/ultrahdr/heifultrahdr.h
@@ -59,6 +59,7 @@ class HeifUltraHdr : public UltraHdr {
    * sdr intent. sdr intent and gain map coefficient are compressed using heif/avif encoding.
    * compressed sdr intent is signalled as primary item and compressed gainmap is signalled as a
    * tone map derived item
+   * NOTE: Alpha is preserved as straight 8-bit alpha when hdr intent uses an RGBA pixel format.
    *
    * \param[in]       hdr_intent        hdr intent raw input image descriptor
    * \param[in, out]  dest              output image descriptor to store compressed ultrahdr image
@@ -79,6 +80,7 @@ class HeifUltraHdr : public UltraHdr {
    * coefficient are compressed using heif/avif encoding. compressed sdr intent is signalled as
    * primary item and compressed gainmap is signalled as a tone map derived item
    * NOTE: Color transfer of sdr intent is expected to be sRGB.
+   * NOTE: Alpha is preserved as straight 8-bit alpha when sdr intent uses an RGBA pixel format.
    *
    * \param[in]       hdr_intent        hdr intent raw input image descriptor
    * \param[in]       sdr_intent        sdr intent raw input image descriptor
@@ -147,6 +149,8 @@ class HeifUltraHdr : public UltraHdr {
    * primary item and compressed gainmap is signalled as a tone map derived item
    *
    * \param[in]       sdr_intent        sdr intent raw input image descriptor
+   * \param[in]       base_alpha_source optional raw RGBA image whose alpha is encoded as straight
+   *                                    8-bit alpha in the base image
    * \param[in]       gainmap_img       gainmap raw image descriptor
    * \param[in]       metadata          gainmap metadata descriptor
    * \param[in, out]  dest              output image descriptor to store compressed ultrahdr image
@@ -158,10 +162,13 @@ class HeifUltraHdr : public UltraHdr {
    *
    * \return uhdr_error_info_t #UHDR_CODEC_OK if operation succeeds, uhdr_codec_err_t otherwise.
    */
-  uhdr_error_info_t encodeHeicUltraHdr(uhdr_raw_image_t* sdr_intent, uhdr_raw_image_t* gainmap_img,
-                                uhdr_gainmap_metadata_ext_t* metadata,
-                                uhdr_compressed_image_t* dest, int quality, uhdr_mem_block_t* exif,
-                                DataStruct* baseIcc, DataStruct* alternateIcc);
+  uhdr_error_info_t encodeHeicUltraHdr(uhdr_raw_image_t* sdr_intent,
+                                       uhdr_raw_image_t* base_alpha_source,
+                                       uhdr_raw_image_t* gainmap_img,
+                                       uhdr_gainmap_metadata_ext_t* metadata,
+                                       uhdr_compressed_image_t* dest, int quality,
+                                       uhdr_mem_block_t* exif, DataStruct* baseIcc,
+                                       DataStruct* alternateIcc);
 
   uhdr_codec_t mCodec;
 };

--- a/lib/src/avifultrahdr.cpp
+++ b/lib/src/avifultrahdr.cpp
@@ -16,6 +16,8 @@
 
 #ifdef UHDR_ENABLE_HEIF
 
+#include <algorithm>
+#include <cmath>
 #include <cstdlib>
 #include <limits>
 #include <map>
@@ -94,6 +96,59 @@ static struct heif_error fill_img_plane(heif_image* img, heif_channel channel, v
     srcRow += srcRowStride;
     dstBuffer += dstStride;
   }
+  return err;
+}
+
+static uint8_t get_alpha_value(const uhdr_raw_image_t* image, size_t x, size_t y) {
+  if (image->fmt == UHDR_IMG_FMT_32bppRGBA8888) {
+    const auto* row = static_cast<const uint32_t*>(image->planes[UHDR_PLANE_PACKED]) +
+                      y * image->stride[UHDR_PLANE_PACKED];
+    return static_cast<uint8_t>(row[x] >> 24);
+  }
+  if (image->fmt == UHDR_IMG_FMT_32bppRGBA1010102) {
+    const auto* row = static_cast<const uint32_t*>(image->planes[UHDR_PLANE_PACKED]) +
+                      y * image->stride[UHDR_PLANE_PACKED];
+    return static_cast<uint8_t>(((row[x] >> 30) & 0x3u) * 85u);
+  }
+  const auto* row = static_cast<const uint16_t*>(image->planes[UHDR_PLANE_PACKED]) +
+                    y * image->stride[UHDR_PLANE_PACKED] * 4;
+  float alpha = halfToFloat(row[x * 4 + 3]);
+  if (std::isnan(alpha)) alpha = 0.0f;
+  alpha = std::clamp(alpha, 0.0f, 1.0f);
+  return static_cast<uint8_t>(alpha * 255.0f + 0.5f);
+}
+
+static struct heif_error add_alpha_plane(heif_image* image, const uhdr_raw_image_t* alpha_source) {
+  if (alpha_source == nullptr || (alpha_source->fmt != UHDR_IMG_FMT_32bppRGBA8888 &&
+                                  alpha_source->fmt != UHDR_IMG_FMT_32bppRGBA1010102 &&
+                                  alpha_source->fmt != UHDR_IMG_FMT_64bppRGBAHalfFloat)) {
+    return {heif_error_Ok, heif_suberror_Unspecified, nullptr};
+  }
+
+  bool has_transparency = false;
+  for (size_t y = 0; y < alpha_source->h && !has_transparency; ++y) {
+    for (size_t x = 0; x < alpha_source->w; ++x) {
+      if (get_alpha_value(alpha_source, x, y) != 255) {
+        has_transparency = true;
+        break;
+      }
+    }
+  }
+  if (!has_transparency) return {heif_error_Ok, heif_suberror_Unspecified, nullptr};
+
+  heif_error err =
+      heif_image_add_plane(image, heif_channel_Alpha, alpha_source->w, alpha_source->h, 8);
+  if (err.code != heif_error_Ok) return err;
+
+  int dst_stride;
+  uint8_t* dst = heif_image_get_plane(image, heif_channel_Alpha, &dst_stride);
+  for (size_t y = 0; y < alpha_source->h; ++y) {
+    for (size_t x = 0; x < alpha_source->w; ++x) {
+      dst[x] = get_alpha_value(alpha_source, x, y);
+    }
+    dst += dst_stride;
+  }
+  heif_image_set_premultiplied_alpha(image, 0);
   return err;
 }
 
@@ -338,8 +393,8 @@ uhdr_error_info_t AvifUltraHdr::encodeAvifUltraHdr(uhdr_raw_image_t* hdr_intent,
   std::shared_ptr<DataStruct> alternateIcc =
       IccHelper::writeIccProfile(gainmap->ct, gainmap->cg);
 
-  return encodeAvifUltraHdr(sdr_intent_yuv, gainmap.get(), &metadata, dest, quality, exif, baseIcc.get(),
-                     alternateIcc.get());
+  return encodeAvifUltraHdr(sdr_intent_yuv, hdr_intent, gainmap.get(), &metadata, dest, quality,
+                            exif, baseIcc.get(), alternateIcc.get());
 }
 
 /* Encode API-1 */
@@ -367,15 +422,17 @@ uhdr_error_info_t AvifUltraHdr::encodeAvifUltraHdr(uhdr_raw_image_t* hdr_intent,
   std::shared_ptr<DataStruct> alternateIcc =
       IccHelper::writeIccProfile(gainmap->ct, gainmap->cg);
 
-  return encodeAvifUltraHdr(sdr_intent_yuv, gainmap.get(), &metadata, dest, quality, exif, baseIcc.get(),
-                     alternateIcc.get());
+  return encodeAvifUltraHdr(sdr_intent_yuv, sdr_intent, gainmap.get(), &metadata, dest, quality,
+                            exif, baseIcc.get(), alternateIcc.get());
 }
 
-uhdr_error_info_t AvifUltraHdr::encodeAvifUltraHdr(uhdr_raw_image_t* sdr_intent, uhdr_raw_image_t* gainmap_img,
-                                     uhdr_gainmap_metadata_ext_t* metadata,
-                                     uhdr_compressed_image_t* dest, int quality,
-                                     uhdr_mem_block_t* exif, DataStruct* baseIcc,
-                                     DataStruct* alternateIcc) {
+uhdr_error_info_t AvifUltraHdr::encodeAvifUltraHdr(uhdr_raw_image_t* sdr_intent,
+                                                   uhdr_raw_image_t* base_alpha_source,
+                                                   uhdr_raw_image_t* gainmap_img,
+                                                   uhdr_gainmap_metadata_ext_t* metadata,
+                                                   uhdr_compressed_image_t* dest, int quality,
+                                                   uhdr_mem_block_t* exif, DataStruct* baseIcc,
+                                                   DataStruct* alternateIcc) {
   uhdr_error_info_t status = g_no_error;
   heif_encoder* encoder = nullptr;
   heif_encoding_options* options = nullptr;
@@ -426,6 +483,7 @@ uhdr_error_info_t AvifUltraHdr::encodeAvifUltraHdr(uhdr_raw_image_t* sdr_intent,
                                 chromaWd, chromaHt, sdr_intent->stride[UHDR_PLANE_U]));
   HEIF_ERR_CHECK(fill_img_plane(baseImage, heif_channel_Cr, sdr_intent->planes[UHDR_PLANE_V],
                                 chromaWd, chromaHt, sdr_intent->stride[UHDR_PLANE_V]));
+  HEIF_ERR_CHECK(add_alpha_plane(baseImage, base_alpha_source));
   if (baseIcc != nullptr) {
     void* ptr = (uint8_t*)baseIcc->getData() + kICCIdentifierSize;
     HEIF_ERR_CHECK(heif_image_set_raw_color_profile(baseImage, "prof", ptr,
@@ -457,6 +515,7 @@ uhdr_error_info_t AvifUltraHdr::encodeAvifUltraHdr(uhdr_raw_image_t* sdr_intent,
     goto CleanUp;
   }
   options->save_two_colr_boxes_when_ICC_and_nclx_available = 1;
+  options->save_alpha_channel = 1;
   options->output_nclx_profile = sdrNclx;
   HEIF_ERR_CHECK(heif_image_set_nclx_color_profile(baseImage, sdrNclx));
   HEIF_ERR_CHECK(heif_context_encode_image(ctx, baseImage, encoder, options, &baseHandle));

--- a/lib/src/heifultrahdr.cpp
+++ b/lib/src/heifultrahdr.cpp
@@ -16,6 +16,8 @@
 
 #ifdef UHDR_ENABLE_HEIF
 
+#include <algorithm>
+#include <cmath>
 #include <cstdlib>
 #include <limits>
 #include <map>
@@ -94,6 +96,59 @@ static struct heif_error fill_img_plane(heif_image* img, heif_channel channel, v
     srcRow += srcRowStride;
     dstBuffer += dstStride;
   }
+  return err;
+}
+
+static uint8_t get_alpha_value(const uhdr_raw_image_t* image, size_t x, size_t y) {
+  if (image->fmt == UHDR_IMG_FMT_32bppRGBA8888) {
+    const auto* row = static_cast<const uint32_t*>(image->planes[UHDR_PLANE_PACKED]) +
+                      y * image->stride[UHDR_PLANE_PACKED];
+    return static_cast<uint8_t>(row[x] >> 24);
+  }
+  if (image->fmt == UHDR_IMG_FMT_32bppRGBA1010102) {
+    const auto* row = static_cast<const uint32_t*>(image->planes[UHDR_PLANE_PACKED]) +
+                      y * image->stride[UHDR_PLANE_PACKED];
+    return static_cast<uint8_t>(((row[x] >> 30) & 0x3u) * 85u);
+  }
+  const auto* row = static_cast<const uint16_t*>(image->planes[UHDR_PLANE_PACKED]) +
+                    y * image->stride[UHDR_PLANE_PACKED] * 4;
+  float alpha = halfToFloat(row[x * 4 + 3]);
+  if (std::isnan(alpha)) alpha = 0.0f;
+  alpha = std::clamp(alpha, 0.0f, 1.0f);
+  return static_cast<uint8_t>(alpha * 255.0f + 0.5f);
+}
+
+static struct heif_error add_alpha_plane(heif_image* image, const uhdr_raw_image_t* alpha_source) {
+  if (alpha_source == nullptr || (alpha_source->fmt != UHDR_IMG_FMT_32bppRGBA8888 &&
+                                  alpha_source->fmt != UHDR_IMG_FMT_32bppRGBA1010102 &&
+                                  alpha_source->fmt != UHDR_IMG_FMT_64bppRGBAHalfFloat)) {
+    return {heif_error_Ok, heif_suberror_Unspecified, nullptr};
+  }
+
+  bool has_transparency = false;
+  for (size_t y = 0; y < alpha_source->h && !has_transparency; ++y) {
+    for (size_t x = 0; x < alpha_source->w; ++x) {
+      if (get_alpha_value(alpha_source, x, y) != 255) {
+        has_transparency = true;
+        break;
+      }
+    }
+  }
+  if (!has_transparency) return {heif_error_Ok, heif_suberror_Unspecified, nullptr};
+
+  heif_error err =
+      heif_image_add_plane(image, heif_channel_Alpha, alpha_source->w, alpha_source->h, 8);
+  if (err.code != heif_error_Ok) return err;
+
+  int dst_stride;
+  uint8_t* dst = heif_image_get_plane(image, heif_channel_Alpha, &dst_stride);
+  for (size_t y = 0; y < alpha_source->h; ++y) {
+    for (size_t x = 0; x < alpha_source->w; ++x) {
+      dst[x] = get_alpha_value(alpha_source, x, y);
+    }
+    dst += dst_stride;
+  }
+  heif_image_set_premultiplied_alpha(image, 0);
   return err;
 }
 
@@ -338,8 +393,8 @@ uhdr_error_info_t HeifUltraHdr::encodeHeicUltraHdr(uhdr_raw_image_t* hdr_intent,
   std::shared_ptr<DataStruct> alternateIcc =
       IccHelper::writeIccProfile(gainmap->ct, gainmap->cg);
 
-  return encodeHeicUltraHdr(sdr_intent_yuv, gainmap.get(), &metadata, dest, quality, exif, baseIcc.get(),
-                     alternateIcc.get());
+  return encodeHeicUltraHdr(sdr_intent_yuv, hdr_intent, gainmap.get(), &metadata, dest, quality,
+                            exif, baseIcc.get(), alternateIcc.get());
 }
 
 /* Encode API-1 */
@@ -367,15 +422,17 @@ uhdr_error_info_t HeifUltraHdr::encodeHeicUltraHdr(uhdr_raw_image_t* hdr_intent,
   std::shared_ptr<DataStruct> alternateIcc =
       IccHelper::writeIccProfile(gainmap->ct, gainmap->cg);
 
-  return encodeHeicUltraHdr(sdr_intent_yuv, gainmap.get(), &metadata, dest, quality, exif, baseIcc.get(),
-                     alternateIcc.get());
+  return encodeHeicUltraHdr(sdr_intent_yuv, sdr_intent, gainmap.get(), &metadata, dest, quality,
+                            exif, baseIcc.get(), alternateIcc.get());
 }
 
-uhdr_error_info_t HeifUltraHdr::encodeHeicUltraHdr(uhdr_raw_image_t* sdr_intent, uhdr_raw_image_t* gainmap_img,
-                                     uhdr_gainmap_metadata_ext_t* metadata,
-                                     uhdr_compressed_image_t* dest, int quality,
-                                     uhdr_mem_block_t* exif, DataStruct* baseIcc,
-                                     DataStruct* alternateIcc) {
+uhdr_error_info_t HeifUltraHdr::encodeHeicUltraHdr(uhdr_raw_image_t* sdr_intent,
+                                                   uhdr_raw_image_t* base_alpha_source,
+                                                   uhdr_raw_image_t* gainmap_img,
+                                                   uhdr_gainmap_metadata_ext_t* metadata,
+                                                   uhdr_compressed_image_t* dest, int quality,
+                                                   uhdr_mem_block_t* exif, DataStruct* baseIcc,
+                                                   DataStruct* alternateIcc) {
   uhdr_error_info_t status = g_no_error;
   heif_encoder* encoder = nullptr;
   heif_encoding_options* options = nullptr;
@@ -426,6 +483,7 @@ uhdr_error_info_t HeifUltraHdr::encodeHeicUltraHdr(uhdr_raw_image_t* sdr_intent,
                                 chromaWd, chromaHt, sdr_intent->stride[UHDR_PLANE_U]));
   HEIF_ERR_CHECK(fill_img_plane(baseImage, heif_channel_Cr, sdr_intent->planes[UHDR_PLANE_V],
                                 chromaWd, chromaHt, sdr_intent->stride[UHDR_PLANE_V]));
+  HEIF_ERR_CHECK(add_alpha_plane(baseImage, base_alpha_source));
   if (baseIcc != nullptr) {
     void* ptr = (uint8_t*)baseIcc->getData() + kICCIdentifierSize;
     HEIF_ERR_CHECK(heif_image_set_raw_color_profile(baseImage, "prof", ptr,
@@ -457,6 +515,7 @@ uhdr_error_info_t HeifUltraHdr::encodeHeicUltraHdr(uhdr_raw_image_t* sdr_intent,
     goto CleanUp;
   }
   options->save_two_colr_boxes_when_ICC_and_nclx_available = 1;
+  options->save_alpha_channel = 1;
   options->output_nclx_profile = sdrNclx;
   HEIF_ERR_CHECK(heif_image_set_nclx_color_profile(baseImage, sdrNclx));
   HEIF_ERR_CHECK(heif_context_encode_image(ctx, baseImage, encoder, options, &baseHandle));

--- a/tests/ultrahdr_api_test.cpp
+++ b/tests/ultrahdr_api_test.cpp
@@ -18,6 +18,7 @@
 #include "ultrahdr_api.h"
 #include "ultrahdr/ultrahdrcommon.h"
 #include "ultrahdr/jpegr.h"
+#include "ultrahdr/gainmapmath.h"
 #include "ultrahdr/heifultrahdr.h"
 #include "ultrahdr/avifultrahdr.h"
 
@@ -325,6 +326,196 @@ static bool setBackwardDirectionFlag(const uhdr_compressed_image_t* image,
   metadata_pos[4] |= 4;
   return true;
 }
+
+namespace {
+
+constexpr size_t kAlphaTestWidth = 64;
+constexpr size_t kAlphaTestHeight = 64;
+
+struct AlphaTestImages {
+  std::vector<uint32_t> hdr1010102;
+  std::vector<uint16_t> hdrHalfFloat;
+  std::vector<uint32_t> sdr8888;
+  uhdr_raw_image_t hdr1010102Desc{};
+  uhdr_raw_image_t hdrHalfFloatDesc{};
+  uhdr_raw_image_t sdr8888Desc{};
+
+  AlphaTestImages()
+      : hdr1010102(kAlphaTestWidth * kAlphaTestHeight),
+        hdrHalfFloat(kAlphaTestWidth * kAlphaTestHeight * 4),
+        sdr8888(kAlphaTestWidth * kAlphaTestHeight) {
+    for (size_t y = 0; y < kAlphaTestHeight; ++y) {
+      for (size_t x = 0; x < kAlphaTestWidth; ++x) {
+        const size_t pixel = y * kAlphaTestWidth + x;
+        const uint32_t alpha2 = static_cast<uint32_t>(x / (kAlphaTestWidth / 4));
+        const uint32_t alpha8 = alpha2 * 85u;
+        hdr1010102[pixel] = 700u | (500u << 10) | (300u << 20) | (alpha2 << 30);
+        hdrHalfFloat[pixel * 4] = floatToHalf(2.0f);
+        hdrHalfFloat[pixel * 4 + 1] = floatToHalf(1.5f);
+        hdrHalfFloat[pixel * 4 + 2] = floatToHalf(1.0f);
+        hdrHalfFloat[pixel * 4 + 3] = floatToHalf(alpha2 / 3.0f);
+        sdr8888[pixel] = 120u | (80u << 8) | (40u << 16) | (alpha8 << 24);
+      }
+    }
+
+    hdr1010102Desc.fmt = UHDR_IMG_FMT_32bppRGBA1010102;
+    hdr1010102Desc.cg = UHDR_CG_BT_2100;
+    hdr1010102Desc.ct = UHDR_CT_HLG;
+    hdr1010102Desc.range = UHDR_CR_FULL_RANGE;
+    hdr1010102Desc.w = kAlphaTestWidth;
+    hdr1010102Desc.h = kAlphaTestHeight;
+    hdr1010102Desc.planes[UHDR_PLANE_PACKED] = hdr1010102.data();
+    hdr1010102Desc.stride[UHDR_PLANE_PACKED] = kAlphaTestWidth;
+
+    hdrHalfFloatDesc.fmt = UHDR_IMG_FMT_64bppRGBAHalfFloat;
+    hdrHalfFloatDesc.cg = UHDR_CG_BT_2100;
+    hdrHalfFloatDesc.ct = UHDR_CT_LINEAR;
+    hdrHalfFloatDesc.range = UHDR_CR_FULL_RANGE;
+    hdrHalfFloatDesc.w = kAlphaTestWidth;
+    hdrHalfFloatDesc.h = kAlphaTestHeight;
+    hdrHalfFloatDesc.planes[UHDR_PLANE_PACKED] = hdrHalfFloat.data();
+    hdrHalfFloatDesc.stride[UHDR_PLANE_PACKED] = kAlphaTestWidth;
+
+    sdr8888Desc.fmt = UHDR_IMG_FMT_32bppRGBA8888;
+    sdr8888Desc.cg = UHDR_CG_BT_709;
+    sdr8888Desc.ct = UHDR_CT_SRGB;
+    sdr8888Desc.range = UHDR_CR_FULL_RANGE;
+    sdr8888Desc.w = kAlphaTestWidth;
+    sdr8888Desc.h = kAlphaTestHeight;
+    sdr8888Desc.planes[UHDR_PLANE_PACKED] = sdr8888.data();
+    sdr8888Desc.stride[UHDR_PLANE_PACKED] = kAlphaTestWidth;
+  }
+
+  void makeHdr1010102AlphaOpaque() {
+    for (uint32_t& pixel : hdr1010102) pixel |= 3u << 30;
+  }
+};
+
+uhdr_error_info_t encodeRawAlphaImage(uhdr_codec_t codec, uhdr_raw_image_t* hdr,
+                                      uhdr_raw_image_t* sdr, std::vector<uint8_t>* encoded) {
+  uhdr_codec_private_t* enc = uhdr_create_encoder();
+  if (enc == nullptr) {
+    uhdr_error_info_t status{};
+    status.error_code = UHDR_CODEC_MEM_ERROR;
+    return status;
+  }
+
+  uhdr_error_info_t status = uhdr_enc_set_raw_image(enc, hdr, UHDR_HDR_IMG);
+  if (status.error_code == UHDR_CODEC_OK && sdr != nullptr) {
+    status = uhdr_enc_set_raw_image(enc, sdr, UHDR_SDR_IMG);
+  }
+  if (status.error_code == UHDR_CODEC_OK) status = uhdr_enc_set_output_format(enc, codec);
+  if (status.error_code == UHDR_CODEC_OK) status = uhdr_enc_set_quality(enc, 100, UHDR_BASE_IMG);
+  if (status.error_code == UHDR_CODEC_OK) status = uhdr_encode(enc);
+  if (status.error_code == UHDR_CODEC_OK) {
+    uhdr_compressed_image_t* output = uhdr_get_encoded_stream(enc);
+    if (output == nullptr || output->data_sz == 0) {
+      status.error_code = UHDR_CODEC_ERROR;
+    } else {
+      const uint8_t* data = static_cast<const uint8_t*>(output->data);
+      encoded->assign(data, data + output->data_sz);
+    }
+  }
+  uhdr_release_encoder(enc);
+  return status;
+}
+
+::testing::AssertionResult containerHasStraightAlpha(const std::vector<uint8_t>& encoded) {
+  heif_context* context = heif_context_alloc();
+  if (context == nullptr) return ::testing::AssertionFailure() << "libheif allocation failed";
+
+  heif_error error =
+      heif_context_read_from_memory_without_copy(context, encoded.data(), encoded.size(), nullptr);
+  if (error.code != heif_error_Ok) {
+    const std::string detail = error.message != nullptr ? error.message : "no detail";
+    heif_context_free(context);
+    return ::testing::AssertionFailure() << "libheif read failed: " << detail;
+  }
+
+  heif_image_handle* primary = nullptr;
+  error = heif_context_get_primary_image_handle(context, &primary);
+  if (error.code != heif_error_Ok || primary == nullptr) {
+    const std::string detail = error.message != nullptr ? error.message : "no detail";
+    heif_context_free(context);
+    return ::testing::AssertionFailure() << "primary image lookup failed: " << detail;
+  }
+
+  const bool has_alpha = heif_image_handle_has_alpha_channel(primary);
+  const bool is_premultiplied = heif_image_handle_is_premultiplied_alpha(primary);
+  heif_image_handle_release(primary);
+  heif_context_free(context);
+  if (!has_alpha) return ::testing::AssertionFailure() << "base image has no alpha channel";
+  if (is_premultiplied) {
+    return ::testing::AssertionFailure() << "base image alpha is marked premultiplied";
+  }
+  return ::testing::AssertionSuccess();
+}
+
+::testing::AssertionResult decodedAlphaMatches(const std::vector<uint8_t>& encoded) {
+  const ::testing::AssertionResult container_result = containerHasStraightAlpha(encoded);
+  if (!container_result) return container_result;
+
+  uhdr_compressed_image_t input{};
+  input.data = const_cast<uint8_t*>(encoded.data());
+  input.data_sz = encoded.size();
+  input.capacity = encoded.size();
+
+  uhdr_codec_private_t* dec = uhdr_create_decoder();
+  if (dec == nullptr) return ::testing::AssertionFailure() << "decoder allocation failed";
+  uhdr_error_info_t status = uhdr_dec_set_image(dec, &input);
+  if (status.error_code == UHDR_CODEC_OK) {
+    status = uhdr_dec_set_out_color_transfer(dec, UHDR_CT_SRGB);
+  }
+  if (status.error_code == UHDR_CODEC_OK) {
+    status = uhdr_dec_set_out_img_format(dec, UHDR_IMG_FMT_32bppRGBA8888);
+  }
+  if (status.error_code == UHDR_CODEC_OK) status = uhdr_dec_probe(dec);
+  if (status.error_code == UHDR_CODEC_OK) status = uhdr_decode(dec);
+  if (status.error_code != UHDR_CODEC_OK) {
+    const std::string detail = status.has_detail ? status.detail : "no detail";
+    uhdr_release_decoder(dec);
+    return ::testing::AssertionFailure() << "decode failed: " << detail;
+  }
+
+  uhdr_raw_image_t* decoded = uhdr_get_decoded_image(dec);
+  if (decoded == nullptr || decoded->fmt != UHDR_IMG_FMT_32bppRGBA8888 ||
+      decoded->w != kAlphaTestWidth || decoded->h != kAlphaTestHeight) {
+    uhdr_release_decoder(dec);
+    return ::testing::AssertionFailure() << "unexpected decoded image descriptor";
+  }
+
+  const auto* pixels = static_cast<const uint32_t*>(decoded->planes[UHDR_PLANE_PACKED]);
+  const size_t stride = decoded->stride[UHDR_PLANE_PACKED];
+  for (size_t y = 0; y < kAlphaTestHeight; ++y) {
+    for (size_t x = 0; x < kAlphaTestWidth; ++x) {
+      const int alpha = pixels[y * stride + x] >> 24;
+      const int expected = static_cast<int>(x / (kAlphaTestWidth / 4)) * 85;
+      if (std::abs(alpha - expected) > 16) {
+        uhdr_release_decoder(dec);
+        return ::testing::AssertionFailure() << "unexpected alpha " << alpha << ", expected "
+                                             << expected << " at (" << x << ", " << y << ")";
+      }
+    }
+  }
+  uhdr_release_decoder(dec);
+  return ::testing::AssertionSuccess();
+}
+
+void expectRawAlphaPreserved(uhdr_codec_t codec, uhdr_raw_image_t* hdr,
+                             uhdr_raw_image_t* sdr = nullptr) {
+  std::vector<uint8_t> encoded;
+  const uhdr_error_info_t status = encodeRawAlphaImage(codec, hdr, sdr, &encoded);
+  ASSERT_EQ(status.error_code, UHDR_CODEC_OK) << (status.has_detail ? status.detail : "no detail");
+  EXPECT_TRUE(decodedAlphaMatches(encoded));
+}
+
+bool encoderUnavailable(const uhdr_error_info_t& status) {
+  return status.error_code != UHDR_CODEC_OK && status.has_detail &&
+         (strstr(status.detail, "Unsupported file-type") != nullptr ||
+          strstr(status.detail, "No encoder") != nullptr);
+}
+
+}  // namespace
 
 TEST_F(UltraHdrApiTest, HeicEncodeApi0AndDecode) {
   uhdr_codec_private_t* enc = uhdr_create_encoder();
@@ -662,6 +853,36 @@ TEST_F(UltraHdrApiTest, AvifCompressedIntentsUnsupported) {
   EXPECT_EQ(err.error_code, UHDR_CODEC_UNSUPPORTED_FEATURE);
 
   uhdr_release_encoder(enc);
+}
+
+TEST_F(UltraHdrApiTest, AvifPreservesRawAlpha) {
+  AlphaTestImages images;
+  std::vector<uint8_t> encoded;
+  uhdr_error_info_t status =
+      encodeRawAlphaImage(UHDR_CODEC_AVIF, &images.hdr1010102Desc, nullptr, &encoded);
+  if (encoderUnavailable(status)) {
+    GTEST_SKIP() << "AV1 encoder plugin not available in environment: " << status.detail;
+  }
+  ASSERT_EQ(status.error_code, UHDR_CODEC_OK) << (status.has_detail ? status.detail : "no detail");
+  EXPECT_TRUE(decodedAlphaMatches(encoded));
+  expectRawAlphaPreserved(UHDR_CODEC_AVIF, &images.hdrHalfFloatDesc);
+  images.makeHdr1010102AlphaOpaque();
+  expectRawAlphaPreserved(UHDR_CODEC_AVIF, &images.hdr1010102Desc, &images.sdr8888Desc);
+}
+
+TEST_F(UltraHdrApiTest, HeifPreservesRawAlpha) {
+  AlphaTestImages images;
+  std::vector<uint8_t> encoded;
+  uhdr_error_info_t status =
+      encodeRawAlphaImage(UHDR_CODEC_HEIF, &images.hdr1010102Desc, nullptr, &encoded);
+  if (encoderUnavailable(status)) {
+    GTEST_SKIP() << "HEVC encoder plugin not available in environment: " << status.detail;
+  }
+  ASSERT_EQ(status.error_code, UHDR_CODEC_OK) << (status.has_detail ? status.detail : "no detail");
+  EXPECT_TRUE(decodedAlphaMatches(encoded));
+  expectRawAlphaPreserved(UHDR_CODEC_HEIF, &images.hdrHalfFloatDesc);
+  images.makeHdr1010102AlphaOpaque();
+  expectRawAlphaPreserved(UHDR_CODEC_HEIF, &images.hdr1010102Desc, &images.sdr8888Desc);
 }
 #else
 TEST_F(UltraHdrApiTest, HeicCodecUnsupportedWhenDisabled) {


### PR DESCRIPTION
## What changed

Preserve alpha when AVIF or HEIF is encoded from a supported raw RGBA input.

- API-0 takes alpha from the original HDR input (`RGBA1010102` or `RGBAHalfFloat`).
- API-1 takes alpha from the supplied `RGBA8888` SDR base image.
- Non-opaque alpha is attached to the encoded base as a straight 8-bit alpha plane.

Previously, the RGB-to-YCbCr conversion discarded alpha before encoding, so accepted RGBA inputs always decoded as fully opaque. For API-0, alpha must come from the original HDR input because the internally tone-mapped SDR image has already been made opaque.

Half-float alpha is quantized to 8-bit, matching the current 8-bit base-image encoding. The public C API and non-RGBA paths are unchanged.

## Testing

Added public-API regression coverage for both AVIF and HEIF:

- API-0 with `RGBA1010102`
- API-0 with `RGBAHalfFloat`
- API-1 with different HDR and SDR alpha, confirming the SDR base is the source
- intermediate alpha values (`0`, `85`, `170`, and `255`)
- direct verification that the encoded base carries non-premultiplied alpha

All six cases fail on current `main` because decoded alpha is always `255`; they pass with this change. The full unit suite also passes: 1,073 passed, with 224 existing parameter skips.

Compressed-input/API-4 AVIF/HEIF transcoding is outside this focused fix and is tracked separately in [#454](https://github.com/google/libultrahdr/issues/454).
