### PR TITLE
Decode ISO gain-map integers without signed intermediates

### DIFF
--- a/lib/src/gainmapmetadata.cpp
+++ b/lib/src/gainmapmetadata.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 
 #include "ultrahdr/gainmapmath.h"
 #include "ultrahdr/gainmapmetadata.h"
@@ -77,23 +78,16 @@ uhdr_error_info_t streamReadU32(const std::vector<uint8_t> &data, uint32_t &valu
              (int)data.size());
     return status;
   }
-  value = (data[pos] << 24 | data[pos + 1] << 16 | data[pos + 2] << 8 | data[pos + 3]);
+  value = (static_cast<uint32_t>(data[pos]) << 24 | static_cast<uint32_t>(data[pos + 1]) << 16 |
+           static_cast<uint32_t>(data[pos + 2]) << 8 | static_cast<uint32_t>(data[pos + 3]));
   pos += 4;
   return g_no_error;
 }
 
 uhdr_error_info_t streamReadS32(const std::vector<uint8_t> &data, int32_t &value, size_t &pos) {
-  if (pos > data.size() || data.size() - pos < 4) {
-    uhdr_error_info_t status;
-    status.error_code = UHDR_CODEC_MEM_ERROR;
-    status.has_detail = 1;
-    snprintf(status.detail, sizeof status.detail,
-             "attempting to read 4 bytes from position %d when the buffer size is %d", (int)pos,
-             (int)data.size());
-    return status;
-  }
-  value = (data[pos] << 24 | data[pos + 1] << 16 | data[pos + 2] << 8 | data[pos + 3]);
-  pos += 4;
+  uint32_t unsigned_value;
+  UHDR_ERR_CHECK(streamReadU32(data, unsigned_value, pos))
+  memcpy(&value, &unsigned_value, sizeof(value));
   return g_no_error;
 }
 

--- a/tests/gainmapmetadata_test.cpp
+++ b/tests/gainmapmetadata_test.cpp
@@ -9,6 +9,8 @@
  */
 
 #include <gtest/gtest.h>
+#include <cstdint>
+#include <limits>
 #include <vector>
 
 #include "ultrahdr/gainmapmetadata.h"
@@ -34,6 +36,22 @@ void GainMapMetadataTest::SetUp() {}
 void GainMapMetadataTest::TearDown() {}
 
 const std::string kIso = "urn:iso:std:iso:ts:21496:-1";
+
+namespace {
+
+void appendU16(std::vector<uint8_t>& data, uint16_t value) {
+  data.push_back((value >> 8) & 0xff);
+  data.push_back(value & 0xff);
+}
+
+void appendU32(std::vector<uint8_t>& data, uint32_t value) {
+  data.push_back((value >> 24) & 0xff);
+  data.push_back((value >> 16) & 0xff);
+  data.push_back((value >> 8) & 0xff);
+  data.push_back(value & 0xff);
+}
+
+}  // namespace
 
 TEST_F(GainMapMetadataTest, encodeMetadataThenDecode) {
   uhdr_gainmap_metadata_ext_t expected("1.0");
@@ -145,6 +163,30 @@ TEST(GainmapMetadataTest, RejectsMalformedISO21496_1Ratios) {
   frac.baseHdrHeadroomN = 1;      // log2(headroom_min) = 1 -> 2.0
   EXPECT_EQ(uhdr_gainmap_metadata_frac::gainmapMetadataFractionToFloat(&frac, &float_meta).error_code,
             UHDR_CODEC_INVALID_PARAM);
+}
+
+TEST_F(GainMapMetadataTest, decodeHandlesHighBitIntegerFields) {
+  std::vector<uint8_t> data;
+  appendU16(data, 0);                          // minimum version
+  appendU16(data, 0);                          // writer version
+  data.push_back(kUseBaseColorSpaceMask | 8);  // single channel, common denominator
+  appendU32(data, 1);                          // common denominator
+  appendU32(data, 0);                          // base HDR headroom numerator
+  appendU32(data, 1);                          // alternate HDR headroom numerator
+  appendU32(data, 0x80000000u);                // gainMapMin numerator
+  appendU32(data, 0xffffffffu);                // gainMapMax numerator
+  appendU32(data, 0x80000000u);                // gainMapGamma numerator
+  appendU32(data, 0xffffffffu);                // baseOffset numerator
+  appendU32(data, 0x80000000u);                // alternateOffset numerator
+
+  uhdr_gainmap_metadata_frac decoded_metadata;
+  ASSERT_EQ(uhdr_gainmap_metadata_frac::decodeGainmapMetadata(data, &decoded_metadata).error_code,
+            UHDR_CODEC_OK);
+  EXPECT_EQ(decoded_metadata.gainMapMinN[0], std::numeric_limits<int32_t>::min());
+  EXPECT_EQ(decoded_metadata.gainMapMaxN[0], -1);
+  EXPECT_EQ(decoded_metadata.gainMapGammaN[0], 0x80000000u);
+  EXPECT_EQ(decoded_metadata.baseOffsetN[0], -1);
+  EXPECT_EQ(decoded_metadata.alternateOffsetN[0], std::numeric_limits<int32_t>::min());
 }
 
 }  // namespace ultrahdr


### PR DESCRIPTION
# Decode ISO gain-map integers without signed intermediates

## Summary

- assemble 32-bit ISO metadata fields with explicit unsigned operations
- preserve the encoded bit pattern when reading signed fields
- cover signed and unsigned values with the high bit set

## Why

`streamReadU32()` currently assembles four bytes using signed `int` intermediates and then converts the result to the destination type. High-bit values consequently produce signed-conversion diagnostics even though the encoded field is unsigned.

This change performs the byte assembly as `uint32_t` and reuses that path for signed fields, copying the encoded bit pattern into `int32_t`. It makes the intended big-endian interpretation explicit and avoids signed conversion in the parser without changing the metadata format or public API.

## Testing

- added a focused ISO metadata decode test covering `INT32_MIN`, `-1`, and an unsigned value with the high bit set
- complete unit suite passes with UBSan and warnings treated as errors
