### PR TITLE
cmake: prefer selected libheif headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -731,6 +731,12 @@ if(UHDR_ENABLE_HEIF)
   endif()
   if(LIBHEIF_FOUND)
     message(STATUS "Found libheif: ${LIBHEIF_LIBRARIES}")
+    get_target_property(LIBHEIF_INCLUDE_DIRS libheif::heif INTERFACE_INCLUDE_DIRECTORIES)
+    if(LIBHEIF_INCLUDE_DIRS)
+      # Prepending fixes ordering, but does not remove imported-target system
+      # classification.
+      list(PREPEND PRIVATE_INCLUDE_DIR ${LIBHEIF_INCLUDE_DIRS})
+    endif()
     add_compile_options(-DUHDR_ENABLE_HEIF)
     list(APPEND PRIVATE_LINK_LIBS libheif::heif)
   else()
@@ -752,6 +758,9 @@ target_include_directories(${IMAGEIO_TARGET_NAME} PRIVATE
 set(UHDR_CORE_LIB_NAME core)
 add_library(${UHDR_CORE_LIB_NAME} STATIC ${UHDR_CORE_SRCS_LIST})
 target_compile_options(${UHDR_CORE_LIB_NAME} PRIVATE ${UHDR_WERROR_FLAGS})
+if(UHDR_ENABLE_HEIF AND LIBHEIF_FOUND)
+  set_target_properties(${UHDR_CORE_LIB_NAME} PROPERTIES NO_SYSTEM_FROM_IMPORTED TRUE)
+endif()
 if(NOT JPEG_FOUND)
   add_dependencies(${UHDR_CORE_LIB_NAME} ${JPEGTURBO_TARGET_NAME})
 endif()
@@ -820,6 +829,9 @@ if(UHDR_BUILD_TESTS)
     add_dependencies(ultrahdr_unit_test ${LIBHEIF_TARGET_NAME})
   endif()
   target_compile_options(ultrahdr_unit_test PRIVATE ${UHDR_WERROR_FLAGS})
+  if(UHDR_ENABLE_HEIF AND LIBHEIF_FOUND)
+    set_target_properties(ultrahdr_unit_test PROPERTIES NO_SYSTEM_FROM_IMPORTED TRUE)
+  endif()
   target_include_directories(ultrahdr_unit_test PRIVATE
     ${PRIVATE_INCLUDE_DIR}
     ${GTEST_INCLUDE_DIRS}


### PR DESCRIPTION
It is possible for CMake to select one libheif library while the compiler finds another installation's `libheif/heif.h` first. This can happen when another dependency exposes a broad include directory containing libheif headers. The resulting header/library mismatch causes confusing, environment-dependent build failures.

This change:
- prepends the available include directories exported by `libheif::heif` to   libultrahdr's private include search path;
- treats imported dependency includes as normal include directories for the core   and unit-test targets, preserving the selected dependency's header priority.

There is no runtime behavior change and no new dependency.

## Validation
- Reproduced the failure with a matching 9-argument libheif library and a   conflicting 10-argument `heif.h` earlier in a broad include directory.
- Confirmed the fixed compile commands select the matching libheif include   directory first.
- Built the core with warnings treated as errors using an external libheif   package.
- Built and ran the unit tests: `ctest --output-on-failure` passed.
- Built the no-HEIF configuration with warnings treated as errors.
- Built the bundled-dependency configuration on Ubuntu 24.04 with GCC 13.3 and   warnings treated as errors; the build and CTest suite passed.