### PR TITLE
Handle JPEG XMP size limits without losing metadata

### DIFF
--- a/lib/src/jpegr.cpp
+++ b/lib/src/jpegr.cpp
@@ -1286,17 +1286,26 @@ uhdr_error_info_t JpegR::appendGainMap(uhdr_compressed_image_t* sdr_intent_compr
   }
 
   if (!xmp_primary_str.empty()) {
-    const size_t length = 2 + xmpNameSpaceLength + xmp_primary_str.size();
-    if (length <= 65535) {
-      const uint8_t lengthH = ((length >> 8) & 0xff);
-      const uint8_t lengthL = (length & 0xff);
-      UHDR_ERR_CHECK(Write(dest, &photos_editing_formats::image_io::JpegMarker::kStart, 1, pos));
-      UHDR_ERR_CHECK(Write(dest, &photos_editing_formats::image_io::JpegMarker::kAPP1, 1, pos));
-      UHDR_ERR_CHECK(Write(dest, &lengthH, 1, pos));
-      UHDR_ERR_CHECK(Write(dest, &lengthL, 1, pos));
-      UHDR_ERR_CHECK(Write(dest, (void*)kXmpNameSpace.c_str(), xmpNameSpaceLength, pos));
-      UHDR_ERR_CHECK(Write(dest, (void*)xmp_primary_str.c_str(), xmp_primary_str.size(), pos));
+    constexpr size_t kJpegSegmentMaxLength = 0xffff;
+    if (xmpNameSpaceLength > kJpegSegmentMaxLength - 2 ||
+        xmp_primary_str.size() > kJpegSegmentMaxLength - 2 - xmpNameSpaceLength) {
+      uhdr_error_info_t status;
+      status.error_code = UHDR_CODEC_INVALID_PARAM;
+      status.has_detail = 1;
+      snprintf(status.detail, sizeof status.detail,
+               "serialized XMP metadata exceeds the JPEG APP1 segment size limit");
+      return status;
     }
+
+    const size_t length = 2 + xmpNameSpaceLength + xmp_primary_str.size();
+    const uint8_t lengthH = ((length >> 8) & 0xff);
+    const uint8_t lengthL = (length & 0xff);
+    UHDR_ERR_CHECK(Write(dest, &photos_editing_formats::image_io::JpegMarker::kStart, 1, pos));
+    UHDR_ERR_CHECK(Write(dest, &photos_editing_formats::image_io::JpegMarker::kAPP1, 1, pos));
+    UHDR_ERR_CHECK(Write(dest, &lengthH, 1, pos));
+    UHDR_ERR_CHECK(Write(dest, &lengthL, 1, pos));
+    UHDR_ERR_CHECK(Write(dest, (void*)kXmpNameSpace.c_str(), xmpNameSpaceLength, pos));
+    UHDR_ERR_CHECK(Write(dest, (void*)xmp_primary_str.c_str(), xmp_primary_str.size(), pos));
   }
 
   // Write ICC

--- a/lib/src/ultrahdr_api.cpp
+++ b/lib/src/ultrahdr_api.cpp
@@ -10,6 +10,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <limits>
 
 #include "ultrahdr_api.h"
 #include "ultrahdr/ultrahdrcommon.h"
@@ -41,6 +42,14 @@
 using namespace photos_editing_formats::image_io;
 
 namespace ultrahdr {
+
+namespace {
+
+// A standard XMP APP1 segment can contain 65,504 bytes of packet data, in addition to its
+// marker, length field, and Adobe namespace identifier.
+constexpr size_t kJpegXmpApp1Allowance = 0xffff + 2;
+
+}  // namespace
 
 uhdr_memory_block::uhdr_memory_block(size_t capacity) {
   m_buffer = std::make_unique<uint8_t[]>(capacity);
@@ -1315,6 +1324,18 @@ uhdr_error_info_t uhdr_encode(uhdr_codec_private_t* enc) {
   }
 
   if (handle->m_output_format == UHDR_CODEC_JPG) {
+    const bool mayWriteXmp = !handle->m_xmp.empty() || !handle->m_compressed_images.empty();
+    const size_t xmpAllowance = mayWriteXmp ? ultrahdr::kJpegXmpApp1Allowance : 0;
+    auto addXmpAllowance = [xmpAllowance](size_t base_size, size_t* output_size) {
+      if (xmpAllowance > (std::numeric_limits<size_t>::max)() - base_size) return false;
+      *output_size = base_size + xmpAllowance;
+      return true;
+    };
+    auto reportOutputSizeOverflow = [&status]() {
+      status.error_code = UHDR_CODEC_ERROR;
+      status.has_detail = 1;
+      snprintf(status.detail, sizeof status.detail, "compressed output size calculation overflowed");
+    };
     ultrahdr::JpegR jpegr(nullptr, handle->m_gainmap_scale_factor,
                           handle->m_quality.find(UHDR_GAIN_MAP_IMG)->second,
                           handle->m_use_multi_channel_gainmap, handle->m_gamma,
@@ -1327,6 +1348,10 @@ uhdr_error_info_t uhdr_encode(uhdr_codec_private_t* enc) {
 
       size_t size =
           (std::max)(((size_t)64 * 1024), 2 * (base_entry->data_sz + gainmap_entry->data_sz));
+      if (!addXmpAllowance(size, &size)) {
+        reportOutputSizeOverflow();
+        return status;
+      }
       handle->m_compressed_output_buffer = std::make_unique<ultrahdr::uhdr_compressed_image_ext_t>(
           UHDR_CG_UNSPECIFIED, UHDR_CT_UNSPECIFIED, UHDR_CR_UNSPECIFIED, size);
 
@@ -1340,6 +1365,10 @@ uhdr_error_info_t uhdr_encode(uhdr_codec_private_t* enc) {
       auto& hdr_raw_entry = handle->m_raw_images.find(UHDR_HDR_IMG)->second;
 
       size_t size = (std::max)((64u * 1024), hdr_raw_entry->w * hdr_raw_entry->h * 3 * 2);
+      if (!addXmpAllowance(size, &size)) {
+        reportOutputSizeOverflow();
+        return status;
+      }
       handle->m_compressed_output_buffer = std::make_unique<ultrahdr::uhdr_compressed_image_ext_t>(
           UHDR_CG_UNSPECIFIED, UHDR_CT_UNSPECIFIED, UHDR_CR_UNSPECIFIED, size);
 

--- a/tests/ultrahdr_api_test.cpp
+++ b/tests/ultrahdr_api_test.cpp
@@ -8,9 +8,11 @@
 #include <gtest/gtest.h>
 #endif
 #include <algorithm>
+#include <cstdint>
 #include <fstream>
 #include <cstring>
 #include <limits>
+#include <string>
 #include <vector>
 #include <memory>
 #include <vector>
@@ -28,6 +30,39 @@ static const char* kYCbCr420FileName = "raw_yuv420_image.yuv420";
 static const char* kSdrJpgFileName = "jpeg_image.jpg";
 static const size_t kImageWidth = 1280;
 static const size_t kImageHeight = 720;
+
+static std::string makeLargeXmp(size_t size) {
+  const std::string prefix =
+      "<x:xmpmeta xmlns:x=\"adobe:ns:meta/\"><rdf:RDF "
+      "xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"><rdf:Description "
+      "rdf:about=\"\"><dc:Pad xmlns:dc=\"urn:test\"><!--";
+  const std::string suffix = "--></dc:Pad></rdf:Description></rdf:RDF></x:xmpmeta>";
+  EXPECT_GE(size, prefix.size() + suffix.size());
+  return prefix + std::string(size - prefix.size() - suffix.size(), 'X') + suffix;
+}
+
+static std::vector<uint8_t> makeSmallHdrData() {
+  const uint16_t pixel[] = {0x3c00, 0x4000, 0x3800, 0x3c00};
+  std::vector<uint8_t> data(8 * 8 * sizeof(pixel));
+  for (size_t i = 0; i < 8 * 8; ++i) {
+    memcpy(data.data() + i * sizeof(pixel), pixel, sizeof(pixel));
+  }
+  return data;
+}
+
+static void expectEncodedXmpDecodes(uhdr_compressed_image_t* output, size_t min_xmp_size) {
+  ASSERT_NE(output, nullptr);
+  uhdr_codec_private_t* dec = uhdr_create_decoder();
+  ASSERT_NE(dec, nullptr);
+  ASSERT_EQ(uhdr_dec_set_image(dec, output).error_code, UHDR_CODEC_OK);
+  ASSERT_EQ(uhdr_dec_probe(dec).error_code, UHDR_CODEC_OK);
+  uhdr_mem_block_t* decoded_xmp = uhdr_dec_get_xmp(dec);
+  ASSERT_NE(decoded_xmp, nullptr);
+  ASSERT_NE(decoded_xmp->data, nullptr);
+  EXPECT_GE(decoded_xmp->data_sz, min_xmp_size);
+  ASSERT_EQ(uhdr_decode(dec).error_code, UHDR_CODEC_OK);
+  uhdr_release_decoder(dec);
+}
 
 static bool loadFile(const char* filename, std::vector<uint8_t>& buffer) {
   std::vector<std::string> candidates = {
@@ -417,6 +452,108 @@ TEST_F(UltraHdrApiTest, JpegEncodeApi2WithXmpAndDecode) {
   uhdr_release_encoder(enc2);
   uhdr_release_decoder(dec1);
   uhdr_release_encoder(enc1);
+}
+
+TEST_F(UltraHdrApiTest, LargeXmpFitsSmallRawApiOutput) {
+#ifdef UHDR_WRITE_XMP
+  // The dual writer adds its container directory to the supplied packet.
+  constexpr size_t kXmpSize = 64000;
+#else
+  constexpr size_t kXmpSize = 65504;
+#endif
+  const std::vector<uint8_t> hdr_data = makeSmallHdrData();
+  uhdr_raw_image_t hdr{};
+  hdr.fmt = UHDR_IMG_FMT_64bppRGBAHalfFloat;
+  hdr.cg = UHDR_CG_DISPLAY_P3;
+  hdr.ct = UHDR_CT_LINEAR;
+  hdr.range = UHDR_CR_FULL_RANGE;
+  hdr.w = hdr.h = 8;
+  hdr.planes[UHDR_PLANE_PACKED] = const_cast<uint8_t*>(hdr_data.data());
+  hdr.stride[UHDR_PLANE_PACKED] = 8;
+
+  uhdr_codec_private_t* enc = uhdr_create_encoder();
+  ASSERT_NE(enc, nullptr);
+  ASSERT_EQ(uhdr_enc_set_raw_image(enc, &hdr, UHDR_HDR_IMG).error_code, UHDR_CODEC_OK);
+  const std::string xmp = makeLargeXmp(kXmpSize);
+  uhdr_mem_block_t xmp_block{const_cast<char*>(xmp.data()), xmp.size(), xmp.size()};
+  ASSERT_EQ(uhdr_enc_set_xmp_data(enc, &xmp_block).error_code, UHDR_CODEC_OK);
+  ASSERT_EQ(uhdr_enc_set_output_format(enc, UHDR_CODEC_JPG).error_code, UHDR_CODEC_OK);
+
+  const uhdr_error_info_t status = uhdr_encode(enc);
+  ASSERT_EQ(status.error_code, UHDR_CODEC_OK) << status.detail;
+  uhdr_compressed_image_t* output = uhdr_get_encoded_stream(enc);
+  ASSERT_NE(output, nullptr);
+  EXPECT_GT(output->data_sz, static_cast<size_t>(64 * 1024));
+  expectEncodedXmpDecodes(output, kXmpSize);
+  uhdr_release_encoder(enc);
+}
+
+TEST_F(UltraHdrApiTest, LargeXmpFitsCompressedBaseGainmapApiOutput) {
+#ifdef UHDR_WRITE_XMP
+  constexpr size_t kXmpSize = 64000;
+#else
+  constexpr size_t kXmpSize = 65504;
+#endif
+  uhdr_gainmap_metadata_t metadata{};
+  for (int channel = 0; channel < 3; ++channel) {
+    metadata.max_content_boost[channel] = 2.0f;
+    metadata.min_content_boost[channel] = 1.0f;
+    metadata.gamma[channel] = 1.0f;
+  }
+  metadata.hdr_capacity_min = 1.0f;
+  metadata.hdr_capacity_max = 2.0f;
+  metadata.use_base_cg = 1;
+
+  uhdr_codec_private_t* enc = uhdr_create_encoder();
+  ASSERT_NE(enc, nullptr);
+  ASSERT_EQ(uhdr_enc_set_compressed_image(enc, &mSdrCompressed, UHDR_BASE_IMG).error_code,
+            UHDR_CODEC_OK);
+  ASSERT_EQ(uhdr_enc_set_gainmap_image(enc, &mSdrCompressed, &metadata).error_code,
+            UHDR_CODEC_OK);
+  const std::string xmp = makeLargeXmp(kXmpSize);
+  uhdr_mem_block_t xmp_block{const_cast<char*>(xmp.data()), xmp.size(), xmp.size()};
+  ASSERT_EQ(uhdr_enc_set_xmp_data(enc, &xmp_block).error_code, UHDR_CODEC_OK);
+  ASSERT_EQ(uhdr_enc_set_output_format(enc, UHDR_CODEC_JPG).error_code, UHDR_CODEC_OK);
+
+  const uhdr_error_info_t status = uhdr_encode(enc);
+  ASSERT_EQ(status.error_code, UHDR_CODEC_OK) << status.detail;
+  uhdr_compressed_image_t* output = uhdr_get_encoded_stream(enc);
+  ASSERT_NE(output, nullptr);
+  EXPECT_GT(output->data_sz, static_cast<size_t>(64 * 1024));
+  expectEncodedXmpDecodes(output, kXmpSize);
+  uhdr_release_encoder(enc);
+}
+
+TEST_F(UltraHdrApiTest, OversizedFinalXmpIsRejected) {
+  uhdr_gainmap_metadata_t metadata{};
+  for (int channel = 0; channel < 3; ++channel) {
+    metadata.max_content_boost[channel] = 2.0f;
+    metadata.min_content_boost[channel] = 1.0f;
+    metadata.gamma[channel] = 1.0f;
+  }
+  metadata.hdr_capacity_min = 1.0f;
+  metadata.hdr_capacity_max = 2.0f;
+  metadata.use_base_cg = 1;
+
+  uhdr_codec_private_t* enc = uhdr_create_encoder();
+  ASSERT_NE(enc, nullptr);
+  ASSERT_EQ(uhdr_enc_set_compressed_image(enc, &mSdrCompressed, UHDR_BASE_IMG).error_code,
+            UHDR_CODEC_OK);
+  ASSERT_EQ(uhdr_enc_set_gainmap_image(enc, &mSdrCompressed, &metadata).error_code,
+            UHDR_CODEC_OK);
+#ifdef UHDR_WRITE_XMP
+  const std::string xmp = makeLargeXmp(65504);
+#else
+  const std::string xmp = makeLargeXmp(65505);
+#endif
+  uhdr_mem_block_t xmp_block{const_cast<char*>(xmp.data()), xmp.size(), xmp.size()};
+  ASSERT_EQ(uhdr_enc_set_xmp_data(enc, &xmp_block).error_code, UHDR_CODEC_OK);
+  ASSERT_EQ(uhdr_enc_set_output_format(enc, UHDR_CODEC_JPG).error_code, UHDR_CODEC_OK);
+
+  const uhdr_error_info_t status = uhdr_encode(enc);
+  EXPECT_NE(status.error_code, UHDR_CODEC_OK);
+  EXPECT_TRUE(status.has_detail);
+  uhdr_release_encoder(enc);
 }
 
 // ============================================================================


### PR DESCRIPTION
A valid 65,504-byte XMP packet can exceed the image-based output allocation, while a larger packet is silently omitted with a successful encode. Reserve room for one standard XMP APP1 segment when explicit or inherited XMP may be written, and reject a final serialized packet that exceeds the segment limit, including after dual-mode merging.

Adds three regression tests covering raw-image and compressed base/gain-map encoding, metadata extraction and decoding, and oversized output. All three fail against the original feature branch in both configurations; all 12 API tests pass with the fix in ISO and dual configurations.

Based on `feat/preserve-xmp-metadata` at `59418fb`. Extended XMP and XML merging behavior are outside this patch.