### PR TITLE
gainmapmath: restore odd-dimension OOB read fixes reverted by #413

### DIFF
--- a/lib/src/gainmapmath.cpp
+++ b/lib/src/gainmapmath.cpp
@@ -429,7 +429,11 @@ Color getP010Pixel(uhdr_raw_image_t* image, size_t x, size_t y) {
   size_t chroma_stride = image->stride[UHDR_PLANE_UV];
 
   size_t pixel_y_idx = y * luma_stride + x;
-  size_t pixel_u_idx = (y >> 1) * chroma_stride + (x & ~0x1);
+  size_t chroma_x = x & ~(size_t)0x1;
+  if (chroma_x + 1 >= image->w) {
+    chroma_x = (image->w >= 2) ? ((image->w - 2) & ~(size_t)0x1) : 0;
+  }
+  size_t pixel_u_idx = (y >> 1) * chroma_stride + chroma_x;
   size_t pixel_v_idx = pixel_u_idx + 1;
 
   uint16_t y_uint = luma_data[pixel_y_idx] >> 6;
@@ -1317,8 +1321,8 @@ std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr(uhdr_raw_image_
     uint16_t* uData = static_cast<uint16_t*>(dst->planes[UHDR_PLANE_UV]);
     uint16_t* vData = uData + 1;
 
-    for (size_t i = 0; i < dst->h; i += 2) {
-      for (size_t j = 0; j < dst->w; j += 2) {
+    for (size_t i = 0; i + 1 < dst->h; i += 2) {
+      for (size_t j = 0; j + 1 < dst->w; j += 2) {
         Color pixel[4];
 
         pixel[0].r = float(rgbData[srcStride * i + j] & 0x3ff);
@@ -1410,8 +1414,8 @@ std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr(uhdr_raw_image_
     uint8_t* yData = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_Y]);
     uint8_t* uData = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_U]);
     uint8_t* vData = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_V]);
-    for (size_t i = 0; i < dst->h; i += 2) {
-      for (size_t j = 0; j < dst->w; j += 2) {
+    for (size_t i = 0; i + 1 < dst->h; i += 2) {
+      for (size_t j = 0; j + 1 < dst->w; j += 2) {
         Color pixel[4];
 
         pixel[0] = getPixel(src, j, i);


### PR DESCRIPTION
Restores the defect fix from #391, originally submitted by @jortles in #392 and landed by @DichenZhang1 as #407 (`586ed42`).

#413's `07bc6a2` was branched before #407 and reverted all three hunks when it merged nine days later, so v2.0.0, v2.0.1, v2.0.2 and current `main` all ship the pre-fix code:

- **`lib/src/gainmapmath.cpp:432`** — `getP010Pixel`'s chroma index is back to `(x & ~0x1)` with no clamp, so `pixel_v_idx = pixel_u_idx + 1` reads one element past the chroma plane on the last column of an odd-width P010 image.
- **`lib/src/gainmapmath.cpp:1320` and `:1413`** — `convert_raw_input_to_ycbcr`'s 2×2 block loops are back to `i < dst->h` / `j < dst->w`, reading row `i + 1` / column `j + 1` past the edge on odd dimensions. Both the RGBA1010102 and RGBA8888 paths.

`git diff 586ed42 07bc6a2 -- lib/src/gainmapmath.cpp` shows the three hunks being undone. The revert looks incidental rather than deliberate — the HEIF/AVIF staging branch predated #407 and carried the older copy of the file forward over it.

#407's test `GetP010PixelOddWidth` was *not* reverted and is still in `tests/gainmapmath_test.cpp`, but it asserts `EXPECT_NO_FATAL_FAILURE`, which a short read past a heap allocation does not trip outside a sanitizer build. The test and the code it guards were reverted independently, leaving a green guard over absent code.

This is a cherry-pick of `586ed42` onto current `main`, preserving its original authorship. The test hunk is already present, so only `lib/src/gainmapmath.cpp` changes (+9 / −5).

One caveat carried over from #407: the loop-bound half skips the trailing incomplete block rather than clamping, so the final row and column of an odd-dimension image are left value-initialized — black with fully saturated chroma — instead of read out of bounds. Clamping the source index the way `getP010Pixel` now does would fix the values too, but I have kept this to exactly what #407 did so it reads as a pure restoration. Happy to follow up.

Verified to build clean on MSVC 2022 x64 Release; I have not run it under ASan.