### PR TITLE
Signal sRGB correctly in HEIF and AVIF NCLX profiles

### DIFF
--- a/lib/src/avifultrahdr.cpp
+++ b/lib/src/avifultrahdr.cpp
@@ -132,7 +132,7 @@ static const std::map<uhdr_color_transfer_t, heif_transfer_characteristics> map_
     {UHDR_CT_LINEAR, heif_transfer_characteristic_linear},
     {UHDR_CT_PQ, heif_transfer_characteristic_ITU_R_BT_2100_0_PQ},
     {UHDR_CT_HLG, heif_transfer_characteristic_ITU_R_BT_2100_0_HLG},
-    {UHDR_CT_SRGB, heif_transfer_characteristic_ITU_R_BT_709_5},
+    {UHDR_CT_SRGB, heif_transfer_characteristic_IEC_61966_2_1},
     {UHDR_CT_UNSPECIFIED, heif_transfer_characteristic_unspecified},
 };
 
@@ -153,6 +153,8 @@ static uhdr_color_gamut_t map_primaries_inverse(heif_color_primaries primaries) 
 }
 
 static uhdr_color_transfer_t map_transfer_inverse(heif_transfer_characteristics transfer) {
+  // Accept files written by older libultrahdr versions, which signaled sRGB as BT.709.
+  if (transfer == heif_transfer_characteristic_ITU_R_BT_709_5) return UHDR_CT_SRGB;
   for (const auto& [key, value] : map_transfer) {
     if (value == transfer) return key;
   }

--- a/lib/src/heifultrahdr.cpp
+++ b/lib/src/heifultrahdr.cpp
@@ -132,7 +132,7 @@ static const std::map<uhdr_color_transfer_t, heif_transfer_characteristics> map_
     {UHDR_CT_LINEAR, heif_transfer_characteristic_linear},
     {UHDR_CT_PQ, heif_transfer_characteristic_ITU_R_BT_2100_0_PQ},
     {UHDR_CT_HLG, heif_transfer_characteristic_ITU_R_BT_2100_0_HLG},
-    {UHDR_CT_SRGB, heif_transfer_characteristic_ITU_R_BT_709_5},
+    {UHDR_CT_SRGB, heif_transfer_characteristic_IEC_61966_2_1},
     {UHDR_CT_UNSPECIFIED, heif_transfer_characteristic_unspecified},
 };
 
@@ -153,6 +153,8 @@ static uhdr_color_gamut_t map_primaries_inverse(heif_color_primaries primaries) 
 }
 
 static uhdr_color_transfer_t map_transfer_inverse(heif_transfer_characteristics transfer) {
+  // Accept files written by older libultrahdr versions, which signaled sRGB as BT.709.
+  if (transfer == heif_transfer_characteristic_ITU_R_BT_709_5) return UHDR_CT_SRGB;
   for (const auto& [key, value] : map_transfer) {
     if (value == transfer) return key;
   }

--- a/tests/ultrahdr_api_test.cpp
+++ b/tests/ultrahdr_api_test.cpp
@@ -122,6 +122,44 @@ class UltraHdrApiTest : public ::testing::Test {
   uhdr_compressed_image_t mSdrCompressed{};
 };
 
+#if defined(UHDR_ENABLE_HEIF)
+static heif_transfer_characteristics getPrimaryImageTransfer(
+    const uhdr_compressed_image_t* image) {
+  heif_transfer_characteristics transfer = heif_transfer_characteristic_unspecified;
+  heif_context* context = heif_context_alloc();
+  if (context == nullptr) {
+    ADD_FAILURE() << "failed to allocate libheif context";
+    return transfer;
+  }
+
+  heif_image_handle* primary_handle = nullptr;
+  heif_color_profile_nclx* nclx = nullptr;
+  heif_error error =
+      heif_context_read_from_memory_without_copy(context, image->data, image->data_sz, nullptr);
+  if (error.code != heif_error_Ok) {
+    ADD_FAILURE() << "failed to parse encoded image";
+    goto CleanUp;
+  }
+  error = heif_context_get_primary_image_handle(context, &primary_handle);
+  if (error.code != heif_error_Ok) {
+    ADD_FAILURE() << "failed to get primary image";
+    goto CleanUp;
+  }
+  error = heif_image_handle_get_nclx_color_profile(primary_handle, &nclx);
+  if (error.code != heif_error_Ok) {
+    ADD_FAILURE() << "failed to get primary image nclx profile";
+    goto CleanUp;
+  }
+  transfer = nclx->transfer_characteristics;
+
+CleanUp:
+  if (nclx != nullptr) heif_nclx_color_profile_free(nclx);
+  if (primary_handle != nullptr) heif_image_handle_release(primary_handle);
+  heif_context_free(context);
+  return transfer;
+}
+#endif
+
 TEST_F(UltraHdrApiTest, InvalidCompressedImageIntentDoesNotMutateEncoder) {
   uhdr_codec_private_t* enc = uhdr_create_encoder();
   ASSERT_NE(enc, nullptr);
@@ -331,6 +369,7 @@ TEST_F(UltraHdrApiTest, HeicEncodeApi1AndDecode) {
   uhdr_compressed_image_t* output = uhdr_get_encoded_stream(enc);
   ASSERT_NE(output, nullptr);
   ASSERT_GT(output->data_sz, 0u);
+  EXPECT_EQ(getPrimaryImageTransfer(output), heif_transfer_characteristic_IEC_61966_2_1);
 
   uhdr_codec_private_t* dec = uhdr_create_decoder();
   ASSERT_NE(dec, nullptr);
@@ -465,6 +504,7 @@ TEST_F(UltraHdrApiTest, AvifEncodeApi1AndDecode) {
   uhdr_compressed_image_t* output = uhdr_get_encoded_stream(enc);
   ASSERT_NE(output, nullptr);
   ASSERT_GT(output->data_sz, 0u);
+  EXPECT_EQ(getPrimaryImageTransfer(output), heif_transfer_characteristic_IEC_61966_2_1);
 
   uhdr_codec_private_t* dec = uhdr_create_decoder();
   ASSERT_NE(dec, nullptr);


### PR DESCRIPTION
# Signal sRGB correctly in HEIF and AVIF NCLX profiles

## Summary

- signal IEC 61966-2-1 for sRGB primary images in HEIF and AVIF output
- continue interpreting the BT.709 transfer value written by older libultrahdr versions as sRGB
- verify the serialized primary-image NCLX profile for both codecs

## Why

The HEIF/AVIF encoding APIs require the SDR intent to use `UHDR_CT_SRGB`, but the output NCLX profile currently identifies that transfer as BT.709. This conflicts with the sRGB pixel encoding and the sRGB ICC profile written by the same path.

Viewers that honor NCLX may therefore select the BT.709 inverse transfer function for sRGB values, producing incorrect linear-light values that are most noticeable in shadows. The encoded pixels are unchanged by this fix; only their transfer-characteristic signaling is corrected.

The decoder retains BT.709 as a legacy alias for sRGB so files written by existing libultrahdr releases remain compatible.

## Testing

- generated API-1 HEIF and AVIF images and inspected the serialized primary-image NCLX profiles
- confirmed both tests report BT.709 before the fix and IEC 61966-2-1 afterward
- complete unit suite passes
