### PR TITLE
Return null for unavailable compressed probe images

### DIFF
--- a/lib/src/ultrahdr_api.cpp
+++ b/lib/src/ultrahdr_api.cpp
@@ -1882,7 +1882,8 @@ uhdr_mem_block_t* uhdr_dec_get_base_image(uhdr_codec_private_t* dec) {
   }
 
   uhdr_decoder_private* handle = dynamic_cast<uhdr_decoder_private*>(dec);
-  if (!handle->m_probed || handle->m_probe_call_status.error_code != UHDR_CODEC_OK) {
+  if (!handle->m_probed || handle->m_probe_call_status.error_code != UHDR_CODEC_OK ||
+      handle->m_base_img_block.data == nullptr || handle->m_base_img_block.data_sz == 0) {
     return nullptr;
   }
 
@@ -1895,7 +1896,8 @@ uhdr_mem_block_t* uhdr_dec_get_gainmap_image(uhdr_codec_private_t* dec) {
   }
 
   uhdr_decoder_private* handle = dynamic_cast<uhdr_decoder_private*>(dec);
-  if (!handle->m_probed || handle->m_probe_call_status.error_code != UHDR_CODEC_OK) {
+  if (!handle->m_probed || handle->m_probe_call_status.error_code != UHDR_CODEC_OK ||
+      handle->m_gainmap_img_block.data == nullptr || handle->m_gainmap_img_block.data_sz == 0) {
     return nullptr;
   }
 

--- a/tests/ultrahdr_api_test.cpp
+++ b/tests/ultrahdr_api_test.cpp
@@ -126,6 +126,14 @@ TEST_F(UltraHdrApiTest, JpegEncodeApi0AndDecode) {
   EXPECT_EQ(uhdr_dec_probe(dec).error_code, UHDR_CODEC_OK);
   EXPECT_EQ(uhdr_dec_get_image_width(dec), static_cast<int>(kImageWidth));
   EXPECT_EQ(uhdr_dec_get_image_height(dec), static_cast<int>(kImageHeight));
+  uhdr_mem_block_t* base_image = uhdr_dec_get_base_image(dec);
+  ASSERT_NE(base_image, nullptr);
+  EXPECT_NE(base_image->data, nullptr);
+  EXPECT_GT(base_image->data_sz, 0u);
+  uhdr_mem_block_t* gainmap_image = uhdr_dec_get_gainmap_image(dec);
+  ASSERT_NE(gainmap_image, nullptr);
+  EXPECT_NE(gainmap_image->data, nullptr);
+  EXPECT_GT(gainmap_image->data_sz, 0u);
 
   ASSERT_EQ(uhdr_decode(dec).error_code, UHDR_CODEC_OK);
   uhdr_raw_image_t* decoded = uhdr_get_decoded_image(dec);
@@ -222,6 +230,8 @@ TEST_F(UltraHdrApiTest, HeicEncodeApi0AndDecode) {
   EXPECT_EQ(uhdr_dec_probe(dec).error_code, UHDR_CODEC_OK);
   EXPECT_EQ(uhdr_dec_get_image_width(dec), static_cast<int>(kImageWidth));
   EXPECT_EQ(uhdr_dec_get_image_height(dec), static_cast<int>(kImageHeight));
+  EXPECT_EQ(uhdr_dec_get_base_image(dec), nullptr);
+  EXPECT_EQ(uhdr_dec_get_gainmap_image(dec), nullptr);
 
   uhdr_gainmap_metadata_t* metadata = uhdr_dec_get_gainmap_metadata(dec);
   EXPECT_NE(metadata, nullptr);
@@ -327,6 +337,8 @@ TEST_F(UltraHdrApiTest, AvifEncodeApi0AndDecode) {
   EXPECT_EQ(uhdr_dec_probe(dec).error_code, UHDR_CODEC_OK);
   EXPECT_EQ(uhdr_dec_get_image_width(dec), static_cast<int>(kImageWidth));
   EXPECT_EQ(uhdr_dec_get_image_height(dec), static_cast<int>(kImageHeight));
+  EXPECT_EQ(uhdr_dec_get_base_image(dec), nullptr);
+  EXPECT_EQ(uhdr_dec_get_gainmap_image(dec), nullptr);
 
   uhdr_error_info_t dec_status = uhdr_decode(dec);
   if (dec_status.error_code != UHDR_CODEC_OK) {


### PR DESCRIPTION
# Return null for unavailable compressed probe images

## Summary

- return `nullptr` from the compressed base and gain-map getters when probing did not provide a payload
- preserve existing JPEG behavior when compressed item data is available
- add public-API coverage for JPEG, HEIF, and AVIF

## Why

`uhdr_dec_get_base_image()` and `uhdr_dec_get_gainmap_image()` document that they return `nullptr` when compressed image data is unavailable. HEIF/AVIF probing currently does not populate those compressed payloads, but the getters return a non-null descriptor with `data == nullptr` and `data_sz == 0`.

Callers following the documented pointer contract can therefore mistake an unavailable payload for valid compressed data and pass a null data pointer downstream.

This change returns `nullptr` unless a non-empty compressed payload is present. JPEG probing behavior is unchanged.

## Testing

- verified JPEG probing still returns non-empty compressed base and gain-map payloads
- verified HEIF and AVIF probes return `nullptr` for unavailable compressed payloads
- complete unit suite passes
