### PR TITLE
Reject and propagate invalid ISO gain-map metadata

### DIFF
--- a/lib/src/gainmapmetadata.cpp
+++ b/lib/src/gainmapmetadata.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 
 #include "ultrahdr/gainmapmath.h"
 #include "ultrahdr/gainmapmetadata.h"
@@ -298,6 +299,14 @@ uhdr_error_info_t uhdr_gainmap_metadata_frac::decodeGainmapMetadata(
     return status;                                                                                 \
   }
 
+static uhdr_error_info_t invalidGainMapMetadata(const char *detail) {
+  uhdr_error_info_t status;
+  status.error_code = UHDR_CODEC_INVALID_PARAM;
+  status.has_detail = 1;
+  snprintf(status.detail, sizeof status.detail, "%s", detail);
+  return status;
+}
+
 uhdr_error_info_t uhdr_gainmap_metadata_frac::gainmapMetadataFractionToFloat(
     const uhdr_gainmap_metadata_frac *from, uhdr_gainmap_metadata_ext_t *to) {
   if (from == nullptr || to == nullptr) {
@@ -317,6 +326,11 @@ uhdr_error_info_t uhdr_gainmap_metadata_frac::gainmapMetadataFractionToFloat(
     UHDR_CHECK_NON_ZERO(from->gainMapMinD[i], "gainMapMin denominator");
     UHDR_CHECK_NON_ZERO(from->baseOffsetD[i], "baseOffset denominator");
     UHDR_CHECK_NON_ZERO(from->alternateOffsetD[i], "alternateOffset denominator");
+    if (static_cast<int64_t>(from->gainMapMaxN[i]) * from->gainMapMinD[i] <
+        static_cast<int64_t>(from->gainMapMinN[i]) * from->gainMapMaxD[i]) {
+      return invalidGainMapMetadata(
+          "decoded gain map maximum content boost is less than its minimum");
+    }
   }
 
   // jpeg supports only 8 bits per component, applying gainmap in inverse direction is unexpected

--- a/lib/src/ultrahdr_api.cpp
+++ b/lib/src/ultrahdr_api.cpp
@@ -1716,26 +1716,41 @@ uhdr_error_info_t uhdr_dec_probe(uhdr_codec_private_t* dec) {
               handle->m_gainmap_ht = heif_image_handle_get_height(gainmap_handle);
               handle->m_gainmap_num_comp = 1;
 
-              int meta_len = heif_image_handle_get_gain_map_metadata_size(base_handle);
+              size_t meta_len = heif_image_handle_get_gain_map_metadata_size(base_handle);
               if (meta_len > 0) {
                 std::vector<uint8_t> meta(meta_len);
-                heif_image_handle_get_gain_map_metadata(base_handle, meta.data());
-                ultrahdr::uhdr_gainmap_metadata_frac frac;
-                if (ultrahdr::uhdr_gainmap_metadata_frac::decodeGainmapMetadata(meta, &frac).error_code == UHDR_CODEC_OK) {
+                err = heif_image_handle_get_gain_map_metadata(base_handle, meta.data());
+                if (err.code != heif_error_Ok) {
+                  status.error_code = UHDR_CODEC_ERROR;
+                  status.has_detail = 1;
+                  snprintf(status.detail, sizeof status.detail, "%s", err.message);
+                } else {
+                  ultrahdr::uhdr_gainmap_metadata_frac frac;
+                  status = ultrahdr::uhdr_gainmap_metadata_frac::decodeGainmapMetadata(meta, &frac);
                   ultrahdr::uhdr_gainmap_metadata_ext_t metadata;
-                  if (ultrahdr::uhdr_gainmap_metadata_frac::gainmapMetadataFractionToFloat(&frac, &metadata).error_code == UHDR_CODEC_OK) {
+                  if (status.error_code == UHDR_CODEC_OK) {
+                    status = ultrahdr::uhdr_gainmap_metadata_frac::gainmapMetadataFractionToFloat(
+                        &frac, &metadata);
+                  }
+                  if (status.error_code == UHDR_CODEC_OK) {
                     std::copy(metadata.max_content_boost, metadata.max_content_boost + 3,
                               handle->m_metadata.max_content_boost);
                     std::copy(metadata.min_content_boost, metadata.min_content_boost + 3,
                               handle->m_metadata.min_content_boost);
                     std::copy(metadata.gamma, metadata.gamma + 3, handle->m_metadata.gamma);
-                    std::copy(metadata.offset_sdr, metadata.offset_sdr + 3, handle->m_metadata.offset_sdr);
-                    std::copy(metadata.offset_hdr, metadata.offset_hdr + 3, handle->m_metadata.offset_hdr);
+                    std::copy(metadata.offset_sdr, metadata.offset_sdr + 3,
+                              handle->m_metadata.offset_sdr);
+                    std::copy(metadata.offset_hdr, metadata.offset_hdr + 3,
+                              handle->m_metadata.offset_hdr);
                     handle->m_metadata.hdr_capacity_min = metadata.hdr_capacity_min;
                     handle->m_metadata.hdr_capacity_max = metadata.hdr_capacity_max;
                     handle->m_metadata.use_base_cg = metadata.use_base_cg;
                   }
                 }
+              } else {
+                status.error_code = UHDR_CODEC_INVALID_PARAM;
+                status.has_detail = 1;
+                snprintf(status.detail, sizeof status.detail, "gain map metadata is empty");
               }
               heif_image_handle_release(gainmap_handle);
             }

--- a/tests/gainmapmetadata_test.cpp
+++ b/tests/gainmapmetadata_test.cpp
@@ -145,6 +145,17 @@ TEST(GainmapMetadataTest, RejectsMalformedISO21496_1Ratios) {
   frac.baseHdrHeadroomN = 1;      // log2(headroom_min) = 1 -> 2.0
   EXPECT_EQ(uhdr_gainmap_metadata_frac::gainmapMetadataFractionToFloat(&frac, &float_meta).error_code,
             UHDR_CODEC_INVALID_PARAM);
+
+  // These fractions are ordered incorrectly but both round to 1.0f. Validate their exact rational
+  // values so float precision cannot hide the invalid range.
+  frac.alternateHdrHeadroomN = 1;
+  frac.baseHdrHeadroomN = 0;
+  frac.gainMapMinN[0] = 16777217;
+  frac.gainMapMinD[0] = 16777216;
+  frac.gainMapMaxN[0] = 1;
+  frac.gainMapMaxD[0] = 1;
+  EXPECT_EQ(uhdr_gainmap_metadata_frac::gainmapMetadataFractionToFloat(&frac, &float_meta).error_code,
+            UHDR_CODEC_INVALID_PARAM);
 }
 
 }  // namespace ultrahdr

--- a/tests/ultrahdr_api_test.cpp
+++ b/tests/ultrahdr_api_test.cpp
@@ -7,6 +7,7 @@
 #else
 #include <gtest/gtest.h>
 #endif
+#include <algorithm>
 #include <fstream>
 #include <cstring>
 #include <limits>
@@ -242,6 +243,43 @@ TEST_F(UltraHdrApiTest, JpegEncodeApi2AndDecode) {
 // ============================================================================
 
 #if defined(UHDR_ENABLE_HEIF)
+static bool setBackwardDirectionFlag(const uhdr_compressed_image_t* image,
+                                     std::vector<uint8_t>& modified_image) {
+  std::unique_ptr<heif_context, decltype(&heif_context_free)> context(heif_context_alloc(),
+                                                                      heif_context_free);
+  if (context == nullptr) return false;
+  heif_error error = heif_context_read_from_memory_without_copy(context.get(), image->data,
+                                                                image->data_sz, nullptr);
+  if (error.code != heif_error_Ok) return false;
+
+  heif_image_handle* raw_base_handle = nullptr;
+  error = heif_context_get_primary_image_handle(context.get(), &raw_base_handle);
+  std::unique_ptr<heif_image_handle, decltype(&heif_image_handle_release)> base_handle(
+      raw_base_handle, heif_image_handle_release);
+  if (error.code != heif_error_Ok || base_handle == nullptr) return false;
+
+  const size_t metadata_size = heif_image_handle_get_gain_map_metadata_size(base_handle.get());
+  if (metadata_size <= 4) return false;
+  std::vector<uint8_t> metadata(metadata_size);
+  error = heif_image_handle_get_gain_map_metadata(base_handle.get(), metadata.data());
+  if (error.code != heif_error_Ok) return false;
+
+  modified_image.assign(static_cast<const uint8_t*>(image->data),
+                        static_cast<const uint8_t*>(image->data) + image->data_sz);
+  auto metadata_pos =
+      std::search(modified_image.begin(), modified_image.end(), metadata.begin(), metadata.end());
+  if (metadata_pos == modified_image.end()) return false;
+  if (std::search(metadata_pos + metadata.size(), modified_image.end(), metadata.begin(),
+                  metadata.end()) != modified_image.end()) {
+    return false;
+  }
+
+  // ISO 21496-1 metadata stores its flags after two 16-bit version fields.
+  // Set backwardDirection, which this decoder explicitly does not support.
+  metadata_pos[4] |= 4;
+  return true;
+}
+
 TEST_F(UltraHdrApiTest, HeicEncodeApi0AndDecode) {
   uhdr_codec_private_t* enc = uhdr_create_encoder();
   ASSERT_NE(enc, nullptr);
@@ -494,6 +532,70 @@ TEST_F(UltraHdrApiTest, AvifEncodeRejectsUndersizedDestination) {
   EXPECT_EQ(dest.capacity, 1u);
   EXPECT_EQ(dest.data_sz, 0u);
   EXPECT_EQ(backing_store.front(), 0xa5);
+}
+
+TEST_F(UltraHdrApiTest, HeifAndAvifPropagateGainMapMetadataErrors) {
+  int tested_formats = 0;
+  for (uhdr_codec_t codec : {UHDR_CODEC_AVIF, UHDR_CODEC_HEIF}) {
+    SCOPED_TRACE(codec == UHDR_CODEC_AVIF ? "AVIF" : "HEIF");
+    uhdr_codec_private_t* enc = uhdr_create_encoder();
+    ASSERT_NE(enc, nullptr);
+
+    ASSERT_EQ(uhdr_enc_set_raw_image(enc, &mHdrRaw, UHDR_HDR_IMG).error_code, UHDR_CODEC_OK);
+    ASSERT_EQ(uhdr_enc_set_output_format(enc, codec).error_code, UHDR_CODEC_OK);
+    uhdr_error_info_t enc_status = uhdr_encode(enc);
+    if (enc_status.error_code != UHDR_CODEC_OK && enc_status.has_detail &&
+        (strstr(enc_status.detail, "Unsupported file-type") != nullptr ||
+         strstr(enc_status.detail, "No encoder") != nullptr)) {
+      uhdr_release_encoder(enc);
+      continue;
+    }
+    ASSERT_EQ(enc_status.error_code, UHDR_CODEC_OK);
+    ++tested_formats;
+
+    uhdr_compressed_image_t* output = uhdr_get_encoded_stream(enc);
+    ASSERT_NE(output, nullptr);
+    std::vector<uint8_t> invalid_data;
+    ASSERT_TRUE(setBackwardDirectionFlag(output, invalid_data));
+
+    uhdr_compressed_image_t invalid_image = *output;
+    invalid_image.data = invalid_data.data();
+    invalid_image.data_sz = invalid_image.capacity = invalid_data.size();
+
+    uhdr_codec_private_t* dec = uhdr_create_decoder();
+    ASSERT_NE(dec, nullptr);
+    ASSERT_EQ(uhdr_dec_set_image(dec, &invalid_image).error_code, UHDR_CODEC_OK);
+    EXPECT_EQ(uhdr_dec_probe(dec).error_code, UHDR_CODEC_UNSUPPORTED_FEATURE);
+    uhdr_release_decoder(dec);
+
+    // Exercise each backend error path directly as well. Sanitizer builds verify that these paths
+    // release the partially decoded libheif objects before returning the metadata error.
+    std::vector<uint8_t> decoded_data(kImageWidth * kImageHeight * 4);
+    uhdr_raw_image_t decoded_image{};
+    decoded_image.fmt = UHDR_IMG_FMT_32bppRGBA8888;
+    decoded_image.cg = UHDR_CG_BT_709;
+    decoded_image.ct = UHDR_CT_SRGB;
+    decoded_image.range = UHDR_CR_FULL_RANGE;
+    decoded_image.w = kImageWidth;
+    decoded_image.h = kImageHeight;
+    decoded_image.planes[UHDR_PLANE_PACKED] = decoded_data.data();
+    decoded_image.stride[UHDR_PLANE_PACKED] = kImageWidth;
+    uhdr_gainmap_metadata_t metadata{};
+    uhdr_error_info_t decode_status;
+    if (codec == UHDR_CODEC_AVIF) {
+      AvifUltraHdr avif;
+      decode_status = avif.decodeAvifUltraHdr(&invalid_image, &decoded_image, FLT_MAX, UHDR_CT_SRGB,
+                                              UHDR_IMG_FMT_32bppRGBA8888, nullptr, &metadata);
+    } else {
+      HeifUltraHdr heif;
+      decode_status = heif.decodeHeicUltraHdr(&invalid_image, &decoded_image, FLT_MAX, UHDR_CT_SRGB,
+                                              UHDR_IMG_FMT_32bppRGBA8888, nullptr, &metadata);
+    }
+    EXPECT_EQ(decode_status.error_code, UHDR_CODEC_UNSUPPORTED_FEATURE);
+
+    uhdr_release_encoder(enc);
+  }
+  if (tested_formats == 0) GTEST_SKIP() << "AV1 and HEVC encoder plugins are unavailable";
 }
 
 TEST_F(UltraHdrApiTest, AvifCompressedIntentsUnsupported) {


### PR DESCRIPTION
## Summary

- propagate HEIF/AVIF metadata errors during probe instead of exposing invalid values
- reject reversed rational boost bounds that float conversion can conceal

## Why

Current main validates converted gain-map descriptors, but HEIF/AVIF probing can still discard
metadata errors and report success. Comparing the original rational values also catches invalid
bounds that become indistinguishable after float rounding.

This change returns metadata read, decode, and conversion errors to the caller and validates exact
rational boost ordering before conversion. It intentionally preserves valid signed offsets and
does not add trailing-byte restrictions, keeping versioned payload compatibility policy separate.

## Testing

- confirmed both retained regressions fail on current main and pass with this change
- full release suite: 1,079 passed; 224 expected editor tests skipped
- focused metadata and API tests under AddressSanitizer: 16/16 passed

Addresses the numeric-validation portion of #446; version-aware trailing-byte and payload-size
policy is intentionally left for separate follow-up.
