### PR TITLE
gainmap: validate destination layout before applying gain map

### DIFF
--- a/lib/include/ultrahdr/ultrahdrcommon.h
+++ b/lib/include/ultrahdr/ultrahdrcommon.h
@@ -515,6 +515,9 @@ class UltraHdr {
    * same color gamut as sdr intent.
    *
    * NOTE: The SDR input is assumed to use the sRGB transfer function.
+   * NOTE: `dest->w` and `dest->h` must equal `sdr_intent->w` and `sdr_intent->h`. Row padding is
+   * supported by setting the destination packed stride to a value greater than or equal to
+   * `dest->w`.
    *
    * \param[in]       sdr_intent               sdr intent raw input image descriptor
    * \param[in]       gainmap_img              gainmap image descriptor

--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -1543,13 +1543,22 @@ uhdr_error_info_t UltraHdr::applyGainMap(uhdr_raw_image_t* sdr_intent, uhdr_raw_
              "apply gainmap method received nullptr for destination image or plane pointer");
     return status;
   }
-  if (dest->stride[UHDR_PLANE_PACKED] < dest->w) {
+  if (dest->w != sdr_intent->w || dest->h != sdr_intent->h) {
     uhdr_error_info_t status;
     status.error_code = UHDR_CODEC_INVALID_PARAM;
     status.has_detail = 1;
     snprintf(status.detail, sizeof status.detail,
-             "destination stride (%u) cannot be less than image width (%u)",
-             dest->stride[UHDR_PLANE_PACKED], dest->w);
+             "destination image dimensions %ux%u do not match output dimensions %ux%u", dest->w,
+             dest->h, sdr_intent->w, sdr_intent->h);
+    return status;
+  }
+  if (dest->stride[UHDR_PLANE_PACKED] < sdr_intent->w) {
+    uhdr_error_info_t status;
+    status.error_code = UHDR_CODEC_INVALID_PARAM;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail,
+             "destination stride (%u) cannot be less than output width (%u)",
+             dest->stride[UHDR_PLANE_PACKED], sdr_intent->w);
     return status;
   }
   if (output_ct != UHDR_CT_LINEAR && output_ct != UHDR_CT_HLG && output_ct != UHDR_CT_PQ) {

--- a/tests/jpegr_test.cpp
+++ b/tests/jpegr_test.cpp
@@ -1454,7 +1454,7 @@ TEST(JpegRTest, ApplyGainMapInvalidArgs) {
   dest.w = 16;
   dest.h = 16;
   dest.stride[0] = 16;
-  std::vector<uint8_t> dest_buf(16 * 16 * 8);
+  std::vector<uint8_t> dest_buf(32 * 16 * 8);
   dest.planes[0] = dest_buf.data();
 
   // Test nullptr dest or plane pointer
@@ -1467,6 +1467,40 @@ TEST(JpegRTest, ApplyGainMapInvalidArgs) {
   // Test stride < width
   dest.stride[0] = 8;
   EXPECT_EQ(uHdrLib.applyGainMap(&sdr_intent, &gainmap_img, &metadata, UHDR_CT_LINEAR, dest.fmt, 2.0f, &dest).error_code, UHDR_CODEC_INVALID_PARAM);
+  dest.stride[0] = 16;
+
+  // Test destination dimensions that do not match the output dimensions
+  dest.w = 8;
+  EXPECT_EQ(
+      uHdrLib
+          .applyGainMap(&sdr_intent, &gainmap_img, &metadata, UHDR_CT_LINEAR, dest.fmt, 2.0f, &dest)
+          .error_code,
+      UHDR_CODEC_INVALID_PARAM);
+  dest.w = 16;
+
+  dest.h = 8;
+  EXPECT_EQ(
+      uHdrLib
+          .applyGainMap(&sdr_intent, &gainmap_img, &metadata, UHDR_CT_LINEAR, dest.fmt, 2.0f, &dest)
+          .error_code,
+      UHDR_CODEC_INVALID_PARAM);
+  dest.h = 16;
+
+  dest.w = 32;
+  dest.stride[0] = 32;
+  EXPECT_EQ(
+      uHdrLib
+          .applyGainMap(&sdr_intent, &gainmap_img, &metadata, UHDR_CT_LINEAR, dest.fmt, 2.0f, &dest)
+          .error_code,
+      UHDR_CODEC_INVALID_PARAM);
+  dest.w = 16;
+
+  // Test valid row padding
+  EXPECT_EQ(
+      uHdrLib
+          .applyGainMap(&sdr_intent, &gainmap_img, &metadata, UHDR_CT_LINEAR, dest.fmt, 2.0f, &dest)
+          .error_code,
+      UHDR_CODEC_OK);
   dest.stride[0] = 16;
 
   // Test invalid output_ct


### PR DESCRIPTION
### Summary

- Require the destination width and height passed to `applyGainMap()` to match the SDR input/output dimensions.
- Validate the packed destination stride against the width actually processed by the write loop.
- Document the destination layout contract and add regression coverage for mismatched dimensions, insufficient stride, and valid row padding.

### Why

`applyGainMap()` processes `sdr_intent->w` by `sdr_intent->h` pixels, but the existing validation only checks whether the packed stride is at least `dest->w`. A destination descriptor with smaller logical dimensions can therefore pass validation even though processing and raw-pointer writes continue over the full SDR extent.

Related: #367. This PR addresses the same destination-buffer validation issue by rejecting inconsistent destination dimensions and stride before CPU or GLES dispatch. Raw plane writes do not throw `std::out_of_range`, so validation is performed at the descriptor boundary.

### Compatibility

The destination's logical dimensions must describe the generated output, so `dest->w` and `dest->h` must equal `sdr_intent->w` and `sdr_intent->h`. Callers may still use row padding by setting the packed destination stride greater than or equal to the output width.

The descriptor does not expose allocation capacity, so callers remain responsible for providing storage large enough for the declared stride and height.

### Testing

- `JpegRTest.ApplyGainMapInvalidArgs`
- Complete default unit-test suite
- Complete AddressSanitizer unit-test suite
- Complete AVIF-enabled unit-test suite
- `UltraHdrApiTest.Avif*` (3 tests)
- `git diff --check upstream/main...HEAD`

All checks pass.