### PR TITLE
gainmap: preserve trailing edges in odd-sized 4:2:0 conversion

### DIFF
--- a/lib/src/avifultrahdr.cpp
+++ b/lib/src/avifultrahdr.cpp
@@ -173,8 +173,8 @@ static heif_error map_fmt_to_heif_chroma_vars(uhdr_img_fmt_t fmt, unsigned int w
                                               int& chromaHt) {
   if (fmt == UHDR_IMG_FMT_12bppYCbCr420) {
     heif_img_fmt = heif_chroma_420;
-    chromaWd = w / 2;
-    chromaHt = h / 2;
+    chromaWd = w / 2 + w % 2;
+    chromaHt = h / 2 + h % 2;
   } else if (fmt == UHDR_IMG_FMT_16bppYCbCr422) {
     heif_img_fmt = heif_chroma_422;
     chromaWd = w;
@@ -466,7 +466,7 @@ uhdr_error_info_t AvifUltraHdr::encodeAvifUltraHdr(uhdr_raw_image_t* sdr_intent,
 
   // encode the gain map image
   if (isUsingMultiChannelGainMap()) {
-    gainmap_yuv_ext = convert_raw_input_to_ycbcr(gainmap_img, true /* use bt601 */);
+    gainmap_yuv_ext = convert_raw_input_to_ycbcr(gainmap_img, true /* chroma sampling enabled */);
     gainmap_img_yuv = gainmap_yuv_ext.get();
   }
   if (isUsingMultiChannelGainMap()) {

--- a/lib/src/gainmapmath.cpp
+++ b/lib/src/gainmapmath.cpp
@@ -429,16 +429,23 @@ Color getP010Pixel(uhdr_raw_image_t* image, size_t x, size_t y) {
   size_t chroma_stride = image->stride[UHDR_PLANE_UV];
 
   size_t pixel_y_idx = y * luma_stride + x;
-  size_t chroma_x = x & ~(size_t)0x1;
-  if (chroma_x + 1 >= image->w) {
-    chroma_x = (image->w >= 2) ? ((image->w - 2) & ~(size_t)0x1) : 0;
-  }
+  // P010 stores complete interleaved UV pairs. The logical row width is ceil(w / 2)
+  // pairs, but a caller-provided stride can be tighter than that capacity.
+  const size_t logical_chroma_samples = 2 * (static_cast<size_t>(image->w) / 2 + image->w % 2);
+  const size_t available_chroma_samples = (std::min)(logical_chroma_samples, chroma_stride);
+  const size_t max_chroma_x =
+      available_chroma_samples >= 2 ? (available_chroma_samples - 2) & ~(size_t)0x1 : 0;
+  const size_t chroma_x = (std::min)(x & ~(size_t)0x1, max_chroma_x);
   size_t pixel_u_idx = (y >> 1) * chroma_stride + chroma_x;
   size_t pixel_v_idx = pixel_u_idx + 1;
 
   uint16_t y_uint = luma_data[pixel_y_idx] >> 6;
-  uint16_t u_uint = chroma_data[pixel_u_idx] >> 6;
-  uint16_t v_uint = chroma_data[pixel_v_idx] >> 6;
+  uint16_t u_uint = 512;
+  uint16_t v_uint = 512;
+  if (available_chroma_samples >= 2) {
+    u_uint = chroma_data[pixel_u_idx] >> 6;
+    v_uint = chroma_data[pixel_v_idx] >> 6;
+  }
 
   if (image->range == UHDR_CR_FULL_RANGE) {
     return {{{static_cast<float>(y_uint) / 1023.0f, static_cast<float>(u_uint) / 1023.0f - 0.5f,
@@ -1248,6 +1255,13 @@ PutPixelFn putPixelFn(uhdr_img_fmt_t format) {
   return nullptr;
 }
 
+static Color getPixelClamped(uhdr_raw_image_t* image, GetPixelFn get_pixel, size_t x, size_t y) {
+  // 4:2:0 processes complete 2x2 blocks; replicate the edge pixel for a partial block.
+  x = (std::min)(x, static_cast<size_t>(image->w - 1));
+  y = (std::min)(y, static_cast<size_t>(image->h - 1));
+  return get_pixel(image, x, y);
+}
+
 SamplePixelFn getSamplePixelFn(uhdr_img_fmt_t format) {
   switch (format) {
     case UHDR_IMG_FMT_24bppYCbCr444:
@@ -1321,25 +1335,27 @@ std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr(uhdr_raw_image_
     uint16_t* uData = static_cast<uint16_t*>(dst->planes[UHDR_PLANE_UV]);
     uint16_t* vData = uData + 1;
 
-    for (size_t i = 0; i + 1 < dst->h; i += 2) {
-      for (size_t j = 0; j + 1 < dst->w; j += 2) {
+    for (size_t i = 0; i < dst->h; i += 2) {
+      for (size_t j = 0; j < dst->w; j += 2) {
+        const size_t next_i = i + 1 < src->h ? i + 1 : i;
+        const size_t next_j = j + 1 < src->w ? j + 1 : j;
         Color pixel[4];
 
         pixel[0].r = float(rgbData[srcStride * i + j] & 0x3ff);
         pixel[0].g = float((rgbData[srcStride * i + j] >> 10) & 0x3ff);
         pixel[0].b = float((rgbData[srcStride * i + j] >> 20) & 0x3ff);
 
-        pixel[1].r = float(rgbData[srcStride * i + j + 1] & 0x3ff);
-        pixel[1].g = float((rgbData[srcStride * i + j + 1] >> 10) & 0x3ff);
-        pixel[1].b = float((rgbData[srcStride * i + j + 1] >> 20) & 0x3ff);
+        pixel[1].r = float(rgbData[srcStride * i + next_j] & 0x3ff);
+        pixel[1].g = float((rgbData[srcStride * i + next_j] >> 10) & 0x3ff);
+        pixel[1].b = float((rgbData[srcStride * i + next_j] >> 20) & 0x3ff);
 
-        pixel[2].r = float(rgbData[srcStride * (i + 1) + j] & 0x3ff);
-        pixel[2].g = float((rgbData[srcStride * (i + 1) + j] >> 10) & 0x3ff);
-        pixel[2].b = float((rgbData[srcStride * (i + 1) + j] >> 20) & 0x3ff);
+        pixel[2].r = float(rgbData[srcStride * next_i + j] & 0x3ff);
+        pixel[2].g = float((rgbData[srcStride * next_i + j] >> 10) & 0x3ff);
+        pixel[2].b = float((rgbData[srcStride * next_i + j] >> 20) & 0x3ff);
 
-        pixel[3].r = float(rgbData[srcStride * (i + 1) + j + 1] & 0x3ff);
-        pixel[3].g = float((rgbData[srcStride * (i + 1) + j + 1] >> 10) & 0x3ff);
-        pixel[3].b = float((rgbData[srcStride * (i + 1) + j + 1] >> 20) & 0x3ff);
+        pixel[3].r = float(rgbData[srcStride * next_i + next_j] & 0x3ff);
+        pixel[3].g = float((rgbData[srcStride * next_i + next_j] >> 10) & 0x3ff);
+        pixel[3].b = float((rgbData[srcStride * next_i + next_j] >> 20) & 0x3ff);
 
         for (int k = 0; k < 4; k++) {
           // Now we only support the RGB input being full range
@@ -1351,9 +1367,15 @@ std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr(uhdr_raw_image_
         }
 
         yData[dst->stride[UHDR_PLANE_Y] * i + j] = uint16_t(pixel[0].y) << 6;
-        yData[dst->stride[UHDR_PLANE_Y] * i + j + 1] = uint16_t(pixel[1].y) << 6;
-        yData[dst->stride[UHDR_PLANE_Y] * (i + 1) + j] = uint16_t(pixel[2].y) << 6;
-        yData[dst->stride[UHDR_PLANE_Y] * (i + 1) + j + 1] = uint16_t(pixel[3].y) << 6;
+        if (j + 1 < dst->w) {
+          yData[dst->stride[UHDR_PLANE_Y] * i + j + 1] = uint16_t(pixel[1].y) << 6;
+        }
+        if (i + 1 < dst->h) {
+          yData[dst->stride[UHDR_PLANE_Y] * (i + 1) + j] = uint16_t(pixel[2].y) << 6;
+          if (j + 1 < dst->w) {
+            yData[dst->stride[UHDR_PLANE_Y] * (i + 1) + j + 1] = uint16_t(pixel[3].y) << 6;
+          }
+        }
 
         pixel[0].u = (pixel[0].u + pixel[1].u + pixel[2].u + pixel[3].u) / 4;
         pixel[0].v = (pixel[0].v + pixel[1].v + pixel[2].v + pixel[3].v) / 4;
@@ -1414,14 +1436,14 @@ std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr(uhdr_raw_image_
     uint8_t* yData = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_Y]);
     uint8_t* uData = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_U]);
     uint8_t* vData = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_V]);
-    for (size_t i = 0; i + 1 < dst->h; i += 2) {
-      for (size_t j = 0; j + 1 < dst->w; j += 2) {
-        Color pixel[4];
-
-        pixel[0] = getPixel(src, j, i);
-        pixel[1] = getPixel(src, j + 1, i);
-        pixel[2] = getPixel(src, j, i + 1);
-        pixel[3] = getPixel(src, j + 1, i + 1);
+    for (size_t i = 0; i < dst->h; i += 2) {
+      for (size_t j = 0; j < dst->w; j += 2) {
+        Color pixel[4] = {
+            getPixelClamped(src, getPixel, j, i),
+            getPixelClamped(src, getPixel, j + 1, i),
+            getPixelClamped(src, getPixel, j, i + 1),
+            getPixelClamped(src, getPixel, j + 1, i + 1),
+        };
 
         for (int k = 0; k < 4; k++) {
           // Now we only support the RGB input being full range
@@ -1431,9 +1453,15 @@ std::unique_ptr<uhdr_raw_image_ext_t> convert_raw_input_to_ycbcr(uhdr_raw_image_
           pixel[k].y = CLIP3(pixel[k].y, 0.0f, 255.0f);
         }
         yData[dst->stride[UHDR_PLANE_Y] * i + j] = uint8_t(pixel[0].y);
-        yData[dst->stride[UHDR_PLANE_Y] * i + j + 1] = uint8_t(pixel[1].y);
-        yData[dst->stride[UHDR_PLANE_Y] * (i + 1) + j] = uint8_t(pixel[2].y);
-        yData[dst->stride[UHDR_PLANE_Y] * (i + 1) + j + 1] = uint8_t(pixel[3].y);
+        if (j + 1 < dst->w) {
+          yData[dst->stride[UHDR_PLANE_Y] * i + j + 1] = uint8_t(pixel[1].y);
+        }
+        if (i + 1 < dst->h) {
+          yData[dst->stride[UHDR_PLANE_Y] * (i + 1) + j] = uint8_t(pixel[2].y);
+          if (j + 1 < dst->w) {
+            yData[dst->stride[UHDR_PLANE_Y] * (i + 1) + j + 1] = uint8_t(pixel[3].y);
+          }
+        }
 
         pixel[0].u = (pixel[0].u + pixel[1].u + pixel[2].u + pixel[3].u) / 4;
         pixel[0].v = (pixel[0].v + pixel[1].v + pixel[2].v + pixel[3].v) / 4;
@@ -1508,9 +1536,27 @@ uhdr_error_info_t copy_raw_image(uhdr_raw_image_t* src, uhdr_raw_image_t* dst) {
   dst->cg = src->cg;
   dst->ct = src->ct;
   dst->range = src->range;
+  auto invalid_chroma_stride = [](const char* image, size_t stride, size_t required) {
+    uhdr_error_info_t status;
+    status.error_code = UHDR_CODEC_INVALID_PARAM;
+    status.has_detail = 1;
+    snprintf(status.detail, sizeof status.detail,
+             "%s chroma stride %zu is smaller than the required row width %zu", image, stride,
+             required);
+    return status;
+  };
   if (dst->fmt == src->fmt) {
     if (src->fmt == UHDR_IMG_FMT_24bppYCbCrP010) {
       size_t bpp = 2;
+      const size_t chroma_height = src->h / 2 + src->h % 2;
+      const size_t chroma_width = src->w / 2 + src->w % 2;
+      const size_t chroma_row_samples = 2 * chroma_width;
+      if (src->stride[UHDR_PLANE_UV] < chroma_row_samples) {
+        return invalid_chroma_stride("source", src->stride[UHDR_PLANE_UV], chroma_row_samples);
+      }
+      if (dst->stride[UHDR_PLANE_UV] < chroma_row_samples) {
+        return invalid_chroma_stride("destination", dst->stride[UHDR_PLANE_UV], chroma_row_samples);
+      }
       uint8_t* y_dst = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_Y]);
       uint8_t* y_src = static_cast<uint8_t*>(src->planes[UHDR_PLANE_Y]);
       uint8_t* uv_dst = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_UV]);
@@ -1523,13 +1569,25 @@ uhdr_error_info_t copy_raw_image(uhdr_raw_image_t* src, uhdr_raw_image_t* dst) {
         y_src += (src->stride[UHDR_PLANE_Y] * bpp);
       }
       // copy cbcr
-      for (size_t i = 0; i < src->h / 2; i++) {
-        memcpy(uv_dst, uv_src, src->w * bpp);
+      for (size_t i = 0; i < chroma_height; i++) {
+        memcpy(uv_dst, uv_src, chroma_row_samples * bpp);
         uv_dst += (dst->stride[UHDR_PLANE_UV] * bpp);
         uv_src += (src->stride[UHDR_PLANE_UV] * bpp);
       }
       return g_no_error;
     } else if (src->fmt == UHDR_IMG_FMT_12bppYCbCr420) {
+      const size_t chroma_height = src->h / 2 + src->h % 2;
+      const size_t chroma_width = src->w / 2 + src->w % 2;
+      if (src->stride[UHDR_PLANE_U] < chroma_width || src->stride[UHDR_PLANE_V] < chroma_width) {
+        return invalid_chroma_stride(
+            "source", (std::min)(src->stride[UHDR_PLANE_U], src->stride[UHDR_PLANE_V]),
+            chroma_width);
+      }
+      if (dst->stride[UHDR_PLANE_U] < chroma_width || dst->stride[UHDR_PLANE_V] < chroma_width) {
+        return invalid_chroma_stride(
+            "destination", (std::min)(dst->stride[UHDR_PLANE_U], dst->stride[UHDR_PLANE_V]),
+            chroma_width);
+      }
       uint8_t* y_dst = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_Y]);
       uint8_t* y_src = static_cast<uint8_t*>(src->planes[UHDR_PLANE_Y]);
       uint8_t* u_dst = static_cast<uint8_t*>(dst->planes[UHDR_PLANE_U]);
@@ -1544,9 +1602,9 @@ uhdr_error_info_t copy_raw_image(uhdr_raw_image_t* src, uhdr_raw_image_t* dst) {
         y_src += src->stride[UHDR_PLANE_Y];
       }
       // copy cb & cr
-      for (size_t i = 0; i < src->h / 2; i++) {
-        memcpy(u_dst, u_src, src->w / 2);
-        memcpy(v_dst, v_src, src->w / 2);
+      for (size_t i = 0; i < chroma_height; i++) {
+        memcpy(u_dst, u_src, chroma_width);
+        memcpy(v_dst, v_src, chroma_width);
         u_dst += dst->stride[UHDR_PLANE_U];
         v_dst += dst->stride[UHDR_PLANE_V];
         u_src += src->stride[UHDR_PLANE_U];

--- a/lib/src/heifultrahdr.cpp
+++ b/lib/src/heifultrahdr.cpp
@@ -173,8 +173,8 @@ static heif_error map_fmt_to_heif_chroma_vars(uhdr_img_fmt_t fmt, unsigned int w
                                               int& chromaHt) {
   if (fmt == UHDR_IMG_FMT_12bppYCbCr420) {
     heif_img_fmt = heif_chroma_420;
-    chromaWd = w / 2;
-    chromaHt = h / 2;
+    chromaWd = w / 2 + w % 2;
+    chromaHt = h / 2 + h % 2;
   } else if (fmt == UHDR_IMG_FMT_16bppYCbCr422) {
     heif_img_fmt = heif_chroma_422;
     chromaWd = w;
@@ -466,7 +466,7 @@ uhdr_error_info_t HeifUltraHdr::encodeHeicUltraHdr(uhdr_raw_image_t* sdr_intent,
 
   // encode the gain map image
   if (isUsingMultiChannelGainMap()) {
-    gainmap_yuv_ext = convert_raw_input_to_ycbcr(gainmap_img, true /* use bt601 */);
+    gainmap_yuv_ext = convert_raw_input_to_ycbcr(gainmap_img, true /* chroma sampling enabled */);
     gainmap_img_yuv = gainmap_yuv_ext.get();
   }
   if (isUsingMultiChannelGainMap()) {

--- a/lib/src/ultrahdr_api.cpp
+++ b/lib/src/ultrahdr_api.cpp
@@ -74,15 +74,17 @@ uhdr_raw_image_ext::uhdr_raw_image_ext(uhdr_img_fmt_t fmt_, uhdr_color_gamut_t c
   size_t plane_1_sz = bpp * aligned_width * h_;
   size_t plane_2_sz;
   size_t plane_3_sz;
+  const size_t chroma_width = aligned_width / 2 + aligned_width % 2;
+  const size_t chroma_height = h_ / 2 + h_ % 2;
   if (fmt_ == UHDR_IMG_FMT_24bppYCbCrP010) {
-    plane_2_sz = (2 /* planes */ * bpp * (aligned_width / 2) * (h_ / 2));
+    plane_2_sz = (2 /* planes */ * bpp * chroma_width * chroma_height);
     plane_3_sz = 0;
   } else if (fmt_ == UHDR_IMG_FMT_30bppYCbCr444 || fmt_ == UHDR_IMG_FMT_24bppYCbCr444) {
     plane_2_sz = bpp * aligned_width * h_;
     plane_3_sz = bpp * aligned_width * h_;
   } else if (fmt_ == UHDR_IMG_FMT_12bppYCbCr420) {
-    plane_2_sz = (bpp * (aligned_width / 2) * (h_ / 2));
-    plane_3_sz = (bpp * (aligned_width / 2) * (h_ / 2));
+    plane_2_sz = (bpp * chroma_width * chroma_height);
+    plane_3_sz = (bpp * chroma_width * chroma_height);
   } else {
     plane_2_sz = 0;
     plane_3_sz = 0;
@@ -95,7 +97,7 @@ uhdr_raw_image_ext::uhdr_raw_image_ext(uhdr_img_fmt_t fmt_, uhdr_color_gamut_t c
   this->stride[UHDR_PLANE_Y] = aligned_width;
   if (fmt_ == UHDR_IMG_FMT_24bppYCbCrP010) {
     this->planes[UHDR_PLANE_UV] = data + plane_1_sz;
-    this->stride[UHDR_PLANE_UV] = aligned_width;
+    this->stride[UHDR_PLANE_UV] = 2 * chroma_width;
     this->planes[UHDR_PLANE_V] = nullptr;
     this->stride[UHDR_PLANE_V] = 0;
   } else if (fmt_ == UHDR_IMG_FMT_30bppYCbCr444 || fmt_ == UHDR_IMG_FMT_24bppYCbCr444) {
@@ -105,9 +107,9 @@ uhdr_raw_image_ext::uhdr_raw_image_ext(uhdr_img_fmt_t fmt_, uhdr_color_gamut_t c
     this->stride[UHDR_PLANE_V] = aligned_width;
   } else if (fmt_ == UHDR_IMG_FMT_12bppYCbCr420) {
     this->planes[UHDR_PLANE_U] = data + plane_1_sz;
-    this->stride[UHDR_PLANE_U] = aligned_width / 2;
+    this->stride[UHDR_PLANE_U] = chroma_width;
     this->planes[UHDR_PLANE_V] = data + plane_1_sz + plane_2_sz;
-    this->stride[UHDR_PLANE_V] = aligned_width / 2;
+    this->stride[UHDR_PLANE_V] = chroma_width;
   } else {
     this->planes[UHDR_PLANE_U] = nullptr;
     this->stride[UHDR_PLANE_U] = 0;

--- a/tests/gainmapmath_test.cpp
+++ b/tests/gainmapmath_test.cpp
@@ -553,6 +553,205 @@ TEST_F(GainMapMathTest, PutRgb888PixelWritesGreenChannel) {
   EXPECT_EQ(230, data[2]);
 }
 
+TEST_F(GainMapMathTest, ConvertRgbInputsToYuv420HandleEveryPartialBlockShape) {
+  constexpr uhdr_img_fmt_t formats[] = {
+      UHDR_IMG_FMT_24bppRGB888,
+      UHDR_IMG_FMT_32bppRGBA8888,
+  };
+  constexpr unsigned geometries[][2] = {
+      {4, 4}, {1, 1}, {1, 3}, {3, 1}, {3, 2}, {2, 3}, {3, 3},
+  };
+  for (const uhdr_img_fmt_t format : formats) {
+    const size_t bytes_per_pixel = format == UHDR_IMG_FMT_24bppRGB888 ? 3 : 4;
+    GetPixelFn get_pixel = getPixelFn(format);
+    ASSERT_NE(get_pixel, nullptr);
+    for (const auto& geometry : geometries) {
+      const unsigned width = geometry[0];
+      const unsigned height = geometry[1];
+      SCOPED_TRACE(testing::Message()
+                   << "format=" << format << ", geometry=" << width << "x" << height);
+      std::vector<uint8_t> source_data(static_cast<size_t>(width) * height * bytes_per_pixel);
+      uhdr_raw_image_t source{};
+      source.fmt = format;
+      source.cg = UHDR_CG_BT_709;
+      source.ct = UHDR_CT_SRGB;
+      source.range = UHDR_CR_FULL_RANGE;
+      source.w = width;
+      source.h = height;
+      source.planes[UHDR_PLANE_PACKED] = source_data.data();
+      source.stride[UHDR_PLANE_PACKED] = width;
+      for (unsigned y = 0; y < height; ++y) {
+        for (unsigned x = 0; x < width; ++x) {
+          const size_t offset =
+              (static_cast<size_t>(y) * source.stride[UHDR_PLANE_PACKED] + x) * bytes_per_pixel;
+          source_data[offset] = static_cast<uint8_t>(31 + x * 37 + y * 3);
+          source_data[offset + 1] = static_cast<uint8_t>(47 + x * 11 + y * 29);
+          source_data[offset + 2] = static_cast<uint8_t>(59 + x * 19 + y * 7);
+          if (bytes_per_pixel == 4) source_data[offset + 3] = 255;
+        }
+      }
+
+      auto converted = convert_raw_input_to_ycbcr(&source, true);
+      ASSERT_NE(converted, nullptr);
+      EXPECT_GE(converted->stride[UHDR_PLANE_U], (width + 1) / 2);
+      EXPECT_GE(converted->stride[UHDR_PLANE_V], (width + 1) / 2);
+
+      for (unsigned y = 0; y < height; ++y) {
+        for (unsigned x = 0; x < width; ++x) {
+          Color expected = srgbRgbToYuv(get_pixel(&source, x, y));
+          expected.y = static_cast<float>(
+                           static_cast<uint8_t>(CLIP3(expected.y * 255.0f + 0.5f, 0.0f, 255.0f))) /
+                       255.0f;
+          EXPECT_NEAR(expected.y, getYuv420Pixel(converted.get(), x, y).y, YuvConversionEpsilon());
+        }
+      }
+
+      for (unsigned y = 0; y < height; y += 2) {
+        for (unsigned x = 0; x < width; x += 2) {
+          const unsigned next_x = (std::min)(x + 1, width - 1);
+          const unsigned next_y = (std::min)(y + 1, height - 1);
+          Color samples[] = {
+              srgbRgbToYuv(get_pixel(&source, x, y)),
+              srgbRgbToYuv(get_pixel(&source, next_x, y)),
+              srgbRgbToYuv(get_pixel(&source, x, next_y)),
+              srgbRgbToYuv(get_pixel(&source, next_x, next_y)),
+          };
+          const float average_u =
+              (samples[0].u + samples[1].u + samples[2].u + samples[3].u) / 4.0f;
+          const float average_v =
+              (samples[0].v + samples[1].v + samples[2].v + samples[3].v) / 4.0f;
+          const float expected_u = static_cast<float>(static_cast<uint8_t>(
+                                       CLIP3(average_u * 255.0f + 128.0f + 0.5f, 0.0f, 255.0f))) /
+                                       255.0f -
+                                   128.0f / 255.0f;
+          const float expected_v = static_cast<float>(static_cast<uint8_t>(
+                                       CLIP3(average_v * 255.0f + 128.0f + 0.5f, 0.0f, 255.0f))) /
+                                       255.0f -
+                                   128.0f / 255.0f;
+          const Color actual = getYuv420Pixel(converted.get(), x, y);
+          EXPECT_NEAR(expected_u, actual.u, YuvConversionEpsilon());
+          EXPECT_NEAR(expected_v, actual.v, YuvConversionEpsilon());
+        }
+      }
+    }
+  }
+}
+
+TEST_F(GainMapMathTest, ConvertRgba1010102ToP010HandlesEveryPartialBlockShape) {
+  constexpr unsigned geometries[][2] = {
+      {4, 4}, {1, 1}, {1, 3}, {3, 1}, {3, 2}, {2, 3}, {3, 3},
+  };
+  for (const auto& geometry : geometries) {
+    const unsigned width = geometry[0];
+    const unsigned height = geometry[1];
+    SCOPED_TRACE(testing::Message() << "geometry=" << width << "x" << height);
+    uhdr_raw_image_ext_t source(UHDR_IMG_FMT_32bppRGBA1010102, UHDR_CG_BT_709, UHDR_CT_HLG,
+                                UHDR_CR_FULL_RANGE, width, height, 64);
+    auto* source_data = static_cast<uint32_t*>(source.planes[UHDR_PLANE_PACKED]);
+    for (unsigned y = 0; y < height; ++y) {
+      for (unsigned x = 0; x < width; ++x) {
+        const float r = static_cast<float>(x + 1) / static_cast<float>(width + 1);
+        const float g = static_cast<float>(y + 1) / static_cast<float>(height + 1);
+        const float b = static_cast<float>(x + y + 1) / static_cast<float>(width + height);
+        source_data[static_cast<size_t>(y) * source.stride[UHDR_PLANE_PACKED] + x] =
+            colorToRgba1010102({{{r, g, b}}});
+      }
+    }
+
+    auto converted = convert_raw_input_to_ycbcr(&source, true);
+    ASSERT_NE(converted, nullptr);
+    EXPECT_EQ(UHDR_IMG_FMT_24bppYCbCrP010, converted->fmt);
+    EXPECT_EQ(width, converted->w);
+    EXPECT_EQ(height, converted->h);
+    EXPECT_GE(converted->stride[UHDR_PLANE_UV], 2 * ((width + 1) / 2));
+
+    for (unsigned y = 0; y < height; ++y) {
+      for (unsigned x = 0; x < width; ++x) {
+        const Color expected = srgbRgbToYuv(getRgba1010102Pixel(&source, x, y));
+        EXPECT_NEAR(expected.y, getP010Pixel(converted.get(), x, y).y, YuvConversionEpsilon());
+      }
+    }
+
+    for (unsigned y = 0; y < height; y += 2) {
+      for (unsigned x = 0; x < width; x += 2) {
+        const unsigned next_x = (std::min)(x + 1, width - 1);
+        const unsigned next_y = (std::min)(y + 1, height - 1);
+        Color samples[] = {
+            srgbRgbToYuv(getRgba1010102Pixel(&source, x, y)),
+            srgbRgbToYuv(getRgba1010102Pixel(&source, next_x, y)),
+            srgbRgbToYuv(getRgba1010102Pixel(&source, x, next_y)),
+            srgbRgbToYuv(getRgba1010102Pixel(&source, next_x, next_y)),
+        };
+        const float expected_u = (samples[0].u + samples[1].u + samples[2].u + samples[3].u) / 4.0f;
+        const float expected_v = (samples[0].v + samples[1].v + samples[2].v + samples[3].v) / 4.0f;
+        const Color actual = getP010Pixel(converted.get(), x, y);
+        EXPECT_NEAR(expected_u, actual.u, YuvConversionEpsilon());
+        EXPECT_NEAR(expected_v, actual.v, YuvConversionEpsilon());
+      }
+    }
+  }
+}
+
+TEST_F(GainMapMathTest, CopyRawImagePreservesOddYuv420ChromaGeometry) {
+  constexpr unsigned width = 3;
+  constexpr unsigned height = 3;
+  uhdr_raw_image_ext_t source(UHDR_IMG_FMT_12bppYCbCr420, UHDR_CG_BT_709, UHDR_CT_SRGB,
+                              UHDR_CR_FULL_RANGE, width, height, 1);
+  auto* source_u = static_cast<uint8_t*>(source.planes[UHDR_PLANE_U]);
+  auto* source_v = static_cast<uint8_t*>(source.planes[UHDR_PLANE_V]);
+  for (size_t y = 0; y < 2; ++y) {
+    for (size_t x = 0; x < 2; ++x) {
+      source_u[y * source.stride[UHDR_PLANE_U] + x] = static_cast<uint8_t>(31 + y * 7 + x);
+      source_v[y * source.stride[UHDR_PLANE_V] + x] = static_cast<uint8_t>(61 + y * 7 + x);
+    }
+  }
+
+  auto copy = copy_raw_image(&source);
+  ASSERT_NE(copy, nullptr);
+  const auto* copied_u = static_cast<const uint8_t*>(copy->planes[UHDR_PLANE_U]);
+  const auto* copied_v = static_cast<const uint8_t*>(copy->planes[UHDR_PLANE_V]);
+  for (size_t y = 0; y < 2; ++y) {
+    for (size_t x = 0; x < 2; ++x) {
+      EXPECT_EQ(source_u[y * source.stride[UHDR_PLANE_U] + x],
+                copied_u[y * copy->stride[UHDR_PLANE_U] + x]);
+      EXPECT_EQ(source_v[y * source.stride[UHDR_PLANE_V] + x],
+                copied_v[y * copy->stride[UHDR_PLANE_V] + x]);
+    }
+  }
+
+  uhdr_raw_image_t malformed = source;
+  malformed.stride[UHDR_PLANE_U] = 1;
+  EXPECT_EQ(copy_raw_image(&malformed, copy.get()).error_code, UHDR_CODEC_INVALID_PARAM);
+}
+
+TEST_F(GainMapMathTest, CopyRawImagePreservesOddP010ChromaGeometry) {
+  constexpr unsigned width = 3;
+  constexpr unsigned height = 3;
+  uhdr_raw_image_ext_t source(UHDR_IMG_FMT_24bppYCbCrP010, UHDR_CG_BT_2100, UHDR_CT_HLG,
+                              UHDR_CR_FULL_RANGE, width, height, 1);
+  auto* source_uv = static_cast<uint16_t*>(source.planes[UHDR_PLANE_UV]);
+  for (size_t y = 0; y < 2; ++y) {
+    for (size_t x = 0; x < 4; ++x) {
+      source_uv[y * source.stride[UHDR_PLANE_UV] + x] =
+          static_cast<uint16_t>((101 + y * 11 + x) << 6);
+    }
+  }
+
+  auto copy = copy_raw_image(&source);
+  ASSERT_NE(copy, nullptr);
+  const auto* copied_uv = static_cast<const uint16_t*>(copy->planes[UHDR_PLANE_UV]);
+  for (size_t y = 0; y < 2; ++y) {
+    for (size_t x = 0; x < 4; ++x) {
+      EXPECT_EQ(source_uv[y * source.stride[UHDR_PLANE_UV] + x],
+                copied_uv[y * copy->stride[UHDR_PLANE_UV] + x]);
+    }
+  }
+
+  uhdr_raw_image_t malformed = source;
+  malformed.stride[UHDR_PLANE_UV] = 3;
+  EXPECT_EQ(copy_raw_image(&malformed, copy.get()).error_code, UHDR_CODEC_INVALID_PARAM);
+}
+
 TEST_F(GainMapMathTest, SrgbLuminance) {
   EXPECT_FLOAT_EQ(srgbLuminance(RgbBlack()), 0.0f);
   EXPECT_FLOAT_EQ(srgbLuminance(RgbWhite()), 1.0f);
@@ -1497,12 +1696,33 @@ TEST_F(GainMapMathTest, GetP010Pixel) {
 
 TEST_F(GainMapMathTest, GetP010PixelOddWidth) {
   auto image = P010Image();
+  Color(*colors)[4] = P010Colors();
   image.w = 3;
   for (size_t y = 0; y < 4; ++y) {
     for (size_t x = 0; x < 3; ++x) {
-      EXPECT_NO_FATAL_FAILURE(getP010Pixel(&image, x, y));
+      EXPECT_YUV_NEAR(getP010Pixel(&image, x, y), colors[y][x]);
     }
   }
+}
+
+TEST_F(GainMapMathTest, GetP010PixelOddWidthClampsToCompleteAvailablePair) {
+  auto image = P010Image();
+  Color(*colors)[4] = P010Colors();
+  image.w = 3;
+  image.stride[UHDR_PLANE_UV] = 3;
+
+  // A three-sample row cannot contain the second complete interleaved UV pair. Reuse the last
+  // complete pair instead of reading its missing V sample.
+  Color expected = colors[0][2];
+  expected.u = colors[0][0].u;
+  expected.v = colors[0][0].v;
+  EXPECT_YUV_NEAR(getP010Pixel(&image, 2, 0), expected);
+
+  image.w = 1;
+  image.stride[UHDR_PLANE_UV] = 1;
+  Color single_sample_row = getP010Pixel(&image, 0, 0);
+  EXPECT_NEAR(single_sample_row.u, 0.0f, YuvConversionEpsilon());
+  EXPECT_NEAR(single_sample_row.v, 0.0f, YuvConversionEpsilon());
 }
 
 TEST_F(GainMapMathTest, SampleYuv420) {

--- a/tests/ultrahdr_api_test.cpp
+++ b/tests/ultrahdr_api_test.cpp
@@ -650,6 +650,114 @@ TEST_F(UltraHdrApiTest, HeifAndAvifPropagateGainMapMetadataErrors) {
   if (tested_formats == 0) GTEST_SKIP() << "AV1 and HEVC encoder plugins are unavailable";
 }
 
+class OddMultichannelGainMapCodecTest : public ::testing::TestWithParam<uhdr_codec_t> {};
+
+TEST_P(OddMultichannelGainMapCodecTest, PreservesOddGainMapEdges) {
+  constexpr unsigned width = 36;
+  constexpr unsigned height = 36;
+  constexpr unsigned gainmap_scale_factor = 4;
+  constexpr unsigned gainmap_width = width / gainmap_scale_factor;
+  constexpr unsigned gainmap_height = height / gainmap_scale_factor;
+  constexpr unsigned edge_sample_x = (gainmap_width - 1) * gainmap_scale_factor;
+  constexpr unsigned edge_sample_y = (gainmap_height - 1) * gainmap_scale_factor;
+  std::vector<uint32_t> hdr_pixels(static_cast<size_t>(width) * height,
+                                   700u | (700u << 10) | (700u << 20) | (3u << 30));
+  hdr_pixels[static_cast<size_t>(edge_sample_y) * width + edge_sample_x] =
+      1000u | (300u << 10) | (100u << 20) | (3u << 30);
+  uhdr_raw_image_t hdr{};
+  hdr.fmt = UHDR_IMG_FMT_32bppRGBA1010102;
+  hdr.cg = UHDR_CG_BT_2100;
+  hdr.ct = UHDR_CT_HLG;
+  hdr.range = UHDR_CR_FULL_RANGE;
+  hdr.w = width;
+  hdr.h = height;
+  hdr.planes[UHDR_PLANE_PACKED] = hdr_pixels.data();
+  hdr.stride[UHDR_PLANE_PACKED] = width;
+
+  std::vector<uint8_t> sdr_pixels(static_cast<size_t>(width) * height * 4, 128);
+  for (size_t i = 3; i < sdr_pixels.size(); i += 4) sdr_pixels[i] = 255;
+  uhdr_raw_image_t sdr{};
+  sdr.fmt = UHDR_IMG_FMT_32bppRGBA8888;
+  sdr.cg = UHDR_CG_BT_2100;
+  sdr.ct = UHDR_CT_SRGB;
+  sdr.range = UHDR_CR_FULL_RANGE;
+  sdr.w = width;
+  sdr.h = height;
+  sdr.planes[UHDR_PLANE_PACKED] = sdr_pixels.data();
+  sdr.stride[UHDR_PLANE_PACKED] = width;
+
+  uhdr_codec_private_t* enc = uhdr_create_encoder();
+  ASSERT_NE(enc, nullptr);
+  ASSERT_EQ(uhdr_enc_set_raw_image(enc, &hdr, UHDR_HDR_IMG).error_code, UHDR_CODEC_OK);
+  ASSERT_EQ(uhdr_enc_set_raw_image(enc, &sdr, UHDR_SDR_IMG).error_code, UHDR_CODEC_OK);
+  ASSERT_EQ(uhdr_enc_set_output_format(enc, GetParam()).error_code, UHDR_CODEC_OK);
+  ASSERT_EQ(uhdr_enc_set_using_multi_channel_gainmap(enc, 1).error_code, UHDR_CODEC_OK);
+  ASSERT_EQ(uhdr_enc_set_gainmap_scale_factor(enc, gainmap_scale_factor).error_code, UHDR_CODEC_OK);
+  ASSERT_EQ(uhdr_enc_set_quality(enc, 100, UHDR_GAIN_MAP_IMG).error_code, UHDR_CODEC_OK);
+
+  uhdr_error_info_t enc_status = uhdr_encode(enc);
+  if (enc_status.error_code != UHDR_CODEC_OK && enc_status.has_detail &&
+      (strstr(enc_status.detail, "Unsupported file-type") != nullptr ||
+       strstr(enc_status.detail, "No encoder") != nullptr)) {
+    const std::string detail = enc_status.detail;
+    uhdr_release_encoder(enc);
+    GTEST_SKIP() << "encoder plugin not available in environment: " << detail;
+  }
+  ASSERT_EQ(enc_status.error_code, UHDR_CODEC_OK)
+      << (enc_status.has_detail ? enc_status.detail : "");
+  uhdr_compressed_image_t* output = uhdr_get_encoded_stream(enc);
+  ASSERT_NE(output, nullptr);
+
+  uhdr_codec_private_t* dec = uhdr_create_decoder();
+  ASSERT_NE(dec, nullptr);
+  ASSERT_EQ(uhdr_dec_set_image(dec, output).error_code, UHDR_CODEC_OK);
+  ASSERT_EQ(uhdr_dec_probe(dec).error_code, UHDR_CODEC_OK);
+  EXPECT_EQ(uhdr_dec_get_gainmap_width(dec), static_cast<int>(gainmap_width));
+  EXPECT_EQ(uhdr_dec_get_gainmap_height(dec), static_cast<int>(gainmap_height));
+  ASSERT_EQ(uhdr_decode(dec).error_code, UHDR_CODEC_OK);
+
+  heif_context* heif_ctx = heif_context_alloc();
+  ASSERT_NE(heif_ctx, nullptr);
+  ASSERT_EQ(
+      heif_context_read_from_memory_without_copy(heif_ctx, output->data, output->data_sz, nullptr)
+          .code,
+      heif_error_Ok);
+  heif_image_handle* base_handle = nullptr;
+  ASSERT_EQ(heif_context_get_primary_image_handle(heif_ctx, &base_handle).code, heif_error_Ok);
+  heif_image_handle* gainmap_handle = nullptr;
+  ASSERT_EQ(heif_image_handle_get_gain_map_image_handle(base_handle, &gainmap_handle).code,
+            heif_error_Ok);
+  EXPECT_EQ(heif_image_handle_get_width(gainmap_handle), static_cast<int>(gainmap_width));
+  EXPECT_EQ(heif_image_handle_get_height(gainmap_handle), static_cast<int>(gainmap_height));
+  heif_image* decoded_gainmap = nullptr;
+  ASSERT_EQ(heif_decode_image(gainmap_handle, &decoded_gainmap, heif_colorspace_RGB,
+                              heif_chroma_interleaved_RGBA, nullptr)
+                .code,
+            heif_error_Ok);
+  int gainmap_stride = 0;
+  const uint8_t* gainmap_pixels =
+      heif_image_get_plane_readonly(decoded_gainmap, heif_channel_interleaved, &gainmap_stride);
+  ASSERT_NE(gainmap_pixels, nullptr);
+  const size_t edge_offset =
+      static_cast<size_t>(gainmap_height - 1) * gainmap_stride + (gainmap_width - 1) * 4;
+  // The final source sample has much more red gain than green or blue. This verifies that the
+  // partial lower-right 4:2:0 block carries its own chroma instead of retaining default values or
+  // borrowing the previous complete pair.
+  EXPECT_GT(gainmap_pixels[edge_offset], gainmap_pixels[edge_offset + 1] + 20);
+  EXPECT_GT(gainmap_pixels[edge_offset], gainmap_pixels[edge_offset + 2] + 20);
+
+  heif_image_release(decoded_gainmap);
+  heif_image_handle_release(gainmap_handle);
+  heif_image_handle_release(base_handle);
+  heif_context_free(heif_ctx);
+
+  uhdr_release_decoder(dec);
+  uhdr_release_encoder(enc);
+}
+
+INSTANTIATE_TEST_SUITE_P(AvifAndHeif, OddMultichannelGainMapCodecTest,
+                         ::testing::Values(UHDR_CODEC_AVIF, UHDR_CODEC_HEIF));
+
 TEST_F(UltraHdrApiTest, AvifCompressedIntentsUnsupported) {
   uhdr_codec_private_t* enc = uhdr_create_encoder();
   ASSERT_NE(enc, nullptr);


### PR DESCRIPTION
## Summary

After #459, odd-sized multichannel gain maps no longer read outside the source image, but their final row or column can remain unwritten. This follow-up processes those partial 2x2 blocks by replicating edge samples, preserving every active luma pixel and producing the corresponding 4:2:0 chroma sample.

The change also:

- uses ceil-divided 4:2:0 geometry for internal allocation and copying;
- passes the same chroma geometry to libheif for AVIF and HEIF gain maps;
- bounds P010 UV-pair reads by both logical image capacity and the supplied row stride; and
- rejects YUV420 and P010 copies whose chroma stride cannot hold the required samples.

Direct odd-sized YUV420 and P010 input remains rejected by the public encoder API. This change fixes the internally generated 4:2:0 images used by multichannel gain-map encoding without expanding that public input contract.

## Edge policy

For a partial 2x2 block, the final source row and/or column is replicated before chroma averaging. Only luma positions inside the active image are written. Even-sized conversion is unchanged.

## Tests

- RGB888 and RGBA8888 conversion tests cover even, one-pixel, odd-width, odd-height, and both-odd geometries, checking every luma pixel and every chroma block.
- RGBA1010102-to-P010 tests cover the same geometry matrix and verify final UV-pair handling.
- YUV420 and P010 copy tests cover ceil-divided odd geometry and reject insufficient chroma strides.
- A codec-level regression exercises a 9x9 multichannel gain map produced from a 36x36 source through each available AVIF or HEIF backend and verifies that the final edge sample retains its own chroma.

Local validation passed the 61-test gain-map math suite under normal and ASan/UBSan builds. A full HEIF-enabled run passed 1,083 tests with 228 environment-dependent skips, and the codec regression passed with the available AVIF encoder. The HEVC case was skipped because this environment does not provide an encoder plugin.